### PR TITLE
Improve Retrofit http logging

### DIFF
--- a/modules/http/src/retrofit/http/HttpClients.java
+++ b/modules/http/src/retrofit/http/HttpClients.java
@@ -56,7 +56,17 @@ public class HttpClients {
   public static HttpEntity copyAndLog(HttpEntity entity) throws IOException {
     byte[] bytes = entityToBytes(entity);
     // TODO: Use correct encoding.
-    logger.fine("Response: " + new String(bytes));
+    if (logger.isLoggable(Level.FINE)) {
+      final int chunkSize = 4000;
+      logger.fine("-Response:");
+      for (int i = 0; i < bytes.length; i += chunkSize) {
+        int end = i + chunkSize;
+        logger.fine(((end > bytes.length) ? new String(bytes, i, bytes.length - i)
+                                          : new String(bytes, i, chunkSize)));
+      }
+      logger.fine("-end response.");
+    }
+
     return new ByteArrayEntity(bytes);
   }
 }

--- a/modules/http/src/retrofit/http/HttpRequestBuilder.java
+++ b/modules/http/src/retrofit/http/HttpRequestBuilder.java
@@ -7,6 +7,8 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.message.BasicNameValuePair;
@@ -23,6 +25,8 @@ import org.apache.http.message.BasicNameValuePair;
  * </ol>
  */
 final class HttpRequestBuilder {
+  private static final Logger logger =
+      Logger.getLogger(HttpRequestBuilder.class.getName());
 
   private Method javaMethod;
   private Object[] args;
@@ -158,7 +162,9 @@ final class HttpRequestBuilder {
       nonPathParams = paramList;
     }
 
-    return requestLine.getHttpMethod().createFrom(this);
+    HttpUriRequest request = requestLine.getHttpMethod().createFrom(this);
+    if (logger.isLoggable(Level.FINE)) logger.fine("Request params: "+getParamList(true));
+    return request;
   }
 
   /** Gets the parameter name from the @Named annotation. */


### PR DESCRIPTION
This allows Retrofit to provide more logging of outbound parameters and inbound data.  Before, we only had visibility to GET parameters, and responses would be cut off if more than 4096 or so characters.

Also, our response printing would go through the trouble of creating a string for logging regardless of whether it was used, and it would do this for the entire response at once -- that can potentially be 750K on a tab-heavy payment history.  And strings duplicate the byte array.  Now, this does no string conversion if logging is disabled, and it chunks it 4000 bytes at a time if it does.

Now, for sending data, the log looks like this:
  I/Square  (11350): Request params: [amount_cents=185, tendered_cents=200, change_cents=15, tax_cents=85, description=, unique_key=37c484f1-61d3-4ce3-be44-07ecf3ea2ee2, timestamp=2011-09-12T17:50:02-05:00]
  I/Square  (11350): Sending POST to https://api.broadway.squareup.com/1.0/payments/create

And (a short) response looks like this:
  I/Square  (11350): -Response:
  I/Square  (11350): {"payment_amount_cents":185,"success":true,"payment_id":"6528350"}
  I/Square  (11350): -end response.

Longer responses will have more central lines -- one just needs to remove the 'I/Square  (xxxx): ' and newlines to restore the original request.
