### PR TITLE
Upgrade to Gson 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
         <!-- Dependencies -->
         <android.version>2.2.1</android.version>
-        <gson.version>2.1</gson.version>
+        <gson.version>2.2.1</gson.version>
         <guice.version>3.0</guice.version>
         <httpcomponents.version>4.1.3</httpcomponents.version>
 


### PR DESCRIPTION
The main benefit of this update is that it fixes a DoS vulnerability.
The benefit I'm interested in TypeAdapter.toJsonTree and fromJsonTree.
