### PR TITLE
Support JSR-330 instead of Guice.

### DIFF
--- a/http/pom.xml
+++ b/http/pom.xml
@@ -22,9 +22,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-            <classifier>no_aop</classifier>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/http/src/main/java/retrofit/http/HttpRequestBuilder.java
+++ b/http/src/main/java/retrofit/http/HttpRequestBuilder.java
@@ -1,7 +1,7 @@
 package retrofit.http;
 
 import com.google.gson.Gson;
-import com.google.inject.name.Named;
+import javax.inject.Named;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.message.BasicNameValuePair;

--- a/http/src/test/java/retrofit/http/HttpRequestBuilderTest.java
+++ b/http/src/test/java/retrofit/http/HttpRequestBuilderTest.java
@@ -2,12 +2,12 @@
 package retrofit.http;
 
 import com.google.gson.Gson;
-import com.google.inject.name.Named;
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.util.Set;
 import java.util.UUID;
+import javax.inject.Named;
 import junit.framework.TestCase;
 import org.apache.http.HttpMessage;
 import org.apache.http.client.methods.HttpGet;

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
         <!-- Dependencies -->
         <android.version>2.2.1</android.version>
         <gson.version>2.1</gson.version>
-        <guice.version>3.0</guice.version>
         <httpcomponents.version>4.1.3</httpcomponents.version>
+        <javax.inject.version>1</javax.inject.version>
 
         <!-- Test Dependencies -->
         <junit.version>4.10</junit.version>
@@ -110,10 +110,9 @@
                 <version>${gson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.inject</groupId>
-                <artifactId>guice</artifactId>
-                <version>${guice.version}</version>
-                <classifier>no_aop</classifier>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>${javax.inject.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
This change is _extremely_ backwards and forwards incompatible
because it replaces Guice's `@Named` with JSR-330's `@Named`.
Programs that use the wrong `@Named` will not work at all. For
this reason it's critical that clients of retrofit also change
their `@Named` in sync with this update.
