### PR TITLE
Restore Gson 2.2.3-SNAPSHOT, which now supports serialization.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
         <!-- Dependencies -->
         <android.version>2.2.1</android.version>
-        <gson.version>2.1</gson.version>
+        <gson.version>2.2.3-SNAPSHOT</gson.version>
         <httpcomponents.version>4.1.3</httpcomponents.version>
         <javax.inject.version>1</javax.inject.version>
 


### PR DESCRIPTION
Serialization fix in Gson is here:
http://code.google.com/p/google-gson/source/detail?r=1177
