### PR TITLE
Use ServerError directly in sessionExpired and serverError.

### DIFF
--- a/http/pom.xml
+++ b/http/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.squareup</groupId>
     <artifactId>retrofit</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/http/src/main/java/retrofit/http/Callback.java
+++ b/http/src/main/java/retrofit/http/Callback.java
@@ -21,8 +21,10 @@ public interface Callback<T> {
   /**
    * The session expired or the account has been disabled. Prompt the user to
    * log in again.
+   *
+   * @param error message to show user, or null if no message was returned
    */
-  void sessionExpired();
+  void sessionExpired(ServerError error);
 
   /**
    * Couldn't reach the server. Check network settings and try again.
@@ -43,10 +45,10 @@ public interface Callback<T> {
    * We reached the server, but it encountered an error (5xx) or its response
    * was unparseable. Please try again later.
    *
-   * @param message to show user, or null if no message was returned
+   * @param error message to show user, or null if no message was returned
    * @param statusCode the HTTP response code
    */
-  void serverError(String message, int statusCode);
+  void serverError(ServerError error, int statusCode);
 
   /**
    * An unexpected error occurred. Called if the framework throws an unexpected
@@ -55,4 +57,14 @@ public interface Callback<T> {
    * would have been caught sooner. The user should try updating their client.
    */
   void unexpectedError(Throwable t);
+
+
+  /** JSON object for parsing server error responses. */
+  static class ServerError {
+    public final String message;
+
+    public ServerError(String message) {
+      this.message = message;
+    }
+  }
 }

--- a/http/src/main/java/retrofit/http/Types.java
+++ b/http/src/main/java/retrofit/http/Types.java
@@ -1,0 +1,52 @@
+// Copyright 2012 Square, Inc.
+package retrofit.http;
+
+/**
+ * Helper methods for dealing with generic types via reflection.
+ *
+ * @author Jake Wharton (jw@squareup.com)
+ */
+import java.lang.reflect.Type;
+
+class Types {
+  /**
+   * Returns the generic supertype for {@code supertype}. For example, given a class {@code
+   * IntegerSet}, the result for when supertype is {@code Set.class} is {@code Set<Integer>} and the
+   * result when the supertype is {@code Collection.class} is {@code Collection<Integer>}.
+   * <p/>
+   * NOTE: This method is copied from Guice's {@code MoreTypes} class.
+   */
+  static Type getGenericSupertype(Type context, Class<?> rawType, Class<?> toResolve) {
+    if (toResolve == rawType) {
+      return context;
+    }
+
+    // we skip searching through interfaces if unknown is an interface
+    if (toResolve.isInterface()) {
+      Class<?>[] interfaces = rawType.getInterfaces();
+      for (int i = 0, length = interfaces.length; i < length; i++) {
+        if (interfaces[i] == toResolve) {
+          return rawType.getGenericInterfaces()[i];
+        } else if (toResolve.isAssignableFrom(interfaces[i])) {
+          return getGenericSupertype(rawType.getGenericInterfaces()[i], interfaces[i], toResolve);
+        }
+      }
+    }
+
+    // check our supertypes
+    if (!rawType.isInterface()) {
+      while (rawType != Object.class) {
+        Class<?> rawSupertype = rawType.getSuperclass();
+        if (rawSupertype == toResolve) {
+          return rawType.getGenericSuperclass();
+        } else if (toResolve.isAssignableFrom(rawSupertype)) {
+          return getGenericSupertype(rawType.getGenericSuperclass(), rawSupertype, toResolve);
+        }
+        rawType = rawSupertype;
+      }
+    }
+
+    // we can't resolve this further
+    return toResolve;
+  }
+}

--- a/http/src/main/java/retrofit/http/UiCallback.java
+++ b/http/src/main/java/retrofit/http/UiCallback.java
@@ -29,10 +29,10 @@ public final class UiCallback<T> implements Callback<T> {
     });
   }
 
-  public void sessionExpired() {
+  public void sessionExpired(final ServerError error) {
     mainThread.execute(new Runnable() {
       public void run() {
-        delegate.sessionExpired();
+        delegate.sessionExpired(error);
       }
     });
   }
@@ -53,10 +53,10 @@ public final class UiCallback<T> implements Callback<T> {
     });
   }
 
-  public void serverError(final String message, final int statusCode) {
+  public void serverError(final ServerError error, final int statusCode) {
     mainThread.execute(new Runnable() {
       public void run() {
-        delegate.serverError(message, statusCode);
+        delegate.serverError(error, statusCode);
       }
     });
   }

--- a/http/src/test/java/retrofit/http/HttpRequestBuilderTest.java
+++ b/http/src/test/java/retrofit/http/HttpRequestBuilderTest.java
@@ -224,7 +224,7 @@ public class HttpRequestBuilderTest {
     @Override public void call(SimpleResponse simpleResponse) {
     }
 
-    @Override public void sessionExpired() {
+    @Override public void sessionExpired(ServerError error) {
     }
 
     @Override public void networkError() {
@@ -233,7 +233,7 @@ public class HttpRequestBuilderTest {
     @Override public void clientError(SimpleResponse response, int statusCode) {
     }
 
-    @Override public void serverError(String message, int statusCode) {
+    @Override public void serverError(ServerError error, int statusCode) {
     }
 
     @Override public void unexpectedError(Throwable t) {

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.squareup</groupId>
     <artifactId>retrofit</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>com.squareup</groupId>
   <artifactId>retrofit</artifactId>
-  <version>0.7.0-SNAPSHOT</version>
+  <version>0.8.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Retrofit</name>

--- a/sync-native/pom.xml
+++ b/sync-native/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.squareup</groupId>
     <artifactId>retrofit</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sync-sample/pom.xml
+++ b/sync-sample/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.squareup</groupId>
     <artifactId>retrofit</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sync/pom.xml
+++ b/sync/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>retrofit</artifactId>
     <groupId>com.squareup</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>retrofit-sync</artifactId>


### PR DESCRIPTION
This is a short step on the road to HTTP body format agnostic support. And it's not a pretty step, either.

Version number is bumped so we don't immediately break existing clients.
