### PR TITLE
Report Fetcher progress percentage as a float.

### DIFF
--- a/http/src/main/java/retrofit/http/ProgressListener.java
+++ b/http/src/main/java/retrofit/http/ProgressListener.java
@@ -1,4 +1,4 @@
-// Copyright 2010 Square, Inc.
+// Copyright 2012 Square, Inc.
 package retrofit.http;
 
 /**
@@ -11,7 +11,7 @@ public interface ProgressListener {
   /**
    * Hears a progress update.
    *
-   * @param percent 0-100
+   * @param percent Float bounded by (0..1].
    */
-  void hearProgress(int percent);
+  void hearProgress(float percent);
 }

--- a/http/src/test/java/retrofit/http/FetcherTest.java
+++ b/http/src/test/java/retrofit/http/FetcherTest.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.concurrent.Executor;
 
-import static org.easymock.EasyMock.anyInt;
+import static org.easymock.EasyMock.anyFloat;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
@@ -40,8 +40,7 @@ public class FetcherTest {
   private HttpResponse response = createMock(HttpResponse.class);
   @SuppressWarnings("unchecked")
   private Callback<Void> callback = createMock(Callback.class);
-  private ProgressListener progressListener
-      = createMock(ProgressListener.class);
+  private ProgressListener progressListener = createMock(ProgressListener.class);
 
   @Test public void testSuccessfulFetch() throws Exception {
     DummyInputStream in = new DummyInputStream();
@@ -56,7 +55,8 @@ public class FetcherTest {
     expect(entity.getContentLength()).andReturn(3L);
     expect(entity.getContent()).andReturn(in);
     expect(sinkFactory.newSink()).andReturn(sink);
-    progressListener.hearProgress(anyInt()); expectLastCall().atLeastOnce();
+    progressListener.hearProgress(anyFloat());
+    expectLastCall().atLeastOnce();
     callback.call(null);
 
     replayAll();


### PR DESCRIPTION
@swankjesse 

Not sure how I feel about this. I don't like synchronizing on every buffer read but I also don't want to spam the main thread with the same runnable instance.

Fixes #63
