### PR TITLE
Introduce builder pattern to instantiate RestAdapter.

### DIFF
--- a/http/src/main/java/retrofit/http/CallbackResponseHandler.java
+++ b/http/src/main/java/retrofit/http/CallbackResponseHandler.java
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
  * @author Bob Lee (bob@squareup.com)
  * @author Jake Wharton (jw@squareup.com)
  */
-public class CallbackResponseHandler<R> implements ResponseHandler<Void> {
+class CallbackResponseHandler<R> implements ResponseHandler<Void> {
 
   private static final Logger LOGGER = Logger.getLogger(CallbackResponseHandler.class.getName());
 
@@ -51,7 +51,7 @@ public class CallbackResponseHandler<R> implements ResponseHandler<Void> {
    * @return parsed response
    * @throws ConversionException if the server returns an unexpected response
    */
-  protected Object parse(HttpEntity entity, Type type) throws ConversionException {
+  private Object parse(HttpEntity entity, Type type) throws ConversionException {
     if (LOGGER.isLoggable(Level.FINE)) {
       try {
         entity = HttpClients.copyAndLog(entity, requestUrl, start, dateFormat.get());

--- a/http/src/main/java/retrofit/http/Headers.java
+++ b/http/src/main/java/retrofit/http/Headers.java
@@ -10,6 +10,6 @@ import org.apache.http.HttpMessage;
  */
 public interface Headers {
 
-  /** Sets headers on the given message, with the specified MIME type */
-  void setOn(HttpMessage message, String mimeType);
+  /** Sets headers on the given message */
+  void setOn(HttpMessage message);
 }

--- a/http/src/main/java/retrofit/http/HttpMethodType.java
+++ b/http/src/main/java/retrofit/http/HttpMethodType.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import org.apache.http.HttpMessage;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpDelete;
@@ -34,7 +35,7 @@ public enum HttpMethodType {
         throws URISyntaxException {
       URI uri = getParameterizedUri(builder);
       HttpGet request = new HttpGet(uri);
-      builder.getHeaders().setOn(request, builder.getMimeType());
+      addHeaders(request, builder);
       return request;
     }
   },
@@ -45,7 +46,7 @@ public enum HttpMethodType {
       URI uri = getUri(builder);
       HttpPost request = new HttpPost(uri);
       addParams(request, builder);
-      builder.getHeaders().setOn(request, builder.getMimeType());
+      addHeaders(request, builder);
       return request;
     }
   },
@@ -56,7 +57,7 @@ public enum HttpMethodType {
       URI uri = getUri(builder);
       HttpPut request = new HttpPut(uri);
       addParams(request, builder);
-      builder.getHeaders().setOn(request, builder.getMimeType());
+      addHeaders(request, builder);
       return request;
     }
   },
@@ -66,7 +67,7 @@ public enum HttpMethodType {
         throws URISyntaxException {
       URI uri = getParameterizedUri(builder);
       HttpDelete request = new HttpDelete(uri);
-      builder.getHeaders().setOn(request, builder.getMimeType());
+      addHeaders(request, builder);
       return request;
     }
   };
@@ -94,6 +95,17 @@ public enum HttpMethodType {
     String queryString = URLEncodedUtils.format(queryParams, "UTF-8");
     return URIUtils.createURI(builder.getScheme(), builder.getHost(), -1, builder.getRelativePath(),
         queryString, null);
+  }
+
+  private static void addHeaders(HttpMessage message, HttpRequestBuilder builder) {
+    String mimeType = builder.getMimeType();
+    if (mimeType != null) {
+      message.addHeader("Content-Type", mimeType);
+    }
+    Headers headers = builder.getHeaders();
+    if (headers != null) {
+      headers.setOn(message);
+    }
   }
 
   /**

--- a/http/src/main/java/retrofit/http/HttpProfiler.java
+++ b/http/src/main/java/retrofit/http/HttpProfiler.java
@@ -8,15 +8,6 @@ package retrofit.http;
  */
 public interface HttpProfiler<T> {
 
-  HttpProfiler<Void> NONE = new HttpProfiler<Void>() {
-    @Override public Void beforeCall() {
-      return null;
-    }
-    @Override public void afterCall(RequestInformation requestInfo,
-        long elapsedTime, int statusCode, Void beforeCallData) {
-    }
-  };
-
   /**
    * Invoked before an HTTP method call. The object returned by this method will be
    * passed to {@link #afterCall} when the call returns.

--- a/http/src/main/java/retrofit/http/ProfilingResponseHandler.java
+++ b/http/src/main/java/retrofit/http/ProfilingResponseHandler.java
@@ -1,0 +1,53 @@
+// Copyright 2012 Square, Inc.
+package retrofit.http;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ResponseHandler;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** Sends server call times and response status codes to {@link retrofit.http.HttpProfiler}. */
+class ProfilingResponseHandler<T> implements ResponseHandler<Void> {
+  private static final Logger LOGGER = Logger.getLogger(ProfilingResponseHandler.class.getSimpleName());
+
+  private final ResponseHandler<Void> delegate;
+  private final HttpProfiler<T> profiler;
+  private final HttpProfiler.RequestInformation requestInfo;
+  private final long startTime;
+  private final AtomicReference<T> beforeCallData = new AtomicReference<T>();
+
+  /** Wraps the delegate response handler. */
+  ProfilingResponseHandler(ResponseHandler<Void> delegate, HttpProfiler<T> profiler,
+      HttpProfiler.RequestInformation requestInfo, long startTime) {
+    this.delegate = delegate;
+    this.profiler = profiler;
+    this.requestInfo = requestInfo;
+    this.startTime = startTime;
+  }
+
+  public void beforeCall() {
+    try {
+      beforeCallData.set(profiler.beforeCall());
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Error occurred in HTTP profiler beforeCall().", e);
+    }
+  }
+
+  @Override public Void handleResponse(HttpResponse httpResponse) throws IOException {
+    // Intercept the response and send data to profiler.
+    long elapsedTime = System.currentTimeMillis() - startTime;
+    int statusCode = httpResponse.getStatusLine().getStatusCode();
+
+    try {
+      profiler.afterCall(requestInfo, elapsedTime, statusCode, beforeCallData.get());
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Error occurred in HTTP profiler afterCall().", e);
+    }
+
+    // Pass along the response to the normal handler.
+    return delegate.handleResponse(httpResponse);
+  }
+}

--- a/http/src/test/java/retrofit/http/HttpRequestBuilderTest.java
+++ b/http/src/test/java/retrofit/http/HttpRequestBuilderTest.java
@@ -2,7 +2,6 @@
 package retrofit.http;
 
 import com.google.gson.Gson;
-import org.apache.http.HttpMessage;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -23,10 +22,6 @@ import static org.fest.assertions.Fail.fail;
 public class HttpRequestBuilderTest {
   private static final Gson GSON = new Gson();
   private static final String API_URL = "http://taqueria.com/lengua/taco";
-  private static final Headers BLANK_HEADERS = new Headers() {
-    @Override public void setOn(HttpMessage message, String mimeType) {
-    }
-  };
 
   @Test public void testRegex() throws Exception {
     expectParams("");
@@ -205,7 +200,6 @@ public class HttpRequestBuilderTest {
         .setMethod(method)
         .setArgs(args)
         .setApiUrl(API_URL)
-        .setHeaders(BLANK_HEADERS)
         .build();
   }
 

--- a/http/src/test/java/retrofit/http/RestAdapterTest.java
+++ b/http/src/test/java/retrofit/http/RestAdapterTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import retrofit.http.Callback.ServerError;
 
 import javax.inject.Named;
-import javax.inject.Provider;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
@@ -66,14 +65,14 @@ public class RestAdapterTest {
     mockCallback   = createMock(ResponseCallback.class);
     mockResponse   = createMock(HttpResponse.class);
 
-    Server server = new Server("http://host/api/");
-    Provider<HttpClient> httpClientProvider = new Provider<HttpClient>() {
-      @Override public HttpClient get() {
-        return mockHttpClient;
-      }
-    };
-    restAdapter = new RestAdapter(server, httpClientProvider, mockExecutor, mockMainThread, mockHeaders,
-        new GsonConverter(GSON), HttpProfiler.NONE);
+    restAdapter = new RestAdapter.Builder()
+        .setServer("http://host/api/")
+        .setClient(mockHttpClient)
+        .setExecutor(mockExecutor)
+        .setMainThread(mockMainThread)
+        .setHeaders(mockHeaders)
+        .setConverter(new GsonConverter(GSON))
+        .build();
   }
 
   @Test public void testServiceDeleteSimple() throws IOException {
@@ -392,8 +391,7 @@ public class RestAdapterTest {
   private <T extends HttpUriRequest> void expectSetOnWithRequest(final Class<T> expectedRequestClass,
         final String expectedUri) {
     final Capture<HttpMessage> capture = new Capture<HttpMessage>();
-    final Capture<String> captureMime = new Capture<String>();
-    mockHeaders.setOn(capture(capture), capture(captureMime));
+    mockHeaders.setOn(capture(capture));
     expectLastCall().andAnswer(new IAnswer<Object>() {
       @Override public Object answer() throws Throwable {
         T request = expectedRequestClass.cast(capture.getValue());


### PR DESCRIPTION
Headers and profiler are now optional. Convenience methods for specifying a String URL or an
HttpClient directly are also provided.

`mvn clean verify` passes.
