### PR TITLE
Eliminate dependencies already in Android

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,10 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/retrofit/pom.xml
+++ b/retrofit/pom.xml
@@ -26,6 +26,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
ANDROID-5295

Adjusts scope and exclusions so that apps using Retrofit won't get lots of duplicate class definition warnings.
