### PR TITLE
Provide sane defaults for `HttpClient`, `Converter`, and `Executor`s.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,23 +118,11 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpmime</artifactId>
         <version>${httpcomponents.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>${httpcomponents.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>

--- a/retrofit/src/main/java/retrofit/http/Platform.java
+++ b/retrofit/src/main/java/retrofit/http/Platform.java
@@ -1,0 +1,101 @@
+package retrofit.http;
+
+import android.net.http.AndroidHttpClient;
+import android.os.Process;
+import com.google.gson.Gson;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.inject.Provider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.DefaultHttpClient;
+import retrofit.android.MainThreadExecutor;
+
+import static android.os.Process.THREAD_PRIORITY_BACKGROUND;
+import static retrofit.http.RestAdapter.SynchronousExecutor;
+
+abstract class Platform {
+  private static final Platform PLATFORM = findPlatform();
+
+  static Platform get() {
+    return PLATFORM;
+  }
+
+  private static Platform findPlatform() {
+    try {
+      Class.forName("android.os.Build");
+      return new Android();
+    } catch (ClassNotFoundException e) {
+      return new Base();
+    }
+  }
+
+  Converter defaultConverter() {
+    return new GsonConverter(new Gson());
+  }
+  abstract Provider<HttpClient> defaultHttpClient();
+  abstract Executor defaultHttpExecutor();
+  abstract Executor defaultCallbackExecutor();
+
+  /** Provides sane defaults for operation on the JVM. */
+  private static class Base extends Platform {
+    @Override Provider<HttpClient> defaultHttpClient() {
+      return new Provider<HttpClient>() {
+        @Override public HttpClient get() {
+          return new DefaultHttpClient();
+        }
+      };
+    }
+
+    @Override Executor defaultHttpExecutor() {
+      return Executors.newCachedThreadPool(new ThreadFactory() {
+        private final AtomicInteger threadCounter = new AtomicInteger();
+
+        @Override public Thread newThread(final Runnable r) {
+          return new Thread(new Runnable() {
+            @Override public void run() {
+              Thread.currentThread().setPriority(THREAD_PRIORITY_BACKGROUND);
+              r.run();
+            }
+          }, "Retrofit-" + threadCounter.getAndIncrement());
+        }
+      });
+    }
+
+    @Override Executor defaultCallbackExecutor() {
+      return new SynchronousExecutor();
+    }
+  }
+
+  /** Provides sane defaults for operation on Android. */
+  private static class Android extends Platform {
+    @Override Provider<HttpClient> defaultHttpClient() {
+      // TODO use HttpUrlConnection on Android 2.3+
+      return new Provider<HttpClient>() {
+        @Override public HttpClient get() {
+          return AndroidHttpClient.newInstance("Retrofit");
+        }
+      };
+    }
+
+    @Override Executor defaultHttpExecutor() {
+      return Executors.newCachedThreadPool(new ThreadFactory() {
+        private final AtomicInteger threadCounter = new AtomicInteger();
+
+        @Override public Thread newThread(final Runnable r) {
+          return new Thread(new Runnable() {
+            @Override public void run() {
+              Process.setThreadPriority(THREAD_PRIORITY_BACKGROUND);
+              r.run();
+            }
+          }, "Retrofit-" + threadCounter.getAndIncrement());
+        }
+      });
+    }
+
+    @Override Executor defaultCallbackExecutor() {
+      return new MainThreadExecutor();
+    }
+  }
+}

--- a/retrofit/src/main/java/retrofit/http/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/http/RestAdapter.java
@@ -1,5 +1,20 @@
 package retrofit.http;
 
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.inject.Provider;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -16,22 +31,6 @@ import retrofit.http.RestException.NetworkException;
 import retrofit.http.RestException.ServerHttpException;
 import retrofit.http.RestException.UnauthorizedHttpException;
 import retrofit.http.RestException.UnexpectedException;
-
-import javax.inject.Provider;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Proxy;
-import java.lang.reflect.Type;
-import java.lang.reflect.WildcardType;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static java.util.logging.Level.WARNING;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
@@ -375,14 +374,31 @@ public class RestAdapter {
     }
 
     public RestAdapter build() {
-      if (server == null || clientProvider == null || converter == null) {
-        throw new IllegalArgumentException("Server, client, and converter are required.");
+      if (server == null) {
+        throw new IllegalArgumentException("Server may not be null.");
       }
+      ensureSaneDefaults();
       return new RestAdapter(server, clientProvider, httpExecutor, callbackExecutor, headers, converter, profiler);
+    }
+
+    private void ensureSaneDefaults() {
+      Platform platform = Platform.get();
+      if (converter == null) {
+        converter = platform.defaultConverter();
+      }
+      if (clientProvider == null) {
+        clientProvider = platform.defaultHttpClient();
+      }
+      if (httpExecutor == null) {
+        httpExecutor = platform.defaultHttpExecutor();
+      }
+      if (callbackExecutor == null) {
+        callbackExecutor = platform.defaultCallbackExecutor();
+      }
     }
   }
 
-  private static class SynchronousExecutor implements Executor {
+  static class SynchronousExecutor implements Executor {
     @Override public void execute(Runnable runnable) {
       runnable.run();
     }

--- a/samples/twitter-client/pom.xml
+++ b/samples/twitter-client/pom.xml
@@ -21,18 +21,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>com.squareup.retrofit</groupId>
       <artifactId>retrofit</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This reduces the minimum required API for constructing a `RestAdapter` to

``` java
new RestAdapter.Builder()
    .setServer("http://api.example.com")
    .build();
```
