### PR TITLE
Support using Files directly as entities and form parts.

### DIFF
--- a/retrofit/src/main/java/retrofit/http/GsonConverter.java
+++ b/retrofit/src/main/java/retrofit/http/GsonConverter.java
@@ -18,7 +18,9 @@ import retrofit.io.TypedBytes;
  * @author Jake Wharton (jw@squareup.com)
  */
 public class GsonConverter implements Converter {
-  public static final String ENCODING = "UTF-8"; // TODO use actual encoding
+  private static final String ENCODING = "UTF-8"; // TODO use actual encoding
+  private static final MimeType JSON = new MimeType("application/json", "json");
+
   private final Gson gson;
 
   public GsonConverter(Gson gson) {
@@ -52,7 +54,7 @@ public class GsonConverter implements Converter {
     }
 
     @Override public MimeType mimeType() {
-      return MimeType.JSON;
+      return JSON;
     }
 
     @Override public int length() {

--- a/retrofit/src/main/java/retrofit/http/HttpRequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/http/HttpRequestBuilder.java
@@ -1,11 +1,6 @@
 package retrofit.http;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.message.BasicNameValuePair;
-import retrofit.io.TypedBytes;
-
-import javax.inject.Named;
+import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -17,6 +12,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.inject.Named;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.message.BasicNameValuePair;
+import retrofit.io.MimeType;
+import retrofit.io.TypedBytes;
+import retrofit.io.TypedFile;
 
 /**
  * Builds HTTP requests from Java method invocations.  Handles "path parameters" in the
@@ -29,6 +31,8 @@ import java.util.regex.Pattern;
  * </ol>
  */
 final class HttpRequestBuilder {
+  private static final MimeType OCTET_STREAM = new MimeType("application/octet-stream");
+
   private final Converter converter;
 
   private Method javaMethod;
@@ -146,6 +150,9 @@ final class HttpRequestBuilder {
           if (arg instanceof TypedBytes) {
             // Let the object specify its own entity representation.
             singleEntity = (TypedBytes) arg;
+          } else if (arg instanceof File) {
+            // Wrap the File object in a format we can understand.
+            singleEntity = new TypedFile((File) arg, OCTET_STREAM);
           } else {
             // Just an object: serialize it with supplied converter
             singleEntity = converter.from(arg);

--- a/retrofit/src/main/java/retrofit/http/TypedBytesBody.java
+++ b/retrofit/src/main/java/retrofit/http/TypedBytesBody.java
@@ -6,15 +6,21 @@ import org.apache.http.entity.mime.MIME;
 import org.apache.http.entity.mime.content.AbstractContentBody;
 import retrofit.io.TypedBytes;
 
-/** Adapts ContentBody to TypedBytes. */
-public class TypedBytesBody extends AbstractContentBody {
+/** Adapts HTTP content body to {@link TypedBytes}. */
+class TypedBytesBody extends AbstractContentBody {
   private final TypedBytes typedBytes;
   private final String name;
 
   public TypedBytesBody(TypedBytes typedBytes, String baseName) {
     super(typedBytes.mimeType().mimeName());
     this.typedBytes = typedBytes;
-    this.name = baseName + "." + typedBytes.mimeType().extension();
+
+    String name = baseName;
+    String ext = typedBytes.mimeType().extension();
+    if (ext != null) {
+      name += "." + ext;
+    }
+    this.name = name;
   }
 
   @Override public long getContentLength() {

--- a/retrofit/src/main/java/retrofit/http/TypedBytesEntity.java
+++ b/retrofit/src/main/java/retrofit/http/TypedBytesEntity.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.http.entity.AbstractHttpEntity;
-import retrofit.io.MimeType;
 import retrofit.io.TypedBytes;
 
 /**
@@ -15,12 +14,13 @@ import retrofit.io.TypedBytes;
  *
  * @author Eric Denman (edenman@squareup.com)
  */
-public class TypedBytesEntity extends AbstractHttpEntity {
+class TypedBytesEntity extends AbstractHttpEntity {
 
-  private TypedBytes typedBytes;
+  private final TypedBytes typedBytes;
 
   public TypedBytesEntity(TypedBytes typedBytes) {
     this.typedBytes = typedBytes;
+    setContentType(typedBytes.mimeType().mimeName());
   }
 
   @Override public boolean isRepeatable() {
@@ -43,9 +43,5 @@ public class TypedBytesEntity extends AbstractHttpEntity {
 
   @Override public boolean isStreaming() {
     return false;
-  }
-
-  public MimeType getMimeType() {
-    return typedBytes.mimeType();
   }
 }

--- a/retrofit/src/main/java/retrofit/http/TypedFileEntity.java
+++ b/retrofit/src/main/java/retrofit/http/TypedFileEntity.java
@@ -1,0 +1,11 @@
+package retrofit.http;
+
+import org.apache.http.entity.FileEntity;
+import retrofit.io.TypedFile;
+
+/** Adapts a {@link TypedFile} to an {@link org.apache.http.HttpEntity HttpEntity}. */
+class TypedFileEntity extends FileEntity {
+  public TypedFileEntity(TypedFile typedFile) {
+    super(typedFile.file(), typedFile.mimeType().mimeName());
+  }
+}

--- a/retrofit/src/main/java/retrofit/io/MimeType.java
+++ b/retrofit/src/main/java/retrofit/io/MimeType.java
@@ -6,31 +6,25 @@ package retrofit.io;
  *
  * @author Bob Lee (bob@squareup.com)
  */
-public enum MimeType {
-
-  JSON("application/json", "json"),
-  GIF("image/gif", "gif"),
-  PNG("image/png", "png"),
-  JPEG("image/jpeg", "jpg");
-
+public class MimeType {
   private final String typeName;
   private final String extension;
 
-  MimeType(String typeName, String extension) {
+  public MimeType(String typeName) {
+    this(typeName, null);
+  }
+
+  public MimeType(String typeName, String extension) {
     this.typeName = typeName;
     this.extension = extension;
   }
 
-  /**
-   * Returns the standard type name.
-   */
+  /** Returns the standard type name. */
   public String mimeName() {
     return typeName;
   }
 
-  /**
-   * Returns the standard file extension.
-   */
+  /** Returns the standard file extension. */
   public String extension() {
     return extension;
   }

--- a/retrofit/src/main/java/retrofit/io/TypedFile.java
+++ b/retrofit/src/main/java/retrofit/io/TypedFile.java
@@ -61,7 +61,7 @@ public class TypedFile extends AbstractTypedBytes {
   }
 
   @Override public String toString() {
-    return file.getAbsolutePath() + " (" + mimeType() + ")";
+    return file.getAbsolutePath() + " (" + mimeType().mimeName() + ")";
   }
 
   @Override

--- a/retrofit/src/test/java/retrofit/io/TypedByteArrayTest.java
+++ b/retrofit/src/test/java/retrofit/io/TypedByteArrayTest.java
@@ -7,10 +7,12 @@ import static org.fest.assertions.api.Assertions.assertThat;
 
 /** @author Eric Burke (eric@squareup.com) */
 public class TypedByteArrayTest {
+  private static final MimeType GIF = new MimeType("image/gif", "gif");
+
   @Test public void testEquals() {
-    TypedByteArray a1 = new TypedByteArray(new byte[] { 10, 20 }, MimeType.GIF);
-    TypedByteArray a2 = new TypedByteArray(new byte[] { 10, 20 }, MimeType.GIF);
-    TypedByteArray b = new TypedByteArray(new byte[] { 8, 12 }, MimeType.GIF);
+    TypedByteArray a1 = new TypedByteArray(new byte[] { 10, 20 }, GIF);
+    TypedByteArray a2 = new TypedByteArray(new byte[] { 10, 20 }, GIF);
+    TypedByteArray b = new TypedByteArray(new byte[] { 8, 12 }, GIF);
 
     assertThat(a1).isEqualTo(a2);
     assertThat(a1.hashCode()).isEqualTo(a2.hashCode());

--- a/retrofit/src/test/java/retrofit/io/TypedFileTest.java
+++ b/retrofit/src/test/java/retrofit/io/TypedFileTest.java
@@ -11,17 +11,19 @@ import static org.fest.assertions.api.Assertions.assertThat;
 
 /** @author Eric Burke (eric@squareup.com) */
 public class TypedFileTest {
+  private static final MimeType PNG = new MimeType("image/png", "png");
+
   @Test public void testNotEquals() {
-    TypedFile a = new TypedFile(new File("a.png"), MimeType.PNG);
-    TypedFile b = new TypedFile(new File("b.png"), MimeType.PNG);
+    TypedFile a = new TypedFile(new File("a.png"), PNG);
+    TypedFile b = new TypedFile(new File("b.png"), PNG);
 
     assertThat(a).isNotEqualTo(b);
     assertThat(a.hashCode()).isNotEqualTo(b.hashCode());
   }
 
   @Test public void testEquals() {
-    TypedFile a1 = new TypedFile(new File("a.png"), MimeType.PNG);
-    TypedFile a2 = new TypedFile(new File("a.png"), MimeType.PNG);
+    TypedFile a1 = new TypedFile(new File("a.png"), PNG);
+    TypedFile a2 = new TypedFile(new File("a.png"), PNG);
 
     assertThat(a1).isEqualTo(a2);
     assertThat(a1.hashCode()).isEqualTo(a2.hashCode());
@@ -30,14 +32,14 @@ public class TypedFileTest {
   @Test public void testToString() {
     File file = new File("/path/to/file.png");
 
-    assertThat(new TypedFile(file, MimeType.PNG).toString()) //
-        .isEqualTo(file.getAbsolutePath() + " (PNG)");
+    assertThat(new TypedFile(file, PNG).toString()) //
+        .isEqualTo(file.getAbsolutePath() + " (image/png)");
   }
 
   @Test public void testLength() throws IOException {
     File tempFile = File.createTempFile("foo", ".tmp");
     try {
-      TypedFile typedFile = new TypedFile(tempFile, MimeType.PNG);
+      TypedFile typedFile = new TypedFile(tempFile, PNG);
       assertThat(typedFile.length()).isZero();
 
       writeToFile(tempFile, new byte[] { 0, 1, 2, 3, 4 });


### PR DESCRIPTION
This changes `MimeType` to a be a class rather than an enum. Before we were requiring instances of it for `TypedFile`, `TypedByteArray`, and `AbstractTypedBytes` without providing a way of constructing custom instances.
