### PR TITLE
Switch headers to come from an interface implementation.

### DIFF
--- a/retrofit/src/main/java/retrofit/http/Headers.java
+++ b/retrofit/src/main/java/retrofit/http/Headers.java
@@ -1,0 +1,21 @@
+// Copyright 2013 Square, Inc.
+package retrofit.http;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Manages headers for each request. */
+public interface Headers {
+  /**
+   * Get a list of headers for a request. This method will be called once for each request allowing
+   * you to change the list as the state of your application changes.
+   */
+  List<Header> get();
+
+  /** Empty header list. */
+  Headers NONE = new Headers() {
+    @Override public List<Header> get() {
+      return Collections.emptyList();
+    }
+  };
+}

--- a/retrofit/src/main/java/retrofit/http/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/http/RestAdapter.java
@@ -8,7 +8,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,18 +41,17 @@ public class RestAdapter {
   private final Provider<Client> clientProvider;
   private final Executor httpExecutor;
   private final Executor callbackExecutor;
-  private final Provider<List<Header>> headersProvider;
+  private final Headers headers;
   private final Converter converter;
   private final Profiler profiler;
 
   private RestAdapter(Server server, Provider<Client> clientProvider, Executor httpExecutor,
-      Executor callbackExecutor, Provider<List<Header>> headersProvider, Converter converter,
-      Profiler profiler) {
+      Executor callbackExecutor, Headers headers, Converter converter, Profiler profiler) {
     this.server = server;
     this.clientProvider = clientProvider;
     this.httpExecutor = httpExecutor;
     this.callbackExecutor = callbackExecutor;
-    this.headersProvider = headersProvider;
+    this.headers = headers;
     this.converter = converter;
     this.profiler = profiler;
   }
@@ -151,7 +149,7 @@ public class RestAdapter {
         Request request = new RequestBuilder(converter) //
             .setApiUrl(server.apiUrl())
             .setArgs(args)
-            .setHeaders(headersProvider.get())
+            .setHeaders(headers.get())
             .setMethodInfo(methodDetails)
             .build();
         url = request.getUrl();
@@ -261,7 +259,7 @@ public class RestAdapter {
     private Provider<Client> clientProvider;
     private Executor httpExecutor;
     private Executor callbackExecutor;
-    private Provider<List<Header>> headersProvider;
+    private Headers headers;
     private Converter converter;
     private Profiler profiler;
 
@@ -307,17 +305,9 @@ public class RestAdapter {
       return this;
     }
 
-    public Builder setHeaders(final List<Header> headers) {
-      return setHeaders(new Provider<List<Header>>() {
-        @Override public List<Header> get() {
-          return headers;
-        }
-      });
-    }
-
-    public Builder setHeaders(Provider<List<Header>> headersProvider) {
-      if (headersProvider == null) throw new NullPointerException("headersProvider");
-      this.headersProvider = headersProvider;
+    public Builder setHeaders(Headers headers) {
+      if (headers == null) throw new NullPointerException("headers");
+      this.headers = headers;
       return this;
     }
 
@@ -339,7 +329,7 @@ public class RestAdapter {
       }
       ensureSaneDefaults();
       return new RestAdapter(server, clientProvider, httpExecutor, callbackExecutor,
-          headersProvider, converter, profiler);
+          headers, converter, profiler);
     }
 
     private void ensureSaneDefaults() {
@@ -355,12 +345,8 @@ public class RestAdapter {
       if (callbackExecutor == null) {
         callbackExecutor = Platform.get().defaultCallbackExecutor();
       }
-      if (headersProvider == null) {
-        headersProvider = new Provider<List<Header>>() {
-          @Override public List<Header> get() {
-            return Collections.emptyList();
-          }
-        };
+      if (headers == null) {
+        headers = Headers.NONE;
       }
     }
   }


### PR DESCRIPTION
This makes it much more easy to provide dynamic headers. Rather than dealing with a Provider, you can now have a concrete class implement this interface.

Closes #146.
