### PR TITLE
Fix Url Escaping on GET Parameters

### DIFF
--- a/retrofit/src/main/java/retrofit/http/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/http/RequestBuilder.java
@@ -88,12 +88,7 @@ final class RequestBuilder {
         }
       }
       if (found != null) {
-        String value;
-        try {
-          value = URLEncoder.encode(String.valueOf(found.getValue()), UTF_8);
-        } catch (UnsupportedEncodingException e) {
-          throw new AssertionError(e);
-        }
+        String value = getUrlEncodedValue(found);
         replacedPath = replacedPath.replace("{" + found.getName() + "}", value);
         paramList.remove(found);
       } else {
@@ -127,7 +122,8 @@ final class RequestBuilder {
       for (int i = 0, count = paramList.size(); i < count; i++) {
         url.append((i == 0) ? '?' : '&');
         Parameter nonPathParam = paramList.get(i);
-        url.append(nonPathParam.getName()).append("=").append(nonPathParam.getValue());
+        String value = getUrlEncodedValue(nonPathParam);
+        url.append(nonPathParam.getName()).append("=").append(value);
       }
     } else if (!paramList.isEmpty()) {
       if (methodInfo.isMultipart) {
@@ -156,5 +152,13 @@ final class RequestBuilder {
     }
 
     return new Request(methodInfo.restMethod.value(), url.toString(), headers, body);
+  }
+
+  private static String getUrlEncodedValue(Parameter found) {
+    try {
+      return URLEncoder.encode(String.valueOf(found.getValue()), UTF_8);
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError(e);
+    }
   }
 }

--- a/retrofit/src/test/java/retrofit/http/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/http/RequestBuilderTest.java
@@ -76,6 +76,48 @@ public class RequestBuilderTest {
     assertThat(request.getUrl()).isEqualTo("http://example.com/foo/bar/pong/?kit=kat&riff=raff");
     assertThat(request.getBody()).isNull();
   }
+  
+  @Test public void getWithPathAndQueryQuestionMarkParam() throws Exception {
+    Request request = new Helper() //
+        .setMethod("GET") //
+        .setUrl("http://example.com") //
+        .setPath("/foo/bar/{ping}/") //
+        .addNamedParam("ping", "pong?") //
+        .addNamedParam("kit", "kat?") //
+        .build();
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getHeaders()).isEmpty();
+    assertThat(request.getUrl()).isEqualTo("http://example.com/foo/bar/pong%3F/?kit=kat%3F");
+    assertThat(request.getBody()).isNull();
+  }
+  
+  @Test public void getWithPathAndQueryAmpersandParam() throws Exception {
+    Request request = new Helper() //
+        .setMethod("GET") //
+        .setUrl("http://example.com") //
+        .setPath("/foo/bar/{ping}/") //
+        .addNamedParam("ping", "pong&") //
+        .addNamedParam("kit", "kat&") //
+        .build();
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getHeaders()).isEmpty();
+    assertThat(request.getUrl()).isEqualTo("http://example.com/foo/bar/pong%26/?kit=kat%26");
+    assertThat(request.getBody()).isNull();
+  }
+  
+  @Test public void getWithPathAndQueryHashParam() throws Exception {
+    Request request = new Helper() //
+        .setMethod("GET") //
+        .setUrl("http://example.com") //
+        .setPath("/foo/bar/{ping}/") //
+        .addNamedParam("ping", "pong#") //
+        .addNamedParam("kit", "kat#") //
+        .build();
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getHeaders()).isEmpty();
+    assertThat(request.getUrl()).isEqualTo("http://example.com/foo/bar/pong%23/?kit=kat%23");
+    assertThat(request.getBody()).isNull();
+  }
 
   @Test public void getWithPathAndQueryParamAsync() throws Exception {
     Request request = new Helper() //


### PR DESCRIPTION
This patch fixes #154, url escaping on url-encoded GET parameters. Query parameters will now be escaped. Test cases for common characters ?, #, and & are included.
