### PR TITLE
Relax enforcement of UTF-8 and use the body charset for decoding.

### DIFF
--- a/retrofit/src/main/java/retrofit/http/GsonConverter.java
+++ b/retrofit/src/main/java/retrofit/http/GsonConverter.java
@@ -11,8 +11,6 @@ import java.lang.reflect.Type;
 import retrofit.http.mime.TypedInput;
 import retrofit.http.mime.TypedOutput;
 
-import static retrofit.http.RestAdapter.UTF_8;
-
 /**
  * A {@link Converter} which uses GSON for serialization and deserialization of entities.
  *
@@ -26,9 +24,10 @@ public class GsonConverter implements Converter {
   }
 
   @Override public Object fromBody(TypedInput body, Type type) throws ConversionException {
+    String charset = Utils.parseCharset(body.mimeType());
     InputStreamReader isr = null;
     try {
-      isr = new InputStreamReader(body.in(), UTF_8);
+      isr = new InputStreamReader(body.in(), charset);
       return gson.fromJson(isr, type);
     } catch (IOException e) {
       throw new ConversionException(e);
@@ -46,7 +45,7 @@ public class GsonConverter implements Converter {
 
   @Override public TypedOutput toBody(Object object) {
     try {
-      return new JsonTypedOutput(gson.toJson(object).getBytes(UTF_8));
+      return new JsonTypedOutput(gson.toJson(object).getBytes("UTF-8"));
     } catch (UnsupportedEncodingException e) {
       throw new AssertionError(e);
     }

--- a/retrofit/src/main/java/retrofit/http/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/http/RequestBuilder.java
@@ -11,7 +11,6 @@ import retrofit.http.client.Request;
 import retrofit.http.mime.TypedOutput;
 import retrofit.http.mime.TypedString;
 
-import static retrofit.http.RestAdapter.UTF_8;
 import static retrofit.http.RestMethodInfo.NO_SINGLE_ENTITY;
 
 /**
@@ -156,7 +155,7 @@ final class RequestBuilder {
 
   private static String getUrlEncodedValue(Parameter found) {
     try {
-      return URLEncoder.encode(String.valueOf(found.getValue()), UTF_8);
+      return URLEncoder.encode(String.valueOf(found.getValue()), "UTF-8");
     } catch (UnsupportedEncodingException e) {
       throw new AssertionError(e);
     }

--- a/retrofit/src/main/java/retrofit/http/Utils.java
+++ b/retrofit/src/main/java/retrofit/http/Utils.java
@@ -11,9 +11,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
-import static retrofit.http.RestAdapter.UTF_8;
 
-final class Utils {
+public final class Utils {
   private static final Pattern CHARSET = Pattern.compile("\\Wcharset=([^\\s;]+)", CASE_INSENSITIVE);
   private static final int BUFFER_SIZE = 0x1000;
 
@@ -75,17 +74,21 @@ final class Utils {
     return toResolve;
   }
 
-  static String parseCharset(String mimeType) {
+  public static String parseCharset(String mimeType) {
     Matcher match = CHARSET.matcher(mimeType);
     if (match.find()) {
       return match.group(1).replaceAll("[\"\\\\]", "");
     }
-    return UTF_8;
+    return "UTF-8";
   }
 
   static class SynchronousExecutor implements Executor {
     @Override public void execute(Runnable runnable) {
       runnable.run();
     }
+  }
+
+  public Utils() {
+    // No instances.
   }
 }

--- a/retrofit/src/test/java/retrofit/http/UtilsTest.java
+++ b/retrofit/src/test/java/retrofit/http/UtilsTest.java
@@ -4,21 +4,20 @@ package retrofit.http;
 import org.junit.Test;
 
 import static org.fest.assertions.api.Assertions.assertThat;
-import static retrofit.http.RestAdapter.UTF_8;
 import static retrofit.http.Utils.parseCharset;
 
 public class UtilsTest {
   @Test public void charsetParsing() {
-    assertThat(parseCharset("text/plain;charset=utf-8")).isEqualToIgnoringCase(UTF_8);
-    assertThat(parseCharset("text/plain; charset=utf-8")).isEqualToIgnoringCase(UTF_8);
-    assertThat(parseCharset("text/plain;  charset=utf-8")).isEqualToIgnoringCase(UTF_8);
-    assertThat(parseCharset("text/plain; \tcharset=utf-8")).isEqualToIgnoringCase(UTF_8);
-    assertThat(parseCharset("text/plain; \r\n\tcharset=utf-8")).isEqualToIgnoringCase(UTF_8);
-    assertThat(parseCharset("text/plain; CHARSET=utf-8")).isEqualToIgnoringCase(UTF_8);
-    assertThat(parseCharset("text/plain; charset=UTF-8")).isEqualToIgnoringCase(UTF_8);
-    assertThat(parseCharset("text/plain; charset=\"\\u\\tf-\\8\"")).isEqualToIgnoringCase(UTF_8);
-    assertThat(parseCharset("text/plain; charset=\"utf-8\"")).isEqualToIgnoringCase(UTF_8);
-    assertThat(parseCharset("text/plain; charset=utf-8; other=thing")).isEqualToIgnoringCase(UTF_8);
-    assertThat(parseCharset("text/plain; notthecharset=utf-16;")).isEqualToIgnoringCase(UTF_8);
+    assertThat(parseCharset("text/plain;charset=utf-8")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; charset=utf-8")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain;  charset=utf-8")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; \tcharset=utf-8")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; \r\n\tcharset=utf-8")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; CHARSET=utf-8")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; charset=UTF-8")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; charset=\"\\u\\tf-\\8\"")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; charset=\"utf-8\"")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain;charset=utf-8;other=thing")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; notthecharset=utf-16;")).isEqualToIgnoringCase("UTF-8");
   }
 }


### PR DESCRIPTION
Consumers wanting well-behaved endponts should override or add to their `toBody` charset enforcement:

``` java
String charset = Utils.parseCharset(body.mimeType());
if (!"UTF-8".equalsIgnoreCase(charset)) {
  throw new ConversionException("Invalid charset " + charset + ". Must be UTF-8");
}
```

You can also enforce this at the `Client`, if you want.

Closes #163.
