### PR TITLE
Making TestingUtils abstract so that JUnit ignores

### DIFF
--- a/retrofit/src/test/java/retrofit/http/TestingUtils.java
+++ b/retrofit/src/test/java/retrofit/http/TestingUtils.java
@@ -10,7 +10,7 @@ import retrofit.http.mime.TypedOutput;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
-public class TestingUtils {
+public abstract class TestingUtils {
   public static Method getMethod(Class c, String name) {
     for (Method method : c.getDeclaredMethods()) {
       if (method.getName().equals(name)) {


### PR DESCRIPTION
initializationError(retrofit.http.TestingUtils)
java.lang.Exception: No runnable methods
