### PR TITLE
Only using getErrorStream() for status >= 400

### DIFF
--- a/retrofit/src/main/java/retrofit/http/client/UrlConnectionClient.java
+++ b/retrofit/src/main/java/retrofit/http/client/UrlConnectionClient.java
@@ -58,10 +58,10 @@ public class UrlConnectionClient implements Client {
     String mimeType = connection.getContentType();
     int length = connection.getContentLength();
     InputStream stream;
-    if (status == 200) {
-      stream = connection.getInputStream();
-    } else {
+    if (status >= 400) {
       stream = connection.getErrorStream();
+    } else {
+      stream = connection.getInputStream();
     }
     TypedInput responseBody = new TypedInputStream(mimeType, length, stream);
     return new Response(status, reason, headers, responseBody);

--- a/retrofit/src/test/java/retrofit/http/client/UrlConnectionClientTest.java
+++ b/retrofit/src/test/java/retrofit/http/client/UrlConnectionClientTest.java
@@ -104,6 +104,24 @@ public class UrlConnectionClientTest {
     assertBytes(ByteStreams.toByteArray(response.getBody().in()), "hello");
   }
 
+  @Test public void createdResponse() throws Exception {
+    DummyHttpUrlConnection connection = new DummyHttpUrlConnection(HOST);
+    connection.setResponseCode(201);
+    connection.setResponseMessage("OK");
+    connection.addResponseHeader("Content-Type", "text/plain");
+    connection.addResponseHeader("foo", "bar");
+    connection.addResponseHeader("kit", "kat");
+    connection.setInputStream(new ByteArrayInputStream("hello".getBytes("UTF-8")));
+    Response response = client.readResponse(connection);
+
+    assertThat(response.getStatus()).isEqualTo(201);
+    assertThat(response.getReason()).isEqualTo("OK");
+    assertThat(response.getHeaders()).hasSize(3) //
+        .containsOnly(new Header("foo", "bar"), new Header("kit", "kat"),
+            new Header("Content-Type", "text/plain"));
+    assertBytes(ByteStreams.toByteArray(response.getBody().in()), "hello");
+  }
+
   @Test public void errorResponse() throws Exception {
     DummyHttpUrlConnection connection = new DummyHttpUrlConnection(HOST);
     connection.setResponseCode(401);


### PR DESCRIPTION
TypedInput in() should only use getErrorStream() when status >= 400 because getErrorStream() returns null unless responseCode >= 400 (see: http://hg.openjdk.java.net/jdk6/jdk6-gate/jdk/file/tip/src/share/classes/sun/net/www/protocol/http/HttpURLConnection.java)
