### PR TITLE
Don't hide cause of RetrofitErrors

### DIFF
--- a/retrofit/src/main/java/retrofit/http/RetrofitError.java
+++ b/retrofit/src/main/java/retrofit/http/RetrofitError.java
@@ -30,16 +30,15 @@ public class RetrofitError extends RuntimeException {
   private final Converter converter;
   private final Type successType;
   private final boolean networkError;
-  private final Throwable exception;
 
   private RetrofitError(String url, Response response, Converter converter, Type successType,
       boolean networkError, Throwable exception) {
+    super(exception);
     this.url = url;
     this.response = response;
     this.converter = converter;
     this.successType = successType;
     this.networkError = networkError;
-    this.exception = exception;
   }
 
   /** The request URL which produced the error. */
@@ -84,10 +83,5 @@ public class RetrofitError extends RuntimeException {
     } catch (ConversionException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  /** The exception which caused this error, if any. */
-  public Throwable getException() {
-    return exception;
   }
 }

--- a/retrofit/src/test/java/retrofit/http/RestAdapterTest.java
+++ b/retrofit/src/test/java/retrofit/http/RestAdapterTest.java
@@ -110,7 +110,7 @@ public class RestAdapterTest {
       fail("RetrofitError expected on malformed response body.");
     } catch (RetrofitError e) {
       assertThat(e.getResponse().getStatus()).isEqualTo(200);
-      assertThat(e.getException()).isInstanceOf(ConversionException.class);
+      assertThat(e.getCause()).isInstanceOf(ConversionException.class);
       assertThat(e.getResponse().getBody()).isEqualTo(new TypedString("{"));
     }
   }
@@ -135,7 +135,7 @@ public class RestAdapterTest {
       example.something();
       fail("RetrofitError expected when client throws exception.");
     } catch (RetrofitError e) {
-      assertThat(e.getException()).isSameAs(exception);
+      assertThat(e.getCause()).isSameAs(exception);
     }
   }
 
@@ -147,7 +147,7 @@ public class RestAdapterTest {
       example.something();
       fail("RetrofitError expected when unexpected exception thrown.");
     } catch (RetrofitError e) {
-      assertThat(e.getException()).isSameAs(exception);
+      assertThat(e.getCause()).isSameAs(exception);
     }
   }
 


### PR DESCRIPTION
I had a problem somewhere deep in my app that took me while to track down because RetrofitError.toString() didn't include the parent stacktrace.

If you're not trying to target an ancient Java, this change will hopefully save other people some pain.
