### PR TITLE
Created a small hook-point for subclasses of ApacheClient

### DIFF
--- a/retrofit/src/main/java/retrofit/http/client/ApacheClient.java
+++ b/retrofit/src/main/java/retrofit/http/client/ApacheClient.java
@@ -42,10 +42,25 @@ public class ApacheClient implements Client {
     prepareRequest(apacheRequest);
 
     // Obtain and prepare the Apache response object.
-    HttpResponse apacheResponse = client.execute(apacheRequest);
+    HttpResponse apacheResponse = execute(apacheRequest);
     prepareResponse(apacheResponse);
 
     return parseResponse(apacheResponse);
+  }
+
+  /**
+  * A clean entry point for subclasses to customize how the request is executed.
+  * @param apacheRequest The HttpRequest object to send.
+  * @return The HttpResponse object.
+  * @throws IOException thrown if there is an I/O issue.
+  */
+  protected HttpResponse execute(HttpUriRequest apacheRequest) throws IOException {
+    return client.execute(apacheRequest);
+  }
+
+  /** Provides access to the HttpClient for subclasses. */
+  public HttpClient getClient() {
+    return client;
   }
 
   /** Callback for additional preparation of the request before execution. */


### PR DESCRIPTION
This patch allows for ApacheClient subclasses to get access to the HttpClient and additionally provide a way to customize the execution of the request.

In my case, I had a need to provide an instance of CookieStore as a part of the http request, but there wasn't a clean way of achieving this without basically rewriting the ApacheClient.

Cheers,
Richard L. Burton III
