### PR TITLE
Add ErrorHandler for customization of RetrofitError behavior

### DIFF
--- a/retrofit/src/main/java/retrofit/ErrorHandler.java
+++ b/retrofit/src/main/java/retrofit/ErrorHandler.java
@@ -1,0 +1,27 @@
+package retrofit;
+
+
+/**
+ * A hook allowing clients to customize error exceptions for synchronous
+ * requests.
+ *
+ * @author Sam Beran sberan@gmail.com
+ */
+public interface ErrorHandler {
+  /**
+   * Return a custom exception to be thrown for this RetrofitError instance.
+   *
+   * If the exception is checked, any returned exceptions must be declared to be
+   * thrown on the interface method.
+   *
+   * @param cause the original RetrofitError exception
+   * @return Throwable an exception which will be thrown from the client interface method
+   */
+  Throwable handleError(RetrofitError cause);
+
+  ErrorHandler DEFAULT = new ErrorHandler() {
+    @Override public Throwable handleError(RetrofitError cause) {
+      return cause;
+    }
+  };
+}

--- a/retrofit/src/test/java/retrofit/ErrorHandlerTest.java
+++ b/retrofit/src/test/java/retrofit/ErrorHandlerTest.java
@@ -1,0 +1,67 @@
+package retrofit;
+
+import org.junit.Before;
+import org.junit.Test;
+import retrofit.client.Client;
+import retrofit.client.Request;
+import retrofit.client.Response;
+import retrofit.http.GET;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ErrorHandlerTest {
+
+  interface ExampleClient {
+    @GET("/") Response throwsCustomException() throws IllegalStateException;
+  }
+
+
+  /* An HTTP client which always returns a 400 response */
+  static class MockInvalidResponseClient implements Client {
+    @Override
+    public Response execute(Request request) throws IOException {
+      return new Response(400, "invalid request", Collections.<retrofit.client.Header>emptyList(), null);
+    }
+  }
+
+  
+  ExampleClient client;
+  ErrorHandler errorHandler;
+
+  @Before
+  public void setup() {
+    errorHandler = mock(ErrorHandler.class);
+
+    client = new RestAdapter.Builder()
+        .setServer("http://example.com")
+        .setClient(new MockInvalidResponseClient())
+        .setErrorHandler(errorHandler)
+        .setExecutors(new Utils.SynchronousExecutor(), new Utils.SynchronousExecutor())
+        .build()
+        .create(ExampleClient.class);
+  }
+
+
+  @Test
+  public void testCustomizedExceptionThrown() throws Throwable {
+    when(errorHandler.handleError(any(RetrofitError.class)))
+        .thenThrow(new IllegalStateException("invalid request"));
+
+    try {
+      client.throwsCustomException();
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage()).isEqualTo("invalid request");
+    }
+  }
+
+}


### PR DESCRIPTION
Add a new interface, ErrorHandler, which is responsible for throwing customized exceptions during synchronous request errors, or directing to the appropriate callback method for asynchronous request errors.

Currently, API users must catch `RetrofitError` and try to determine the cause of the error based on certain properties of the HTTP response. This interface allows API clients to expose semantic exceptions to their users.

For example, if I had an API interface method to create a `User`, I might expose an `InvalidUserException` which could be declared on the `createUser` method, and used to indicate that something was invalid about the request.

This implementation allows exceptions to be checked or unchecked, leaving that decision up to the API designer. It also doesn't change any existing behavior. Let me know if there's anything I can do to clean it up!
