### PR TITLE
Abstract logging API.

### DIFF
--- a/retrofit/src/main/java/retrofit/http/Platform.java
+++ b/retrofit/src/main/java/retrofit/http/Platform.java
@@ -2,6 +2,7 @@ package retrofit.http;
 
 import android.os.Build;
 import android.os.Process;
+import android.util.Log;
 import com.google.gson.Gson;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -39,6 +40,7 @@ abstract class Platform {
   abstract Client.Provider defaultClient();
   abstract Executor defaultHttpExecutor();
   abstract Executor defaultCallbackExecutor();
+  abstract RestAdapter.Log defaultLog();
 
   /** Provides sane defaults for operation on the JVM. */
   private static class Base extends Platform {
@@ -68,6 +70,14 @@ abstract class Platform {
 
     @Override Executor defaultCallbackExecutor() {
       return new SynchronousExecutor();
+    }
+
+    @Override RestAdapter.Log defaultLog() {
+      return new RestAdapter.Log() {
+        @Override public void log(String message) {
+          System.out.println(message);
+        }
+      };
     }
   }
 
@@ -104,6 +114,14 @@ abstract class Platform {
 
     @Override Executor defaultCallbackExecutor() {
       return new MainThreadExecutor();
+    }
+
+    @Override RestAdapter.Log defaultLog() {
+      return new RestAdapter.Log() {
+        @Override public void log(String message) {
+          Log.d("Retrofit", message);
+        }
+      };
     }
   }
 }


### PR DESCRIPTION
This also fixes a race condition in the RestHandler's dealing with the response of `server.getUrl()`. Theoretically the response of that invocation could change between creating the request and assembling the profiler information. Cache the result in a local variable and re-use.

Closes #142.
