### PR TITLE
Issues with new multi-part implementation

### DIFF
--- a/retrofit/src/main/java/retrofit/http/GsonConverter.java
+++ b/retrofit/src/main/java/retrofit/http/GsonConverter.java
@@ -58,6 +58,10 @@ public class GsonConverter implements Converter {
       this.jsonBytes = jsonBytes;
     }
 
+    @Override public String fileName() {
+      return null;
+    }
+
     @Override public String mimeType() {
       return "application/json; charset=UTF-8";
     }

--- a/retrofit/src/main/java/retrofit/http/mime/TypedByteArray.java
+++ b/retrofit/src/main/java/retrofit/http/mime/TypedByteArray.java
@@ -36,6 +36,10 @@ public class TypedByteArray implements TypedInput, TypedOutput {
     return bytes;
   }
 
+  @Override public String fileName() {
+    return null;
+  }
+
   @Override public String mimeType() {
     return mimeType;
   }

--- a/retrofit/src/main/java/retrofit/http/mime/TypedFile.java
+++ b/retrofit/src/main/java/retrofit/http/mime/TypedFile.java
@@ -47,6 +47,10 @@ public class TypedFile implements TypedInput, TypedOutput {
     return file.length();
   }
 
+  @Override public String fileName() {
+    return file.getName();
+  }
+
   @Override public InputStream in() throws IOException {
     return new FileInputStream(file);
   }

--- a/retrofit/src/main/java/retrofit/http/mime/TypedOutput.java
+++ b/retrofit/src/main/java/retrofit/http/mime/TypedOutput.java
@@ -10,6 +10,10 @@ import java.io.OutputStream;
  * @author Bob Lee (bob@squareup.com)
  */
 public interface TypedOutput {
+  /** Original filename.
+   *
+   * Used only for multipart requests, may be null. */
+  String fileName();
 
   /** Returns the mime type. */
   String mimeType();

--- a/retrofit/src/test/java/retrofit/http/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/http/RequestBuilderTest.java
@@ -224,15 +224,13 @@ public class RequestBuilderTest {
     MultipartTypedOutput body = (MultipartTypedOutput) request.getBody();
     assertThat(body.parts).hasSize(2);
 
-    Iterator<Map.Entry<String, TypedOutput>> iterator = body.parts.entrySet().iterator();
+    Iterator<byte[]> iterator = body.parts.iterator();
 
-    Map.Entry<String, TypedOutput> one = iterator.next();
-    assertThat(one.getKey()).isEqualTo("ping");
-    assertTypedBytes(one.getValue(), "pong");
+    String one = new String(iterator.next(), "UTF-8");
+    assertThat(one).contains("ping").contains("pong");
 
-    Map.Entry<String, TypedOutput> two = iterator.next();
-    assertThat(two.getKey()).isEqualTo("kit");
-    assertTypedBytes(two.getValue(), "kat");
+    String two = new String(iterator.next(), "UTF-8");
+    assertThat(two).contains("kit").contains("kat");
   }
 
   @Test public void simpleHeaders() throws Exception {

--- a/retrofit/src/test/java/retrofit/http/client/UrlConnectionClientTest.java
+++ b/retrofit/src/test/java/retrofit/http/client/UrlConnectionClientTest.java
@@ -64,11 +64,14 @@ public class UrlConnectionClientTest {
     DummyHttpUrlConnection connection = (DummyHttpUrlConnection) client.openConnection(request);
     client.prepareRequest(connection, request);
 
+    byte[] output = connection.getOutputStream().toByteArray();
+
     assertThat(connection.getRequestMethod()).isEqualTo("POST");
     assertThat(connection.getURL().toString()).isEqualTo(HOST + "/that/");
-    assertThat(connection.getRequestProperties()).hasSize(1);
+    assertThat(connection.getRequestProperties()).hasSize(2);
     assertThat(connection.getRequestProperty("Content-Type")).startsWith("multipart/form-data;");
-    assertThat(connection.getOutputStream().toByteArray().length).isGreaterThan(0);
+    assertThat(connection.getRequestProperty("Content-Length")).isEqualTo(String.valueOf(output.length));
+    assertThat(output.length).isGreaterThan(0);
   }
 
   @Test public void headers() throws Exception {


### PR DESCRIPTION
I ran into two issues with the new multi-part implementation, both of which broke compatibility with an API I'm integrating with:
- **Content-Length is not sent.** I was getting a `411 Length Required` error. The attached patch works but isn't great because it requires writing out the content twice.
- **Can't set filename parameter for non-TypedFile parts** The server uses "carrierwave", which was blowing up without a filename. I created an interface that can be implemented along with TypedOutput. For example:
  
  ``` java
  private static class NamedTypedByteArray extends TypedByteArray implements NamedOutput {
      private final String mFileName;
  
      public NamedTypedByteArray(String fileName, String mimeType, byte[] bytes) {
          super(mimeType, bytes);
          mFileName = fileName;
      }
  
      @Override
      public String fileName() {
          return mFileName;
      }
  }
  ```

Let me know what you think.
