### PR TITLE
Eagerly consume a stream when exposing to caller.

### DIFF
--- a/retrofit/src/main/java/retrofit/http/Converter.java
+++ b/retrofit/src/main/java/retrofit/http/Converter.java
@@ -17,8 +17,10 @@ public interface Converter {
    * @param body HTTP response body.
    * @param type Target object type.
    * @return Instance of {@code type} which will be cast by the caller.
-   * @throws ConversionException If conversion was unable to complete. This will trigger a call to
-   * {@link Callback#failure(RetrofitError)} or throw a {@link retrofit.http.RetrofitError}.
+   * @throws ConversionException if conversion was unable to complete. This will trigger a call to
+   * {@link Callback#failure(RetrofitError)} or throw a {@link retrofit.http.RetrofitError}. The
+   * exception message should report all necessary information about its cause as the response body
+   * will be set to {@code null}.
    */
   Object fromBody(TypedInput body, Type type) throws ConversionException;
 

--- a/retrofit/src/main/java/retrofit/http/Utils.java
+++ b/retrofit/src/main/java/retrofit/http/Utils.java
@@ -8,6 +8,9 @@ import java.io.InputStream;
 import java.util.concurrent.Executor;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import retrofit.http.client.Response;
+import retrofit.http.mime.TypedByteArray;
+import retrofit.http.mime.TypedInput;
 
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
@@ -31,6 +34,27 @@ public final class Utils {
       }
     }
     return baos.toByteArray();
+  }
+
+  /**
+   * Conditionally replace a {@link Response} with an identical copy whose body is backed by a
+   * byte[] rather than an input stream.
+   */
+  static Response readBodyToBytesIfNecessary(Response response) throws IOException {
+    TypedInput body = response.getBody();
+    if (body == null || body instanceof TypedByteArray) {
+      return response;
+    }
+
+    String bodyMime = body.mimeType();
+    byte[] bodyBytes = Utils.streamToBytes(body.in());
+    body = new TypedByteArray(bodyMime, bodyBytes);
+
+    return replaceResponseBody(response, body);
+  }
+
+  static Response replaceResponseBody(Response response, TypedInput body) {
+    return new Response(response.getStatus(), response.getReason(), response.getHeaders(), body);
   }
 
   public static String parseCharset(String mimeType) {

--- a/retrofit/src/test/java/retrofit/http/RestAdapterTest.java
+++ b/retrofit/src/test/java/retrofit/http/RestAdapterTest.java
@@ -111,7 +111,7 @@ public class RestAdapterTest {
     } catch (RetrofitError e) {
       assertThat(e.getResponse().getStatus()).isEqualTo(200);
       assertThat(e.getCause()).isInstanceOf(ConversionException.class);
-      assertThat(e.getResponse().getBody()).isEqualTo(new TypedString("{"));
+      assertThat(e.getResponse().getBody()).isNull();
     }
   }
 


### PR DESCRIPTION
HTTP responses return an input stream wrapped in a TypedInput which we pass to the converter for deserialization as fast as the bytes come in. If we are skipping the converter (non-2xx resposne code) or returning the response directly we eagerly consume the stream to a byte[] for the caller.

If the converter threw an exception while reading the stream then it is nulled out before being handed to the RetrofitError. This prevents partially read streams from being exposed.

Closes #181.
