### PR TITLE
Allow digits in path parameter name

### DIFF
--- a/retrofit/src/main/java/retrofit/http/RestMethodInfo.java
+++ b/retrofit/src/main/java/retrofit/http/RestMethodInfo.java
@@ -15,7 +15,10 @@ import retrofit.http.mime.TypedOutput;
 /** Cached details about an interface method. */
 final class RestMethodInfo {
   static final int NO_SINGLE_ENTITY = -1;
-  private static final Pattern PATH_PARAMETERS = Pattern.compile("\\{([a-z_-]+)\\}");
+
+  // Matches strings containing lowercase characters, digits, underscores, or hyphens that start
+  // with a lowercase character in between '{' and '}'.
+  private static final Pattern PATH_PARAMETERS = Pattern.compile("\\{([a-z][a-z0-9_-]*)\\}");
 
   final Method method;
   final boolean isSynchronous;

--- a/retrofit/src/test/java/retrofit/http/RestMethodInfoTest.java
+++ b/retrofit/src/test/java/retrofit/http/RestMethodInfoTest.java
@@ -31,6 +31,8 @@ public class RestMethodInfoTest {
     expectParams("foo/bar/{taco}/or/{taco}", "taco");
     expectParams("foo/bar/{taco-shell}", "taco-shell");
     expectParams("foo/bar/{taco_shell}", "taco_shell");
+    expectParams("foo/bar/{sha256}", "sha256");
+    expectParams("foo/bar/{1}"); // Invalid parameter, name cannot start with digit.
   }
 
   private static void expectParams(String path, String... expected) {


### PR DESCRIPTION
Modify PATH_PARAMETERS regular expression to allow path parameter names that
are strings containing lowercase characters, digits, underscores, or hyphens
that start with a lowercase character. Closes #199.
