### PR TITLE
add SAXConverter for XML deserialization

### DIFF
--- a/retrofit/src/main/java/retrofit/converter/SAXConverter.java
+++ b/retrofit/src/main/java/retrofit/converter/SAXConverter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit.converter;
+
+import org.xml.sax.ContentHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import retrofit.mime.MimeUtil;
+import retrofit.mime.TypedInput;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+
+/**
+ * A {@link retrofit.converter.Converter} which uses SAX (XML) to deserialize entities.
+ *
+ * @author Adrian Cole (adrianc@netflix.com)
+ */
+public abstract class SAXConverter implements Converter {
+
+  private final SAXParserFactory factory;
+
+  protected SAXConverter() {
+    factory = SAXParserFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setValidating(false);
+  }
+
+  protected SAXConverter(SAXParserFactory factory) {
+    this.factory = factory;
+  }
+
+  @Override
+  public Object fromBody(TypedInput body, Type type) throws ConversionException {
+    String charset = MimeUtil.parseCharset(body.mimeType());
+    Deserializer deserializer = newDeserializer(type);
+    InputStreamReader isr = null;
+    try {
+      XMLReader reader = factory.newSAXParser().getXMLReader();
+      reader.setContentHandler(deserializer);
+      isr = new InputStreamReader(body.in(), charset);
+      InputSource source = new InputSource(isr);
+      source.setEncoding(charset);
+      reader.parse(source);
+      return deserializer.getResult();
+    } catch (IOException e) {
+      throw new ConversionException(e);
+    } catch (ParserConfigurationException e) {
+      throw new ConversionException(e);
+    } catch (SAXException e) {
+      throw new ConversionException(e);
+    } finally {
+      if (isr != null) {
+        try {
+          isr.close();
+        } catch (IOException ignored) {
+        }
+      }
+    }
+  }
+
+  protected abstract Deserializer newDeserializer(Type type);
+
+  public interface Deserializer extends ContentHandler {
+    Object getResult();
+  }
+}

--- a/retrofit/src/test/java/retrofit/converter/SAXConverterTest.java
+++ b/retrofit/src/test/java/retrofit/converter/SAXConverterTest.java
@@ -1,0 +1,80 @@
+// Copyright 2013 Square, Inc.
+package retrofit.converter;
+
+import org.junit.Test;
+import org.xml.sax.helpers.DefaultHandler;
+import retrofit.mime.TypedByteArray;
+import retrofit.mime.TypedOutput;
+
+import java.lang.reflect.Type;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class SAXConverterTest {
+  Converter converter = new TestSAXConverter();
+
+  @Test public void successfulParse() throws Exception {
+    String xml = "<Credentials>\n" +
+        "\t<AccessKeyId>ACCESS</AccessKeyId>\n" +
+        "\t<SecretAccessKey>SECRET</SecretAccessKey>\n" +
+        "</Credentials>";
+
+    TypedByteArray body = new TypedByteArray("UTF-8", xml.getBytes("UTF-8"));
+    SessionCredentials credentials = (SessionCredentials) converter.fromBody(body, SessionCredentials.class);
+    assertThat(credentials.accessKeyId).isEqualTo("ACCESS");
+    assertThat(credentials.secretAccessKey).isEqualTo("SECRET");
+    assertThat(credentials.sessionToken).isNull();
+  }
+
+  @Test(expected = ConversionException.class)
+  public void malformedThrowsConversionException() throws Exception {
+    TypedByteArray body = new TypedByteArray("UTF-8", "</Credentials>".getBytes("UTF-8"));
+    converter.fromBody(body, SessionCredentials.class);
+  }
+
+  static class TestSAXConverter extends SAXConverter {
+    @Override
+    protected Deserializer newDeserializer(Type type) {
+      return new SessionCredentialsHandler();
+    }
+
+    @Override
+    public TypedOutput toBody(Object object) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  static class SessionCredentialsHandler extends DefaultHandler implements SAXConverter.Deserializer {
+
+    private StringBuilder currentText = new StringBuilder();
+    private SessionCredentials credentials = new SessionCredentials();
+
+    @Override
+    public SessionCredentials getResult() {
+      return credentials;
+    }
+
+    @Override
+    public void endElement(String uri, String name, String qName) {
+      if (qName.equals("AccessKeyId")) {
+        credentials.accessKeyId = currentText.toString().trim();
+      } else if (qName.equals("SecretAccessKey")) {
+        credentials.secretAccessKey = currentText.toString().trim();
+      } else if (qName.equals("SessionToken")) {
+        credentials.sessionToken = currentText.toString().trim();
+      }
+      currentText = new StringBuilder();
+    }
+
+    @Override
+    public void characters(char ch[], int start, int length) {
+      currentText.append(ch, start, length);
+    }
+  }
+
+  static class SessionCredentials {
+    String accessKeyId;
+    String secretAccessKey;
+    String sessionToken;
+  }
+}


### PR DESCRIPTION
Per issue #193, this adds support for SAX XML deserialization, supported equally across java and android.  STAX is also supported on android, but I personally use SAX more often.

This PR introduces `SAXConverter.Deserializer`, adding the ability to read the result of a `ContentHandler`.  A Deserializer is created per type, and this is expected to vary with implementations.  Accordingly, `SAXConverter.newDeserializer(Type)` is marked abstract.  

An example implementation could look look like this, though those using Dagger will surely optimize it.

```
  static class STSConverter extends SAXConverter {
    @Override
    protected Deserializer newDeserializer(Type type) {
      if (type == SessionCredentials.class)
        return new SessionCredentialsHandler();
      else if (type == AWSError.class)
        return new AWSErrorHandler();
      throw new UnsupportedOperationException("type not yet supported: " + type);
    }

    @Override
    public TypedOutput toBody(Object object) {
      // serializing to XML can be done many ways including
      // something simple as StringBuilder or String.format
      throw new UnsupportedOperationException();
    }
  }
```
