### PR TITLE
permit use when servers or intermediaries miss Content-Type header

### DIFF
--- a/retrofit/src/main/java/retrofit/converter/GsonConverter.java
+++ b/retrofit/src/main/java/retrofit/converter/GsonConverter.java
@@ -39,7 +39,10 @@ public class GsonConverter implements Converter {
   }
 
   @Override public Object fromBody(TypedInput body, Type type) throws ConversionException {
-    String charset = MimeUtil.parseCharset(body.mimeType());
+    String charset = "UTF-8";
+    if (body.mimeType() != null) {
+      charset = MimeUtil.parseCharset(body.mimeType());
+    }
     InputStreamReader isr = null;
     try {
       isr = new InputStreamReader(body.in(), charset);

--- a/retrofit/src/main/java/retrofit/mime/TypedByteArray.java
+++ b/retrofit/src/main/java/retrofit/mime/TypedByteArray.java
@@ -31,13 +31,13 @@ public class TypedByteArray implements TypedInput, TypedOutput {
   private final byte[] bytes;
 
   /**
-   * Constructs a new typed byte array.
+   * Constructs a new typed byte array.  Sets mimeType to {@code application/unknown} if absent.
    *
-   * @throws NullPointerException if bytes or mimeType is null
+   * @throws NullPointerException if bytes are null
    */
   public TypedByteArray(String mimeType, byte[] bytes) {
     if (mimeType == null) {
-      throw new NullPointerException("mimeType");
+      mimeType = "application/unknown";
     }
     if (bytes == null) {
       throw new NullPointerException("bytes");


### PR DESCRIPTION
fix issue #227: permit use when servers or intermediaries mistakingly miss Content-Type header
