### PR TITLE
Support HTTP 201 Semantics

### DIFF
--- a/retrofit/src/main/java/retrofit/RestMethodInfo.java
+++ b/retrofit/src/main/java/retrofit/RestMethodInfo.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -65,6 +66,7 @@ final class RestMethodInfo {
   RequestType requestType = RequestType.SIMPLE;
   String requestMethod;
   boolean requestHasBody;
+  Integer serverUrlIndex;
   String requestUrl;
   Set<String> requestUrlParamNames;
   String requestQuery;
@@ -381,7 +383,9 @@ final class RestMethodInfo {
         }
       }
 
-      if (!hasRetrofitAnnotation) {
+      if (parameterType == URI.class) {
+        serverUrlIndex = i;
+      } else if (!hasRetrofitAnnotation) {
         throw new IllegalStateException(
             "No annotations found on parameter " + (i + 1) + " of " + method.getName());
       }


### PR DESCRIPTION
[HTTP 201 Created](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) returns the `Location` header of a new resource.  This pull request allows us to receive and use URI data in response to restful services that use 201 semantics.

ex.
```
/**
 * returns id of the new resource created.
 */
@POST("/") URI create();
@GET("/") Thing get(URI id);
```
