### PR TITLE
Allow 'null' parts to remove from request.

### DIFF
--- a/retrofit/src/main/java/retrofit/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilder.java
@@ -167,14 +167,12 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
           }
           break;
         case PART:
-          if (value == null) {
-            throw new IllegalArgumentException(
-                "Multipart part \"" + name + "\" value must not be null.");
-          }
-          if (value instanceof TypedOutput) {
-            multipartBody.addPart(name, (TypedOutput) value);
-          } else {
-            multipartBody.addPart(name, converter.toBody(value));
+          if (value != null) { // Skip null values.
+            if (value instanceof TypedOutput) {
+              multipartBody.addPart(name, (TypedOutput) value);
+            } else {
+              multipartBody.addPart(name, converter.toBody(value));
+            }
           }
           break;
         case BODY:
@@ -207,6 +205,10 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
     StringBuilder queryParams = this.queryParams;
     if (queryParams.length() > 0) {
       url.append(queryParams);
+    }
+
+    if (multipartBody != null && multipartBody.getPartCount() == 0) {
+      throw new IllegalStateException("Multipart requests must contain at least one part.");
     }
 
     return new Request(requestMethod, url.toString(), headers, body);

--- a/retrofit/src/main/java/retrofit/mime/MultipartTypedOutput.java
+++ b/retrofit/src/main/java/retrofit/mime/MultipartTypedOutput.java
@@ -51,6 +51,10 @@ public final class MultipartTypedOutput implements TypedOutput {
     length += part.length;
   }
 
+  public int getPartCount() {
+    return parts.size();
+  }
+
   @Override public String fileName() {
     return null;
   }


### PR DESCRIPTION
This is useful for specifying optional parts in a multipart request without requiring extra logic at the call site.

Closes #250. 
