### PR TITLE
implement Retryer for transient error resolution

### DIFF
--- a/retrofit/src/main/java/retrofit/ErrorHandler.java
+++ b/retrofit/src/main/java/retrofit/ErrorHandler.java
@@ -34,6 +34,8 @@ public interface ErrorHandler {
    *     Response r = cause.getResponse();
    *     if (r != null && r.getStatus() == 401) {
    *       return new UnauthorizedException(cause);
+   *     } else if (r.getStatus() == 500) {
+   *       return new RetryableError(cause);
    *     }
    *     return cause;
    *   }
@@ -42,7 +44,8 @@ public interface ErrorHandler {
    *
    * @param cause the original {@link RetrofitError} exception
    * @return Throwable an exception which will be thrown from the client interface method. Must not
-   *         be {@code null}.
+   *         be {@code null}.  If the exception is retryable, throw an instance of
+   *         {@link RetryableError}.
    */
   Throwable handleError(RetrofitError cause);
 

--- a/retrofit/src/main/java/retrofit/RetryableError.java
+++ b/retrofit/src/main/java/retrofit/RetryableError.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import java.util.Date;
+
+/**
+ * This exception is raised when the {@link retrofit.client.Response} is deemed to be retryable,
+ * typically via an {@link retrofit.ErrorHandler} when the
+ * {@link retrofit.client.Response#getStatus() status} is 503.
+ */
+public class RetryableError extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Date retryAfter;
+
+  public RetryableError(RetrofitError cause) {
+    this(cause, null);
+  }
+
+  /**
+   * @param retryAfter usually corresponds to the {@code Retry-After}
+   *                   header. Can be null.
+   */
+  public RetryableError(RetrofitError cause, Date retryAfter) {
+    super(cause);
+    this.retryAfter = retryAfter;
+  }
+
+  /**
+   * Sometimes corresponds to the {@code Retry-After} header
+   * present in {@code 503} status. Other times parsed from an
+   * application-specific response.  Null if unknown.
+   */
+  public Date retryAfter() {
+    return retryAfter;
+  }
+}

--- a/retrofit/src/main/java/retrofit/Retryer.java
+++ b/retrofit/src/main/java/retrofit/Retryer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Created for each invocation to {@link retrofit.client.Client#execute(retrofit.client.Request)}.
+ * Implementations may keep state to determine if retry operations should
+ * continue or not.
+ */
+public interface Retryer {
+
+  interface Factory {
+    Retryer create();
+  }
+
+  /**
+   * if retry is permitted, return (possibly after sleeping). Otherwise
+   * propagate the exception.
+   */
+  void continueOrPropagate(RetryableError e);
+
+  /**
+   * A {@link Factory} which looks at {@code Retry-After} header, if present.
+   * Otherwise, exponentially backs off.
+   */
+  Factory DEFAULT_FACTORY = new Factory() {
+    @Override public Retryer create() {
+      return new Default();
+    }
+  };
+
+  public static class Default implements Retryer {
+
+    private final int maxAttempts;
+    private final long period;
+    private final long maxPeriod;
+
+    // visible for testing;
+    protected long currentTimeMillis() {
+      return System.currentTimeMillis();
+    }
+
+    int attempt;
+    long sleptForMillis;
+
+    public Default() {
+      this(100, SECONDS.toMillis(1), 5);
+    }
+
+    public Default(long period, long maxPeriod, int maxAttempts) {
+      this.period = period;
+      this.maxPeriod = maxPeriod;
+      this.maxAttempts = maxAttempts;
+      this.attempt = 1;
+    }
+
+    public void continueOrPropagate(RetryableError e) {
+      if (attempt++ >= maxAttempts)
+        throw e;
+
+      long interval;
+      if (e.retryAfter() != null) {
+        interval = e.retryAfter().getTime() - currentTimeMillis();
+        if (interval > maxPeriod)
+          interval = maxPeriod;
+        if (interval < 0)
+          return;
+      } else {
+        interval = nextMaxInterval();
+      }
+      try {
+        Thread.sleep(interval);
+      } catch (InterruptedException ignored) {
+        Thread.currentThread().interrupt();
+      }
+      sleptForMillis += interval;
+    }
+
+    /**
+     * Calculates the time interval to a retry attempt.
+     * <br>
+     * The interval increases exponentially with each attempt, at a rate of
+     * nextInterval *= 1.5 (where 1.5 is the backoff factor), to the maximum
+     * interval.
+     *
+     * @return time in nanoseconds from now until the next attempt.
+     */
+    long nextMaxInterval() {
+      long interval = (long) (period * Math.pow(1.5, attempt - 1));
+      return interval > maxPeriod ? maxPeriod : interval;
+    }
+  }
+}

--- a/retrofit/src/test/java/retrofit/RetryerTest.java
+++ b/retrofit/src/test/java/retrofit/RetryerTest.java
@@ -1,0 +1,121 @@
+// Copyright 2013 Square, Inc.
+package retrofit;
+
+import org.junit.Before;
+import org.junit.Test;
+import retrofit.client.Client;
+import retrofit.client.Header;
+import retrofit.client.Request;
+import retrofit.client.Response;
+import retrofit.http.GET;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Date;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+
+public class RetryerTest {
+
+  interface ExampleClient {
+    @GET("/")
+    Response throwsRetryableException();
+  }
+
+  static class TestException extends Exception {
+  }
+
+  /* An HTTP client which returns a 500 response a couple times. */
+  static class MockServerErrorClient implements Client {
+    int i = 0;
+
+    @Override
+    public Response execute(Request request) throws IOException {
+      if (i++ < 2) {
+        return new Response(500, "temporary error", Collections.<Header>emptyList(), null);
+      }
+      return new Response(200, "OK", Collections.<Header>emptyList(), null);
+    }
+  }
+
+  ExampleClient client;
+  Retryer retryer;
+
+  @Before
+  public void setup() {
+    retryer = mock(Retryer.class);
+
+    client = new RestAdapter.Builder() //
+        .setServer("http://example.com")
+        .setClient(new MockServerErrorClient())
+        .setErrorHandler(new ErrorHandler() {
+          @Override
+          public Throwable handleError(RetrofitError cause) {
+            Response r = cause.getResponse();
+            if (r.getStatus() == 500) {
+              return new RetryableError(cause);
+            }
+            return cause;
+          }
+        })
+        .setRetryerFactory(new Retryer.Factory() {
+          @Override
+          public Retryer create() {
+            return retryer;
+          }
+        })
+        .setExecutors(new Utils.SynchronousExecutor(), new Utils.SynchronousExecutor())
+        .build()
+        .create(ExampleClient.class);
+  }
+
+  @Test
+  public void retriesTransientFailure() throws Throwable {
+    doNothing().when(retryer).continueOrPropagate(any(RetryableError.class));
+    client.throwsRetryableException();
+  }
+
+  @Test(expected = RetryableError.class)
+  public void only5TriesAllowedAndExponentialBackoff() throws Exception {
+    RetryableError e = new RetryableError(null);
+    Retryer.Default retryer = (Retryer.Default) Retryer.DEFAULT_FACTORY.create();
+
+    assertThat(retryer.attempt).isEqualTo(1);
+    assertThat(retryer.sleptForMillis).isZero();
+
+    retryer.continueOrPropagate(e);
+    assertThat(retryer.attempt).isEqualTo(2);
+    assertThat(retryer.sleptForMillis).isEqualTo(150);
+
+    retryer.continueOrPropagate(e);
+    assertThat(retryer.attempt).isEqualTo(3);
+    assertThat(retryer.sleptForMillis).isEqualTo(375);
+
+    retryer.continueOrPropagate(e);
+    assertThat(retryer.attempt).isEqualTo(4);
+    assertThat(retryer.sleptForMillis).isEqualTo(712);
+
+    retryer.continueOrPropagate(e);
+    assertThat(retryer.attempt).isEqualTo(5);
+    assertThat(retryer.sleptForMillis).isEqualTo(1218);
+
+    retryer.continueOrPropagate(e);
+    // fail
+  }
+
+  @Test
+  public void considersRetryAfterButNotMoreThanMaxPeriod() throws Exception {
+    Retryer.Default retryer = new Retryer.Default() {
+      protected long currentTimeMillis() {
+        return 0;
+      }
+    };
+
+    retryer.continueOrPropagate(new RetryableError(null, new Date(5000)));
+    assertThat(retryer.attempt).isEqualTo(2);
+    assertThat(retryer.sleptForMillis).isEqualTo(1000);
+  }
+}


### PR DESCRIPTION
Allows you to throw a `RetryableError` from your ErrorHandler when a response implies a retry.

Ex.

```
new ErrorHandler() {
  @Override public Throwable handleError(RetrofitError cause) {
    Response r = cause.getResponse();
      if (r.getStatus() == 500) {
        return new RetryableError(cause);
      }
      return cause;
    }
};
```

Default `Retryer` exponentially backs off up to 5 times, unless the `retryAfter` field is set in the `RetryableError`.
