### PR TITLE
Better handling of Collection as Query Parameter

### DIFF
--- a/retrofit/src/main/java/retrofit/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilder.java
@@ -18,6 +18,7 @@ package retrofit;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import retrofit.client.Header;
 import retrofit.client.Request;
@@ -154,7 +155,15 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
           break;
         case QUERY:
           if (value != null) { // Skip null values.
-            addQueryParam(name, value.toString());
+              // Each item should have its own key-value pair on URL
+              if (value instanceof Collection) {
+                  Collection<?> casted = (Collection<?>) value;
+
+                  for (Object currObj : casted)
+                      if (currObj != null)
+                          addQueryParam(name, currObj.toString());
+              } else
+                  addQueryParam(name, value.toString());
           }
           break;
         case HEADER:


### PR DESCRIPTION
Originally just called toString, now adds each item of a Collection as
separate key-value pairs when a URL query param.
