### PR TITLE
Improved handling of Iterable as Query Parameter

### DIFF
--- a/retrofit/src/main/java/retrofit/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilder.java
@@ -192,7 +192,7 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
               Iterable<?> casted = (Iterable<?>) value;
 
               for (Object currObj : casted) {
-                if (currObj != null) {
+                if (currObj != null) { // Skip inner null values as well
                   addQueryParam(name, currObj.toString());
                 }
               }

--- a/retrofit/src/main/java/retrofit/http/Query.java
+++ b/retrofit/src/main/java/retrofit/http/Query.java
@@ -24,14 +24,16 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Query parameter appended to the URL. Values are converted to strings using
- * {@link String#valueOf(Object)}. Parameter values will be URL encoded.
+ * {@link Object#toString()}. If the Object implements Iterable, each element
+ * will be appended to the URL as a key-value pair.
  * <p>
  * <pre>
  * &#64;GET("/list")
  * void example(@Query("page") int page, ..);
  * </pre>
  * <p>
- * Query parameters may be {@code null} which will omit them from the URL.
+ * Query parameters may be {@code null} which will omit them from the URL. A
+ * {@code null} in an Iterable will also be omitted.
  */
 @Documented
 @Target(PARAMETER)

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -629,7 +629,7 @@ public class RequestBuilderTest {
       return this;
     }
 
-    Helper addQueryParam(String name, String value) {
+    Helper addQueryParam(String name, Object value) {
       paramNames.add(name);
       paramUsages.add(QUERY);
       args.add(value);


### PR DESCRIPTION
Originally just called toString, now adds each item of Iterable as
separate key-value pairs when a URL query param.
