### PR TITLE
Gson customization docs

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -108,7 +108,7 @@ Photo listUsers(@Path("id") int id);</pre>
             <pre class="prettyprint">@GET("/user/{id}/photo")
 void listUsers(@Path("id") int id, Callback&lt;Photo> cb);</pre>
             <p>On Android, the callbacks will be executed on the main thread. For desktop applications the callbacks will happen on the same thread that executed the HTTP request.</p>
-            
+
             <h4>Response Object Type</h4>
             <p>HTTP responses are automatically converted to a specified type using the <code>RestAdapter</code>'s converter which defaults to JSON. The desired type is declared as the method return type or using the <code>Callback</code>.
             <pre class="prettyprint">@GET("/users/list")
@@ -128,12 +128,12 @@ void userList(Callback&lt;Response> cb);</pre>
 
             <h4>Converter</h4>
             <p>The converter is responsible for serializing and deserializing objects in HTTP.
-			<h4>Customizing the Gson Converter</h4>
-            <p>The built-in Gson converter cannot be customized, but a Gson implementation can be provided while building a <code>RestAdapter</code>.</p>
+			<h4>Default Gson Converter</h4>
+            <p>Retrofit will convert HTTP bodies to and from <code>JSON</code> using Gson's default configuration (the built-in Gson converter cannot be customized). If you need a customized Gson converter, an implementation can be provided while building a <code>RestAdapter</code>. The <a href="https://sites.google.com/site/gson/gson-user-guide#TOC-Built-in-Serializers-and-Deserializers">Gson documentation</a> is a great place to start when customizing the implementation.</p>
+            <h4>Custom Gson Converter Example</h4>
             <p>The following code creates a new <code>Gson</code> instance that will convert all fields from <code>LOWER_CASE_WITH_UNDERSCORES</code> to camel case and vice versa. It also registers a type adapter for the <code>Date</code> class. This <code>DateTypeAdapter</code> will be used anytime Gson encounters a <code>Date</code> field.</p>
-            <p><code>.setConverter(new GsonConverter(gson))</code> is then called passing  the Gson object that was created as a parameter.</p>
-            <p>Each call on the generated<code>GithubService</code> will now return objects that are parsed using the Gson implementation that was provided to the <code>RestAdapter</code>.</p>
-            <pre class="prettyprint">Gson gson = new GsonBuilder()
+            <p>The <code>gson</code> instance is passed as a parameter to a new <code>GsonConverter</code> which is used as the converter for RestAdapter.</p>
+             <pre class="prettyprint">Gson gson = new GsonBuilder()
     .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
     .registerTypeAdapter(Date.class, new DateTypeAdapter())
     .create();
@@ -144,7 +144,7 @@ RestAdapter restAdapter = new RestAdapter.Builder()
     .build();
 
 GitHubService service = restAdapter.create(GitHubService.class);</pre>
-
+            <p>Each call on the generated<code>GithubService</code> will now return objects that are converted using the Gson implementation that was provided to the <code>RestAdapter</code>.</p>
             <h3 id="download">Download</h3>
             <p><a href="http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.squareup.retrofit&a=retrofit&v=LATEST" class="dl version-href">&darr; <span class="version-tag">Latest</span> JAR</a></p>
             <p>The source code to the Retrofit, its samples, and this website is <a href="http://github.com/square/retrofit">available on GitHub</a>.</p>


### PR DESCRIPTION
Adds a Gson customization section to the website.

Is there a way to get the built in `Gson` class to customize it? I currently provide it from an external gson jar, so that is how I wrote the documentation. I can change this if there is a way to pull it from Retrofit.

I'm not sure how detailed we want these docs to be. I figured this would be a great starting point, without adding a ton of details about adding gson to your app's libs.

This should fulfill the requirements for the first item on the Cookbook list square/retrofit#256
