### PR TITLE
Suggestion for revamp of RetrofitError

### DIFF
--- a/retrofit/src/main/java/retrofit/RetrofitConversionError.java
+++ b/retrofit/src/main/java/retrofit/RetrofitConversionError.java
@@ -1,0 +1,13 @@
+package retrofit;
+
+import retrofit.client.Response;
+import retrofit.converter.Converter;
+
+import java.lang.reflect.Type;
+
+public class RetrofitConversionError extends RetrofitResponseError {
+  protected RetrofitConversionError(String url, Response response, Converter converter,
+                                    Type successType, Throwable exception) {
+    super(url, response, converter, successType, exception);
+  }
+}

--- a/retrofit/src/main/java/retrofit/RetrofitHttpError.java
+++ b/retrofit/src/main/java/retrofit/RetrofitHttpError.java
@@ -1,0 +1,13 @@
+package retrofit;
+
+import retrofit.client.Response;
+import retrofit.converter.Converter;
+
+import java.lang.reflect.Type;
+
+public class RetrofitHttpError extends RetrofitResponseError {
+  protected RetrofitHttpError(String url, Response response, Converter converter,
+                              Type successType) {
+    super(url, response, converter, successType);
+  }
+}

--- a/retrofit/src/main/java/retrofit/RetrofitNetworkError.java
+++ b/retrofit/src/main/java/retrofit/RetrofitNetworkError.java
@@ -1,0 +1,36 @@
+package retrofit;
+
+import retrofit.client.Response;
+
+import java.lang.reflect.Type;
+
+public class RetrofitNetworkError extends RetrofitError {
+
+  protected RetrofitNetworkError(String url, Throwable exception) {
+    super("Request to " + url + " failed.", url, exception);
+  }
+
+  @Override
+  @Deprecated
+  public Response getResponse() {
+    return null;
+  }
+
+  @Override
+  @Deprecated
+  public boolean isNetworkError() {
+    return true;
+  }
+
+  @Override
+  @Deprecated
+  public Object getBody() {
+    return null;
+  }
+
+  @Override
+  @Deprecated
+  public Object getBodyAs(Type type) {
+    return null;
+  }
+}

--- a/retrofit/src/main/java/retrofit/RetrofitResponseError.java
+++ b/retrofit/src/main/java/retrofit/RetrofitResponseError.java
@@ -1,0 +1,90 @@
+package retrofit;
+
+import retrofit.client.Response;
+import retrofit.converter.ConversionException;
+import retrofit.converter.Converter;
+import retrofit.mime.TypedInput;
+
+import java.lang.reflect.Type;
+
+public abstract class RetrofitResponseError extends RetrofitError {
+
+  protected Response response;
+  protected Converter converter;
+  protected Type successType;
+
+  protected RetrofitResponseError(String url, Response response, Converter converter,
+                                  Type successType, Throwable exception) {
+    super("Request to " + url + " failed; response code is "
+        + ((response == null) ? "unknown" : response.getStatus() + " " + response.getReason())
+        + ".", url, exception);
+    this.response = response;
+    this.converter = converter;
+    this.successType = successType;
+  }
+
+  protected RetrofitResponseError(String url, Response response, Converter converter,
+                                  Type successType) {
+    super("Request to " + url + " failed; response code is "
+        + ((response == null) ? "unknown" : response.getStatus() + " " + response.getReason())
+        + ".", url);
+    this.response = response;
+    this.converter = converter;
+    this.successType = successType;
+  }
+
+  @Override
+  @Deprecated
+  public boolean isNetworkError() {
+    return false;
+  }
+
+  @Override
+  public Response getResponse() {
+    return response;
+  }
+
+  @Override
+  public Object getBody() {
+    if (response == null) {
+      return null;
+    }
+
+    TypedInput body = response.getBody();
+    if (body == null) {
+      return null;
+    }
+
+    if (converter == null) {
+      throw new RuntimeException("Cannot convert body, supplied converter is null.");
+    }
+
+    try {
+      return converter.fromBody(body, successType);
+    } catch (ConversionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Object getBodyAs(Type type) {
+    if (response == null) {
+      return null;
+    }
+
+    TypedInput body = response.getBody();
+    if (body == null) {
+      return null;
+    }
+
+    if (converter == null) {
+      throw new RuntimeException("Cannot convert body, supplied converter is null.");
+    }
+
+    try {
+      return converter.fromBody(body, type);
+    } catch (ConversionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/retrofit/src/main/java/retrofit/UnexpectedRetrofitError.java
+++ b/retrofit/src/main/java/retrofit/UnexpectedRetrofitError.java
@@ -1,0 +1,35 @@
+package retrofit;
+
+import retrofit.client.Response;
+
+import java.lang.reflect.Type;
+
+public class UnexpectedRetrofitError extends RetrofitError {
+  protected UnexpectedRetrofitError(String url, Throwable exception) {
+    super("Request to " + url + " failed.", url, exception);
+  }
+
+  @Override
+  @Deprecated
+  public Response getResponse() {
+    return null;
+  }
+
+  @Override
+  @Deprecated
+  public boolean isNetworkError() {
+    return false;
+  }
+
+  @Override
+  @Deprecated
+  public Object getBody() {
+    return null;
+  }
+
+  @Override
+  @Deprecated
+  public Object getBodyAs(Type type) {
+    return null;
+  }
+}


### PR DESCRIPTION
After having troubles finding the reason for a `RetrofitError`, I reworked `RetrofitError` and its API for myself. Might be of interest regarding #284. Summary:
- Hierarchy of errors added (like `RetrofitHttpError` and so on), so it's always clear what type of error it is.
- More or less meaningful message to every `RetrofitError` added (like "Request to http://example.org failed; response  code is 406 Bad Request.").
- Unneeded methods deprecated (it does not make sense to have a `getBody()` in case of a network error).

Although the change is quiet big, it should conform to the old API (I wrote the tests against the old API) and not break any existing code.
