### PR TITLE
Move OkHttp connect/read timeouts to OkHttpClient.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <android.version>4.1.1.4</android.version>
     <android.platform>16</android.platform>
     <gson.version>2.2.4</gson.version>
-    <okhttp.version>1.1.1</okhttp.version>
+    <okhttp.version>1.2.1</okhttp.version>
 
     <!-- Converter Dependencies -->
     <protobuf.version>2.5.0</protobuf.version>

--- a/retrofit/src/main/java/retrofit/client/ApacheClient.java
+++ b/retrofit/src/main/java/retrofit/client/ApacheClient.java
@@ -43,8 +43,8 @@ import retrofit.mime.TypedOutput;
 public class ApacheClient implements Client {
   private static HttpClient createDefaultClient() {
     HttpParams params = new BasicHttpParams();
-    HttpConnectionParams.setConnectionTimeout(params, Defaults.CONNECT_TIMEOUT);
-    HttpConnectionParams.setSoTimeout(params, Defaults.READ_TIMEOUT);
+    HttpConnectionParams.setConnectionTimeout(params, Defaults.CONNECT_TIMEOUT_MILLIS);
+    HttpConnectionParams.setSoTimeout(params, Defaults.READ_TIMEOUT_MILLIS);
     return new DefaultHttpClient(params);
   }
 

--- a/retrofit/src/main/java/retrofit/client/Defaults.java
+++ b/retrofit/src/main/java/retrofit/client/Defaults.java
@@ -1,6 +1,6 @@
 package retrofit.client;
 
 class Defaults {
-  static final int CONNECT_TIMEOUT = 15 * 1000; // 15s
-  static final int READ_TIMEOUT = 20 * 1000; // 20s
+  static final int CONNECT_TIMEOUT_MILLIS = 15 * 1000; // 15s
+  static final int READ_TIMEOUT_MILLIS = 20 * 1000; // 20s
 }

--- a/retrofit/src/main/java/retrofit/client/OkClient.java
+++ b/retrofit/src/main/java/retrofit/client/OkClient.java
@@ -19,13 +19,14 @@ import com.squareup.okhttp.OkHttpClient;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 
 /** Retrofit client that uses OkHttp for communication. */
 public class OkClient extends UrlConnectionClient {
   private final OkHttpClient client;
 
   public OkClient() {
-    this(new OkHttpClient());
+    this(generateDefaultOkHttp());
   }
 
   public OkClient(OkHttpClient client) {
@@ -33,9 +34,13 @@ public class OkClient extends UrlConnectionClient {
   }
 
   @Override protected HttpURLConnection openConnection(Request request) throws IOException {
-    HttpURLConnection connection = client.open(new URL(request.getUrl()));
-    connection.setConnectTimeout(Defaults.CONNECT_TIMEOUT);
-    connection.setReadTimeout(Defaults.READ_TIMEOUT);
-    return connection;
+    return client.open(new URL(request.getUrl()));
+  }
+
+  private static OkHttpClient generateDefaultOkHttp() {
+    OkHttpClient okHttp = new OkHttpClient();
+    okHttp.setConnectTimeout(Defaults.CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+    okHttp.setReadTimeout(Defaults.READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+    return okHttp;
   }
 }

--- a/retrofit/src/main/java/retrofit/client/UrlConnectionClient.java
+++ b/retrofit/src/main/java/retrofit/client/UrlConnectionClient.java
@@ -51,8 +51,8 @@ public class UrlConnectionClient implements Client {
   protected HttpURLConnection openConnection(Request request) throws IOException {
     HttpURLConnection connection =
         (HttpURLConnection) new URL(request.getUrl()).openConnection();
-    connection.setConnectTimeout(Defaults.CONNECT_TIMEOUT);
-    connection.setReadTimeout(Defaults.READ_TIMEOUT);
+    connection.setConnectTimeout(Defaults.CONNECT_TIMEOUT_MILLIS);
+    connection.setReadTimeout(Defaults.READ_TIMEOUT_MILLIS);
     return connection;
   }
 


### PR DESCRIPTION
This allows suppliers of custom OkHttpClient instances to configure their own timeouts which are actually honored.

Closes #321.
