### PR TITLE
Close the InputStream before replacing the body

### DIFF
--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -425,7 +425,7 @@ public class RestAdapter {
           }
 
           if (!(body instanceof TypedByteArray)) {
-            // Read the entire response body to we can log it and replace the original response
+            // Read the entire response body so we can log it and replace the original response
             response = Utils.readBodyToBytesIfNecessary(response);
             body = response.getBody();
           }

--- a/retrofit/src/main/java/retrofit/Utils.java
+++ b/retrofit/src/main/java/retrofit/Utils.java
@@ -76,7 +76,9 @@ final class Utils {
     }
 
     String bodyMime = body.mimeType();
-    byte[] bodyBytes = Utils.streamToBytes(body.in());
+    InputStream is = body.in();
+    byte[] bodyBytes = Utils.streamToBytes(is);
+    is.close();
     body = new TypedByteArray(bodyMime, bodyBytes);
 
     return replaceResponseBody(response, body);


### PR DESCRIPTION
This fixes a bug where the InputStream would not always get closed when full
logging is enabled.
