### PR TITLE
Promote Android logging to a class which knows about chunking.

### DIFF
--- a/retrofit/src/main/java/retrofit/Platform.java
+++ b/retrofit/src/main/java/retrofit/Platform.java
@@ -17,12 +17,12 @@ package retrofit;
 
 import android.os.Build;
 import android.os.Process;
-import android.util.Log;
 import com.google.gson.Gson;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import retrofit.android.AndroidApacheClient;
+import retrofit.android.AndroidLog;
 import retrofit.android.MainThreadExecutor;
 import retrofit.client.Client;
 import retrofit.client.OkClient;
@@ -143,11 +143,7 @@ abstract class Platform {
     }
 
     @Override RestAdapter.Log defaultLog() {
-      return new RestAdapter.Log() {
-        @Override public void log(String message) {
-          Log.d("Retrofit", message);
-        }
-      };
+      return new AndroidLog("Retrofit");
     }
   }
 

--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -107,7 +107,6 @@ import retrofit.mime.TypedOutput;
  * @author Jake Wharton (jw@squareup.com)
  */
 public class RestAdapter {
-  private static final int LOG_CHUNK_SIZE = 4000;
   static final String THREAD_PREFIX = "Retrofit-";
   static final String IDLE_THREAD_NAME = THREAD_PREFIX + "Idle";
 
@@ -396,11 +395,7 @@ public class RestAdapter {
           byte[] bodyBytes = ((TypedByteArray) body).getBytes();
           bodySize = bodyBytes.length;
           String bodyCharset = MimeUtil.parseCharset(bodyMime);
-          String bodyString = new String(bodyBytes, bodyCharset);
-          for (int i = 0, len = bodyString.length(); i < len; i += LOG_CHUNK_SIZE) {
-            int end = Math.min(len, i + LOG_CHUNK_SIZE);
-            log.log(bodyString.substring(i, end));
-          }
+          log.log(new String(bodyBytes, bodyCharset));
         }
       }
 
@@ -440,11 +435,7 @@ public class RestAdapter {
           bodySize = bodyBytes.length;
           String bodyMime = body.mimeType();
           String bodyCharset = MimeUtil.parseCharset(bodyMime);
-          String bodyString = new String(bodyBytes, bodyCharset);
-          for (int i = 0, len = bodyString.length(); i < len; i += LOG_CHUNK_SIZE) {
-            int end = Math.min(len, i + LOG_CHUNK_SIZE);
-            log.log(bodyString.substring(i, end));
-          }
+          log.log(new String(bodyBytes, bodyCharset));
         }
       }
 

--- a/retrofit/src/main/java/retrofit/android/AndroidLog.java
+++ b/retrofit/src/main/java/retrofit/android/AndroidLog.java
@@ -1,0 +1,22 @@
+package retrofit.android;
+
+import android.util.Log;
+import retrofit.RestAdapter;
+
+/** A {@link RestAdapter.Log logger} for Android. */
+public class AndroidLog implements RestAdapter.Log {
+  private static final int LOG_CHUNK_SIZE = 4000;
+
+  private final String tag;
+
+  public AndroidLog(String tag) {
+    this.tag = tag;
+  }
+
+  @Override public void log(String message) {
+    for (int i = 0, len = message.length(); i < len; i += LOG_CHUNK_SIZE) {
+      int end = Math.min(len, i + LOG_CHUNK_SIZE);
+      Log.d(tag, message.substring(i, end));
+    }
+  }
+}


### PR DESCRIPTION
Remove the concept of chunking from calling code. This is an Android-specific implementation detail which is now only performed when needed.
