### PR TITLE
Support Functional Interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 1.2.3
+----------------------------
+
+ * Ease integration with functional libraries by allowing single-method interface inheritance.
+
 Version 1.2.2 *(2013-09-12)*
 ----------------------------
 

--- a/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
+++ b/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
@@ -210,15 +210,18 @@ public final class MockRestAdapter {
   public <T> T create(Class<T> service, T mockService) {
     Utils.validateServiceClass(service);
     return (T) Proxy.newProxyInstance(service.getClassLoader(), new Class<?>[] { service },
-        new MockHandler(mockService, restAdapter.getMethodInfoCache(service)));
+        new MockHandler(mockService, service, restAdapter.getMethodInfoCache(service)));
   }
 
   private class MockHandler implements InvocationHandler {
     private final Object mockService;
+    private final Class<?> service;
     private final Map<Method, RestMethodInfo> methodInfoCache;
 
-    public MockHandler(Object mockService, Map<Method, RestMethodInfo> methodInfoCache) {
+    public MockHandler(Object mockService, Class<?> service,
+        Map<Method, RestMethodInfo> methodInfoCache) {
       this.mockService = mockService;
+      this.service = service;
       this.methodInfoCache = methodInfoCache;
     }
 
@@ -230,7 +233,7 @@ public final class MockRestAdapter {
       }
 
       // Load or create the details cache for the current method.
-      final RestMethodInfo methodInfo = RestAdapter.getMethodInfo(methodInfoCache, method);
+      final RestMethodInfo methodInfo = RestAdapter.getMethodInfo(methodInfoCache, service, method);
 
       if (methodInfo.isSynchronous) {
         return invokeSync(methodInfo, restAdapter.requestInterceptor, args);

--- a/retrofit-samples/functional-playground/pom.xml
+++ b/retrofit-samples/functional-playground/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.squareup.retrofit.samples</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.2.3-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>functional-playground</artifactId>
+  <name>Sample: Functional Playground</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup.retrofit</groupId>
+      <artifactId>retrofit</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.netflix.rxjava</groupId>
+      <artifactId>rxjava-core</artifactId>
+      <version>0.14.9</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/retrofit-samples/functional-playground/src/main/java/com/example/retrofit/GuavaGitHub.java
+++ b/retrofit-samples/functional-playground/src/main/java/com/example/retrofit/GuavaGitHub.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.retrofit;
+
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import java.util.Arrays;
+import java.util.List;
+import retrofit.RestAdapter;
+import retrofit.http.GET;
+import retrofit.http.Path;
+
+public class GuavaGitHub {
+  private static final String API_URL = "https://api.github.com";
+
+  static class Contributor {
+    String login;
+    int contributions;
+  }
+
+  interface GitHub extends Function<String, List<Contributor>> {
+
+    @Override @GET("/repos/square/{repo}/contributors")
+    List<Contributor> apply(@Path("repo") String repo);
+  }
+
+  public static void main(String... args) {
+    // Create a very simple REST adapter which points the GitHub API endpoint.
+    RestAdapter restAdapter = new RestAdapter.Builder().setServer(API_URL).build();
+
+    // Create an instance of our GitHub API interface.
+    GitHub github = restAdapter.create(GitHub.class);
+
+    // Use github as a transformation step
+    List<Contributor> contributors = FluentIterable.from(Arrays.asList("okhttp", "retrofit")) //
+        .transformAndConcat(github) //
+        .toList();
+
+    for (Contributor contributor : contributors) {
+      System.out.println(contributor.login + " (" + contributor.contributions + ")");
+    }
+  }
+}

--- a/retrofit-samples/functional-playground/src/main/java/com/example/retrofit/RxGitHub.java
+++ b/retrofit-samples/functional-playground/src/main/java/com/example/retrofit/RxGitHub.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.retrofit;
+
+import java.util.List;
+import retrofit.RestAdapter;
+import retrofit.http.GET;
+import retrofit.http.Path;
+import rx.Observable;
+import rx.Observer;
+import rx.util.functions.Func1;
+
+public class RxGitHub {
+  private static final String API_URL = "https://api.github.com";
+
+  static class Contributor {
+    String login;
+    int contributions;
+  }
+
+  interface GitHub extends Func1<String, List<Contributor>> {
+
+    @Override @GET("/repos/square/{repo}/contributors")
+    List<Contributor> call(@Path("repo") String repo);
+  }
+
+  public static void main(String... args) {
+    // Create a very simple REST adapter which points the GitHub API endpoint.
+    RestAdapter restAdapter = new RestAdapter.Builder().setServer(API_URL).build();
+
+    // Create an instance of our GitHub API interface.
+    GitHub github = restAdapter.create(GitHub.class);
+
+    // Use github as a mapping step
+    Observable.from("okhttp", "retrofit") //
+        .map(github) //
+        .flatMap(new Func1<List<Contributor>, Observable<Contributor>>() {
+          @Override public Observable<Contributor> call(List<Contributor> contributors) {
+            return Observable.from(contributors);
+          }
+        })//
+        .subscribe(new Observer<Contributor>() {
+          @Override public void onCompleted() {
+          }
+
+          @Override public void onError(Throwable e) {
+            e.printStackTrace();
+          }
+
+          @Override public void onNext(Contributor contributor) {
+            System.out.println(contributor.login + " (" + contributor.contributions + ")");
+          }
+        });
+  }
+}

--- a/retrofit-samples/pom.xml
+++ b/retrofit-samples/pom.xml
@@ -17,5 +17,6 @@
 
   <modules>
     <module>github-client</module>
+    <module>functional-playground</module>
   </modules>
 </project>

--- a/retrofit/src/main/java/retrofit/Utils.java
+++ b/retrofit/src/main/java/retrofit/Utils.java
@@ -19,6 +19,7 @@ package retrofit;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.util.concurrent.Executor;
 import retrofit.client.Request;
 import retrofit.client.Response;
@@ -90,6 +91,31 @@ final class Utils {
         }
       }
     }
+  }
+
+  /**
+   * true if the interface is a functional interface, having exactly one
+   * abstract method.  Note methods from {@link Object} are not abstract!
+   */
+  static boolean isFunctionalInterface(Class<?> declaring) {
+    boolean found = false;
+    for (Method method : declaring.getDeclaredMethods()) {
+      if (found) return false;
+      if (matchesSignatureOfObjectMethod(method)) continue;
+      found = true;
+    }
+    return found;
+  }
+
+  private static boolean matchesSignatureOfObjectMethod(Method method) {
+    if (method.getParameterTypes().length == 0) {
+      if ("hashCode".equals(method.getName()) || "toString".equals(method.getName())) return true;
+    }
+    if (method.getParameterTypes().length == 1 && "equals".equals(method.getName()) //
+        && Object.class.equals(method.getParameterTypes()[0])) {
+      return true;
+    }
+    return false;
   }
 
   static Response replaceResponseBody(Response response, TypedInput body) {

--- a/retrofit/src/test/java/retrofit/UtilsTest.java
+++ b/retrofit/src/test/java/retrofit/UtilsTest.java
@@ -1,0 +1,28 @@
+// Copyright 2013 Square, Inc.
+package retrofit;
+
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import java.io.Serializable;
+import org.junit.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class UtilsTest {
+
+  @Test public void markerInterfaceIsNotFunctional() {
+    assertThat(Utils.isFunctionalInterface(Serializable.class)).isFalse();
+  }
+
+  @Test public void singleMethodInterfaceIsFunctional() {
+    assertThat(Utils.isFunctionalInterface(Supplier.class)).isTrue();
+  }
+
+  @Test public void interfaceOverridingObjectMethodIsStillFunctional() {
+    assertThat(Utils.isFunctionalInterface(Function.class)).isTrue();
+  }
+
+  @Test public void multiMethodInterfaceIsNotFunctional() {
+    assertThat(Utils.isFunctionalInterface(Callback.class)).isFalse();
+  }
+}


### PR DESCRIPTION
Currently, integrating a Retrofit adapter into a functional library like RxJava means hard coding something like this:

``` java
interface GitHub {

  @GET("/repos/square/{repo}/contributors")
  List<Contributor> contributors(@Path("repo") String repo);
}

// write an interface that invokes contributors on subscribe
class ContributorsFunc implements Func1<String, List<Contributor>> {
  private final GitHub api;
  private final String repo;

  public ContributorsFunc(GitHub api, String repo) {
    this.api = api;
    this.repo = repo;
  }

  @Override public List<Contributor> call(String repo) {
    return api.contributors(repo);
  }
}

--snip--
// create a retrofit adapter normally
github = restAdapter.create(GitHub.class);

// map the callers
observable = Observable.from("okhttp", "retrofit").map(new ContributorsFunc(github));
```

This works, but it involves a lot of boilerplate coding to create the `Func1` impl.  An alternate would be to allow Retrofit interfaces to extend a functional interface.

Ex.

``` java

// extend a functional interface
interface ContributorsFunc extends Func1<String, List<Contributor>> {

  @Override @GET("/repos/square/{repo}/contributors")
  List<Contributor> call(@Path("repo") String repo);
}

--snip--
// create a retrofit adapter normally
contributors = restAdapter.create(ContributorsFunc.class);

// map the callers
observable = Observable.from("okhttp", "retrofit").map(contributors);
```

Extending a functional interface cleanly integrates patterns similar to RxJava, too.  For example [Java 8](http://download.java.net/jdk8/docs/api/java/util/function/package-summary.html), [guava](http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/base/Function.html) and [reactor](https://github.com/reactor/reactor/blob/master/reactor-core/src/main/java/reactor/function/Function.java) all use functional interfaces.
### Pros
- No boiler-plate interface adapters for common functional patterns.
- No tight coupling to a dependency or specific version of any a specific library or runtime.
- [Only low hundreds of bytes and nanos overhead](https://gist.github.com/adriancole/7372371) on the first call to a functional method.  No impact to existing adapters that don't extend functional interfaces.
### Cons
#### Functional interface means only one method.

The `RestAdapter.getMethodInfo()` takes a short-cut, which reduces the code and performance impact, and assumes there's only a single method.  This would have to be rewritten and re-assessed from a performance pov if we wanted to support multiple declared methods as opposed to just functional interfaces.

_Note_ remember.. this constraint is only on interfaces that extend.  All current retrofit interfaces, complete with multiple methods, do not extend other interfaces, and are not affected by this change!
#### `Observable.create()` takes an `OnSubscribeFunc` not `FuncN`

OnSubscribeFunc has a signature that does not permit passing parameters for seed values, such as the repo to list on subscribe. `Subscription onSubscribe(Observer<? super T> t1)`

As such, we need to compose a function with its seed parameters in order to create an observable whose subscriptions start with a retrofit call.  Ex. `Observable.from(onSubscribe(contributors, "retrofit"));`

Currently, there is no utility in rxjava for composing an `OnSubscribeFunc` from a `FuncN` with initial parameters.  If it existed, the signature would look like this.
`static <T1, R> OnSubscribeFunc<R> onSubscribe(Func1<T1, R> fn, T1 param)`

For the purpose of retrofit, we'd only need Func0-5 versions of this, as it is seldom the case a method has more than 5 args.  If we need such an adapter utility, I don't mind writing it and submitting it to rxjava for inclusion.  However, until then, we'd need to ship around a few Func\* to OnSubscribeFunc methods.
### Alternatives

We could do nothing, but more interestingly we could choose a path to support one or more functional libraries.
#### Make RxJava first-class in Retrofit.

If there's only desire for RxJava, the simplest way would be to make it possible to return an OnSubscribeFunc from a retrofit interface.  Implementation could be pretty straightforward, adding a dozen lines to RestAdapter, an OnSubscribeFunc implementation, plus tests.  
##### Pros
- Super simple:  `Observable.from(github.contributors("square", "retrofit"));`
- Methods that return this could be mixed into existing retrofit interfaces, and not be constrained to single-methods.  
- This could save an allocation or so, as it would implement OnSubscribeFunc directly vs via an adapter.
- No utilities or converters needed for rxjava.
##### Cons
- adds an optional dependency on rxjava, compile-sensitive to the OnSubscribeFunc interface.
- wouldn't help RxJava ops such as map, or compositions which take FuncN.
- the OnSubscribeFunc would a have an internal reference to the rest adapter that created it.  This could surprise users.
