### PR TITLE
Use getTypeFactory instead of defaultInstance for Jackson deserialization

### DIFF
--- a/retrofit-converters/jackson/src/main/java/retrofit/converter/JacksonConverter.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit/converter/JacksonConverter.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 
 /**
  * A {@link Converter} which uses Jackson for reading and writing entities.
@@ -31,7 +30,7 @@ public class JacksonConverter implements Converter {
 
   @Override public Object fromBody(TypedInput body, final Type type) throws ConversionException {
     try {
-      final JavaType javaType = TypeFactory.defaultInstance().constructType(type);
+      final JavaType javaType = objectMapper.getTypeFactory().constructType(type);
       return objectMapper.readValue(body.in(), javaType);
     } catch (final JsonParseException e) {
       throw new ConversionException(e);


### PR DESCRIPTION
When getting the JavaType instance for deserialization with Jackson `objectMapper.getTypeFactory` should be used instead of `TypeFactory.defaultInstance` to make sure that any modules installed on the `ObjectMapper` instance are used when constructing the type.

I'm using Retrofit from Scala and initially thought this was a bug in the jackson-module-scala but after logging a bug there (https://github.com/FasterXML/jackson-module-scala/issues/107) and having a discussion with the maintainer I concluded that the use of `defaultInstance` in the `JacksonConverter` was the cause of the issues I was seeing. 
