### PR TITLE
Add ResponseCallback class

### DIFF
--- a/retrofit/src/main/java/retrofit/ResponseCallback.java
+++ b/retrofit/src/main/java/retrofit/ResponseCallback.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import retrofit.client.Response;
+
+/**
+ * An extension of {@link Callback} which returns only {@link Response} object
+ * in {@link Callback#success(Object, retrofit.client.Response)} method.
+ */
+public abstract class ResponseCallback implements Callback<Response> {
+
+  @Override
+  public void success(Response response, Response response2) {
+    success(response);
+  }
+
+  /** Successful HTTP response. */
+  public abstract void success(Response response);
+}


### PR DESCRIPTION
When accepting raw HTTP response one may use the following code:

``` java
@GET("/users/list")
void userList(Callback<Response> cb);
```

This results in `Callback` with two equal objects in `success` method: 

``` java
service.userList(new Callback<Response>() {
      @Override
      public void success(Response response, Response response2) {
      }
      @Override
      public void failure(RetrofitError error) {
      }
});
```

By using `ResponseCallback` class code becomes a little bit cleaner:

``` java
service.userList(new ResponseCallback() {
      @Override
      public void success(Response response) {
      }
      @Override
      public void failure(RetrofitError error) {
      }
});
```

I'm not sure if this class is needed in retrofit. But I'm using it in my projects so I've decided to propose this.
