### PR TITLE
Check for extended interfaces using getInterfaces().length instead of getSuperclass()

### DIFF
--- a/retrofit/src/main/java/retrofit/Utils.java
+++ b/retrofit/src/main/java/retrofit/Utils.java
@@ -103,7 +103,7 @@ final class Utils {
     // Prevent API interfaces from extending other interfaces. This not only avoids a bug in
     // Android (http://b.android.com/58753) but it forces composition of API declarations which is
     // the recommended pattern.
-    if (service.getSuperclass() != null) {
+    if (service.getInterfaces().length > 0) {
       throw new IllegalArgumentException("Interface definitions must not extend other interfaces.");
     }
   }


### PR DESCRIPTION
According to http://docs.oracle.com/javase/6/docs/api/java/lang/Class.html#getSuperclass(), calling getSuperClass() on an interface always returns null. 

So in the commit 5a3c114 (issue #300) is the following code correct?

```
if (service.getSuperclass() != null) {
    throw new IllegalArgumentException("Interface definitions must not extend other interfaces.");
}
```

The reason I ask is I setup my interfaces this way

```
public interface UserService {
...
}

public interface AuthService {
...
}

public interface MainService extends AuthService, UserService {
...
}
```

and I was able to create a rest adapter for the MainServer without the expected IllegalArgumentException

```
restAdapter.create(MainService.class); // Was expecting this to blow up
```

I am sorry if I misunderstood something. If not can you please review my pull request? Thank you.
