### PR TITLE
move usages of Observable out of RestMethodInfo

### DIFF
--- a/retrofit/src/main/java/retrofit/RestMethodInfo.java
+++ b/retrofit/src/main/java/retrofit/RestMethodInfo.java
@@ -272,8 +272,8 @@ final class RestMethodInfo {
     if (hasReturnType) {
       if (Platform.HAS_RX_JAVA) {
         Class rawReturnType = Types.getRawType(returnType);
-        if (rawReturnType == Observable.class) {
-          returnType = Types.getSupertype(returnType, rawReturnType, Observable.class);
+        if (RxSupport.isObservable(rawReturnType)) {
+          returnType = RxSupport.getObservableType(returnType, rawReturnType);
           responseObjectType = getParameterUpperBound((ParameterizedType) returnType);
           return ResponseType.OBSERVABLE;
         }
@@ -445,5 +445,16 @@ final class RestMethodInfo {
       patterns.add(m.group(1));
     }
     return patterns;
+  }
+
+  /** Indirection to avoid log complaints if RxJava isn't present. */
+  private static final class RxSupport {
+    public static boolean isObservable(Class rawType) {
+      return rawType == Observable.class;
+    }
+
+    public static Type getObservableType(Type contextType, Class contextRawType) {
+      return Types.getSupertype(contextType, contextRawType, Observable.class);
+    }
   }
 }


### PR DESCRIPTION
Moving them into a nested class should prevent Dalvik from trying to
load the class when it's not needed.
