### PR TITLE
Add default constructor to SimpleXmlConverter

### DIFF
--- a/retrofit-converters/simplexml/src/main/java/retrofit/converter/SimpleXMLConverter.java
+++ b/retrofit-converters/simplexml/src/main/java/retrofit/converter/SimpleXMLConverter.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.Type;
 
+import org.simpleframework.xml.core.Persister;
 import org.simpleframework.xml.Serializer;
 
 import retrofit.mime.TypedByteArray;
@@ -21,6 +22,10 @@ public class SimpleXMLConverter implements Converter {
   private static final String MIME_TYPE = "application/xml; charset=" + CHARSET;
 
   private final Serializer serializer;
+
+  public SimpleXMLConverter() {
+    this(new Persister());
+  }
 
   public SimpleXMLConverter(Serializer serializer) {
     this.serializer = serializer;


### PR DESCRIPTION
Thought I'd add this so that `SimpleXMLConverter` works as described in the website example --

``` java
RestAdapter restAdapter = new RestAdapter.Builder()
    .setServer("https://api.soundcloud.com")
    .setConverter(new SimpleXMLConverter())
    .build();

SoundCloudService service = restAdapter.create(SoundCloudService.class);
```

Not sure how common of a use-case it would be to use the default `Serializer` implementation, `Persister`, without any customizations. Alternatively, I could just update those example.
