### PR TITLE
Remove guard against @POST("")

### DIFF
--- a/retrofit/src/main/java/retrofit/RestMethodInfo.java
+++ b/retrofit/src/main/java/retrofit/RestMethodInfo.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import retrofit.http.Body;
 import retrofit.http.EncodedPath;
 import retrofit.http.EncodedQuery;
@@ -183,16 +184,6 @@ final class RestMethodInfo {
 
   /** Loads {@link #requestUrl}, {@link #requestUrlParamNames}, and {@link #requestQuery}. */
   private void parsePath(String path) {
-    if (path == null || path.length() == 0 || path.charAt(0) != '/') {
-      throw new IllegalArgumentException("URL path \""
-          + path
-          + "\" on method "
-          + method.getName()
-          + " must start with '/'. ("
-          + method.getName()
-          + ")");
-    }
-
     // Get the relative URL path and existing query string, if present.
     String url = path;
     String query = null;

--- a/retrofit/src/test/java/retrofit/RestMethodInfoTest.java
+++ b/retrofit/src/test/java/retrofit/RestMethodInfoTest.java
@@ -2,6 +2,9 @@
 package retrofit;
 
 import com.google.gson.reflect.TypeToken;
+
+import org.junit.Test;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
@@ -10,7 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Test;
+
 import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.EncodedPath;
@@ -71,19 +74,6 @@ public class RestMethodInfoTest {
     if (expected.length > 0) {
       assertThat(calculated).containsExactly(expected);
     }
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void pathMustBePrefixedWithSlash() {
-    class Example {
-      @GET("foo/bar") Response a() {
-        return null;
-      }
-    }
-
-    Method method = TestingUtils.getMethod(Example.class, "a");
-    RestMethodInfo methodInfo = new RestMethodInfo(method);
-    methodInfo.init();
   }
 
   @Test public void concreteCallbackTypes() {


### PR DESCRIPTION
An API I use does not follow standard REST conventions.  POST requests all go the same base endpoint and are differentiated with a field param.  The URL endpoint can not have an ending "/" or a 404 is thrown.  I removed the check and the test and 'mvn clean verfiy' ran fan.

http://api.foo.com/main => works
http://api.foo.com/main/ => 404
