### PR TITLE
RequestBuilder: Support Iterable / Map for Field

### DIFF
--- a/retrofit/src/main/java/retrofit/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilder.java
@@ -243,13 +243,15 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
           if (value != null) { // Skip null values.
             if (value instanceof Iterable) {
               for (Object v : (Iterable<?>) value) {
-                formBody.addField(name, v.toString());
+                if (v != null) { // Skip null values.
+                  formBody.addField(name, v.toString());
+                }
               }
             } else if (value instanceof Map) {
               for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
-                Object v = entry.getValue();
-                if (v != null) { // Skip null values.
-                  formBody.addField(entry.getKey().toString(), v.toString());
+                Object entryValue = entry.getValue();
+                if (entryValue != null) { // Skip null values.
+                  formBody.addField(entry.getKey().toString(), entryValue.toString());
                 }
               }
             } else {

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -500,7 +500,7 @@ public class RequestBuilderTest {
   }
 
   @Test public void formEncodedFieldList() throws Exception {
-    List<Object> values = new ArrayList<Object>(Arrays.asList("foo", "bar", 3));
+    List<Object> values = new ArrayList<Object>(Arrays.asList("foo", "bar", null, 3));
 
     Request request = new Helper() //
         .setMethod("POST") //


### PR DESCRIPTION
Similar to what #377 added for Query, this adds support for Iterable and Map types to Field.
