### PR TITLE
Reduce RequestBuilder allocations.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -96,7 +96,7 @@
         <module name="EqualsHashCode"/>
         <!--module name="HiddenField"/-->
         <module name="IllegalInstantiation"/>
-        <module name="InnerAssignment"/>
+        <!--module name="InnerAssignment"/-->
         <!--module name="MagicNumber"/-->
         <module name="MissingSwitchDefault"/>
         <module name="RedundantThrows"/>


### PR DESCRIPTION
Do not initialize the header array unless it's used. When headers are specified by the methodInfo, initialize the ArrayList using the copy constructor.

Do not initialize the query StringBuilder unless it is used.

@dnkoutso 
