### PR TITLE
Allow Multipart requests with parts of unknown length

### DIFF
--- a/retrofit/src/main/java/retrofit/mime/MultipartTypedOutput.java
+++ b/retrofit/src/main/java/retrofit/mime/MultipartTypedOutput.java
@@ -104,7 +104,12 @@ public final class MultipartTypedOutput implements TypedOutput {
     MimePart part = new MimePart(name, body, boundary, mimeParts.isEmpty());
     mimeParts.add(part);
 
-    length += part.size();
+    long size = part.size();
+    if (size == -1) {
+      length = -1;
+    } else if (length != -1) {
+      length += size;
+    }
   }
 
   public int getPartCount() {

--- a/retrofit/src/test/java/retrofit/mime/MultipartTypedOutputTest.java
+++ b/retrofit/src/test/java/retrofit/mime/MultipartTypedOutputTest.java
@@ -64,4 +64,17 @@ public class MultipartTypedOutputTest {
     assertThat(actual).isEqualTo(expected);
     assertThat(mto.mimeType()).isEqualTo("multipart/form-data; boundary=123");
   }
+
+  @Test public void withPartOfUnknownLength() throws Exception {
+    MultipartTypedOutput mto = new MultipartTypedOutput("123");
+
+    mto.addPart("first", new TypedString("value"));
+    mto.addPart("second", new TypedString("unknown size") {
+      @Override public long length() {
+        return -1;
+      }
+    });
+
+    assertThat(mto.length()).isEqualTo(-1);
+  }
 }


### PR DESCRIPTION
I'm not sure if it's allowed by the http specification, but anyway http error `411 Length Required` is much clearer than an exception like:

```
retrofit.RetrofitError: java.net.ProtocolException: expected 43 bytes but received 131424
            at retrofit.RestAdapter$RestHandler.invokeRequest(RestAdapter.java:420)
            at retrofit.RestAdapter$RestHandler.access$100(RestAdapter.java:262)
            at retrofit.RestAdapter$RestHandler$1.call(RestAdapter.java:305)
            at retrofit.RestAdapter$RestHandler$1.call(RestAdapter.java:303)
            at retrofit.RestAdapter$RxSupport$1.onSubscribe(RestAdapter.java:247)
```
