### PR TITLE
Update RxJava usage.

### DIFF
--- a/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
+++ b/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
@@ -13,8 +13,9 @@ import retrofit.client.Request;
 import retrofit.client.Response;
 import rx.Observable;
 import rx.Observer;
+import rx.Scheduler;
 import rx.Subscription;
-import rx.concurrency.Schedulers;
+import rx.schedulers.Schedulers;
 
 import static retrofit.RestAdapter.LogLevel;
 
@@ -510,10 +511,10 @@ public final class MockRestAdapter {
 
   /** Indirection to avoid VerifyError if RxJava isn't present. */
   private static class MockRxSupport {
-    private final RestAdapter restAdapter;
+    private final Scheduler scheduler;
 
     MockRxSupport(RestAdapter restAdapter) {
-      this.restAdapter = restAdapter;
+      scheduler = Schedulers.executor(restAdapter.httpExecutor);
     }
 
     Observable createMockObservable(final MockHandler mockHandler, final RestMethodInfo methodInfo,
@@ -529,7 +530,7 @@ public final class MockRestAdapter {
             return Observable.error(throwable).subscribe(observer);
           }
         }
-      }).subscribeOn(Schedulers.executor(restAdapter.httpExecutor));
+      }).subscribeOn(scheduler);
     }
   }
 }

--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -236,10 +236,6 @@ public class RestAdapter {
       this.scheduler = Schedulers.executor(executor);
     }
 
-    Scheduler getScheduler() {
-      return scheduler;
-    }
-
     Observable createRequestObservable(final Callable<ResponseWrapper> request) {
       return Observable.create(new Observable.OnSubscribeFunc<Object>() {
         @Override public Subscription onSubscribe(Observer<? super Object> observer) {
@@ -255,7 +251,7 @@ public class RestAdapter {
           }
           return Subscriptions.empty();
         }
-      });
+      }).subscribeOn(scheduler);
     }
   }
 
@@ -304,7 +300,7 @@ public class RestAdapter {
           @Override public ResponseWrapper call() throws Exception {
             return (ResponseWrapper) invokeRequest(interceptorTape, methodInfo, args);
           }
-        }).subscribeOn(rxSupport.getScheduler());
+        });
       }
 
       Callback<?> callback = (Callback<?>) args[args.length - 1];


### PR DESCRIPTION
- Avoid allocating a `Scheduler` for every mock request.
- Set `Scheduler` inside the `RxSupport` for proper encapsulation.
