### PR TITLE
Remove hack to support PATCH in HttpUrlConnection.

### DIFF
--- a/retrofit/src/main/java/retrofit/client/UrlConnectionClient.java
+++ b/retrofit/src/main/java/retrofit/client/UrlConnectionClient.java
@@ -17,30 +17,19 @@ package retrofit.client;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
-import java.net.ProtocolException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import retrofit.RetrofitError;
 import retrofit.mime.TypedInput;
 import retrofit.mime.TypedOutput;
 
 /** Retrofit client that uses {@link HttpURLConnection} for communication. */
 public class UrlConnectionClient implements Client {
   private static final int CHUNK_SIZE = 4096;
-  private final Field methodField;
 
   public UrlConnectionClient() {
-    try {
-      this.methodField = HttpURLConnection.class.getDeclaredField("method");
-      this.methodField.setAccessible(true);
-    } catch (NoSuchFieldException e) {
-      throw RetrofitError.unexpectedError(null, e);
-    }
   }
 
   @Override public Response execute(Request request) throws IOException {
@@ -58,17 +47,7 @@ public class UrlConnectionClient implements Client {
   }
 
   void prepareRequest(HttpURLConnection connection, Request request) throws IOException {
-    // HttpURLConnection artificially restricts request method
-    try {
-      connection.setRequestMethod(request.getMethod());
-    } catch (ProtocolException e) {
-      try {
-        methodField.set(connection, request.getMethod());
-      } catch (IllegalAccessException e1) {
-        throw RetrofitError.unexpectedError(request.getUrl(), e1);
-      }
-    }
-
+    connection.setRequestMethod(request.getMethod());
     connection.setDoInput(true);
 
     for (Header header : request.getHeaders()) {

--- a/retrofit/src/test/java/retrofit/client/UrlConnectionClientTest.java
+++ b/retrofit/src/test/java/retrofit/client/UrlConnectionClientTest.java
@@ -37,22 +37,6 @@ public class UrlConnectionClientTest {
     assertThat(connection.getHeaderFields()).isEmpty();
   }
 
-  @Test public void patch() throws Exception {
-    TypedString body = new TypedString("hi");
-    Request request = new Request("PATCH", HOST + "/foo/bar/", null, body);
-
-    DummyHttpUrlConnection connection = (DummyHttpUrlConnection) client.openConnection(request);
-    client.prepareRequest(connection, request);
-
-    assertThat(connection.getRequestMethod()).isEqualTo("PATCH");
-    assertThat(connection.getURL().toString()).isEqualTo(HOST + "/foo/bar/");
-    assertThat(connection.getRequestProperties()).hasSize(2);
-    assertThat(connection.getRequestProperty("Content-Type")) //
-        .isEqualTo("text/plain; charset=UTF-8");
-    assertThat(connection.getRequestProperty("Content-Length")).isEqualTo("2");
-    assertBytes(connection.getOutputStream().toByteArray(), "hi");
-  }
-
   @Test public void post() throws Exception {
     TypedString body = new TypedString("hi");
     Request request = new Request("POST", HOST + "/foo/bar/", null, body);


### PR DESCRIPTION
Hacking around implementation details of specific clients is not our responsibility. If you want PATCH support, use Apache HttpClient or OkHttp.

@swankjesse @adriancole

Refs #282. Refs #294. Refs #421.
