### PR TITLE
Use ErrorHandler to coerce error responses during async invocations.

### DIFF
--- a/retrofit/src/main/java/retrofit/ErrorHandler.java
+++ b/retrofit/src/main/java/retrofit/ErrorHandler.java
@@ -16,7 +16,7 @@
 package retrofit;
 
 /**
- * A hook allowing clients to customize error exceptions for synchronous requests.
+ * A hook allowing clients to customize {@link retrofit.client.Response response} exceptions.
  *
  * @author Sam Beran sberan@gmail.com
  */
@@ -41,8 +41,8 @@ public interface ErrorHandler {
    * </pre>
    *
    * @param cause the original {@link RetrofitError} exception
-   * @return Throwable an exception which will be thrown from the client interface method. Must not
-   *         be {@code null}.
+   * @return Throwable an exception which will be thrown from a synchronous interface method or
+   *         passed to an asynchronous error callback. Must not be {@code null}.
    */
   Throwable handleError(RetrofitError cause);
 

--- a/retrofit/src/test/java/retrofit/CallbackRunnableTest.java
+++ b/retrofit/src/test/java/retrofit/CallbackRunnableTest.java
@@ -4,10 +4,6 @@ package retrofit;
 import java.util.concurrent.Executor;
 import org.junit.Before;
 import org.junit.Test;
-import retrofit.Callback;
-import retrofit.CallbackRunnable;
-import retrofit.ResponseWrapper;
-import retrofit.RetrofitError;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.same;
@@ -21,10 +17,11 @@ public class CallbackRunnableTest {
   private Executor executor = spy(new SynchronousExecutor());
   private CallbackRunnable<Object> callbackRunnable;
   private Callback<Object> callback;
+  private ErrorHandler errorHandler = ErrorHandler.DEFAULT;
 
   @Before public void setUp() {
     callback = mock(Callback.class);
-    callbackRunnable = spy(new CallbackRunnable<Object>(callback, executor) {
+    callbackRunnable = spy(new CallbackRunnable<Object>(callback, executor, errorHandler) {
       @Override public ResponseWrapper obtainResponse() {
         return null; // Must be mocked.
       }

--- a/retrofit/src/test/java/retrofit/ErrorHandlerTest.java
+++ b/retrofit/src/test/java/retrofit/ErrorHandlerTest.java
@@ -10,8 +10,11 @@ import retrofit.client.Header;
 import retrofit.client.Request;
 import retrofit.client.Response;
 import retrofit.http.GET;
+import rx.Observable;
+import rx.Observer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -22,6 +25,12 @@ public class ErrorHandlerTest {
   interface ExampleClient {
     @GET("/")
     Response throwsCustomException() throws TestException;
+
+    @GET("/")
+    void onErrorWrappedCustomException(Callback<Response> callback);
+
+    @GET("/")
+    Observable<Response> onErrorCustomException();
   }
 
   static class TestException extends Exception {
@@ -55,10 +64,45 @@ public class ErrorHandlerTest {
 
     try {
       client.throwsCustomException();
-      fail();
+      failBecauseExceptionWasNotThrown(TestException.class);
     } catch (TestException e) {
       assertThat(e).isSameAs(exception);
     }
+  }
+
+  @Test public void onErrorWrappedCustomException() throws Throwable {
+    final TestException exception = new TestException();
+    doReturn(exception).when(errorHandler).handleError(any(RetrofitError.class));
+
+    client.onErrorWrappedCustomException(new Callback<Response>() {
+
+      @Override public void success(Response response, Response response2) {
+        failBecauseExceptionWasNotThrown(TestException.class);
+      }
+
+      @Override public void failure(RetrofitError error) {
+        assertThat(error.getCause()).isSameAs(exception);
+      }
+    });
+  }
+
+  @Test public void onErrorCustomException() throws Throwable {
+    final TestException exception = new TestException();
+    doReturn(exception).when(errorHandler).handleError(any(RetrofitError.class));
+
+    client.onErrorCustomException().subscribe(new Observer<Response>() {
+      @Override public void onCompleted() {
+        failBecauseExceptionWasNotThrown(TestException.class);
+      }
+
+      @Override public void onError(Throwable e) {
+        assertThat(e).isSameAs(exception);
+      }
+
+      @Override public void onNext(Response response) {
+        failBecauseExceptionWasNotThrown(TestException.class);
+      }
+    });
   }
 
   @Test public void returningNullThrowsException() throws Exception {


### PR DESCRIPTION
 For rx, the handled error is passed to `Observer.onError`.  `Callback.failure` parameter is `RetrofitError error`, so in this case, the handled error is the cause.
