### PR TITLE
Allow overriding 'Content-Type' header.

### DIFF
--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -444,14 +444,6 @@ public class RestAdapter {
       TypedOutput body = request.getBody();
       if (body != null) {
         bodySize = body.length();
-        String bodyMime = body.mimeType();
-
-        if (bodyMime != null) {
-          log.log("Content-Type: " + bodyMime);
-        }
-        if (bodySize != -1) {
-          log.log("Content-Length: " + bodySize);
-        }
 
         if (logLevel.ordinal() >= LogLevel.FULL.ordinal()) {
           if (!request.getHeaders().isEmpty()) {
@@ -465,7 +457,7 @@ public class RestAdapter {
 
           byte[] bodyBytes = ((TypedByteArray) body).getBytes();
           bodySize = bodyBytes.length;
-          String bodyCharset = MimeUtil.parseCharset(bodyMime);
+          String bodyCharset = MimeUtil.parseCharset(body.mimeType());
           log.log(new String(bodyBytes, bodyCharset));
         }
       }

--- a/retrofit/src/main/java/retrofit/appengine/UrlFetchClient.java
+++ b/retrofit/src/main/java/retrofit/appengine/UrlFetchClient.java
@@ -71,12 +71,6 @@ public class UrlFetchClient implements Client {
 
     TypedOutput body = request.getBody();
     if (body != null) {
-      fetchRequest.setHeader(new HTTPHeader("Content-Type", body.mimeType()));
-      long length = body.length();
-      if (length != -1) {
-        fetchRequest.setHeader(new HTTPHeader("Content-Length", String.valueOf(length)));
-      }
-
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       body.writeTo(baos);
       fetchRequest.setPayload(baos.toByteArray());

--- a/retrofit/src/main/java/retrofit/client/ApacheClient.java
+++ b/retrofit/src/main/java/retrofit/client/ApacheClient.java
@@ -131,7 +131,6 @@ public class ApacheClient implements Client {
 
     TypedOutputEntity(TypedOutput typedOutput) {
       this.typedOutput = typedOutput;
-      setContentType(typedOutput.mimeType());
     }
 
     @Override public boolean isRepeatable() {

--- a/retrofit/src/main/java/retrofit/client/Client.java
+++ b/retrofit/src/main/java/retrofit/client/Client.java
@@ -25,6 +25,10 @@ public interface Client {
   /**
    * Synchronously execute an HTTP represented by {@code request} and encapsulate all response data
    * into a {@link Response} instance.
+   * <p>
+   * Note: If the request has a body, its length and mime type will have already been added to the
+   * header list as {@code Content-Length} and {@code Content-Type}, respectively. Do NOT alter
+   * these values as they might have been set as a result of an application-level configuration.
    */
   Response execute(Request request) throws IOException;
 

--- a/retrofit/src/main/java/retrofit/client/UrlConnectionClient.java
+++ b/retrofit/src/main/java/retrofit/client/UrlConnectionClient.java
@@ -57,11 +57,9 @@ public class UrlConnectionClient implements Client {
     TypedOutput body = request.getBody();
     if (body != null) {
       connection.setDoOutput(true);
-      connection.addRequestProperty("Content-Type", body.mimeType());
       long length = body.length();
       if (length != -1) {
         connection.setFixedLengthStreamingMode((int) length);
-        connection.addRequestProperty("Content-Length", String.valueOf(length));
       } else {
         connection.setChunkedStreamingMode(CHUNK_SIZE);
       }

--- a/retrofit/src/test/java/retrofit/appengine/UrlFetchClientTest.java
+++ b/retrofit/src/test/java/retrofit/appengine/UrlFetchClientTest.java
@@ -48,9 +48,7 @@ public class UrlFetchClientTest {
     assertThat(fetchRequest.getMethod()).isEqualTo(POST);
     assertThat(fetchRequest.getURL().toString()).isEqualTo(HOST + "/foo/bar/");
     List<HTTPHeader> fetchHeaders = fetchRequest.getHeaders();
-    assertThat(fetchHeaders).hasSize(2);
-    assertHeader(fetchHeaders.get(0), "Content-Type", "text/plain; charset=UTF-8");
-    assertHeader(fetchHeaders.get(1), "Content-Length", "2");
+    assertThat(fetchHeaders).hasSize(0);
     assertBytes(fetchRequest.getPayload(), "hi");
   }
 
@@ -65,11 +63,7 @@ public class UrlFetchClientTest {
     assertThat(fetchRequest.getMethod()).isEqualTo(POST);
     assertThat(fetchRequest.getURL().toString()).isEqualTo(HOST + "/that/");
     List<HTTPHeader> fetchHeaders = fetchRequest.getHeaders();
-    assertThat(fetchHeaders).hasSize(2);
-    HTTPHeader headerZero = fetchHeaders.get(0);
-    assertThat(headerZero.getName()).isEqualTo("Content-Type");
-    assertThat(headerZero.getValue()).startsWith("multipart/form-data; boundary=");
-    assertHeader(fetchHeaders.get(1), "Content-Length", String.valueOf(body.length()));
+    assertThat(fetchHeaders).hasSize(0);
     assertThat(fetchRequest.getPayload()).isNotEmpty();
   }
 

--- a/retrofit/src/test/java/retrofit/client/ApacheClientTest.java
+++ b/retrofit/src/test/java/retrofit/client/ApacheClientTest.java
@@ -56,7 +56,6 @@ public class ApacheClientTest {
     HttpEntity entity = entityRequest.getEntity();
     assertThat(entity).isNotNull();
     assertBytes(ByteStreams.toByteArray(entity.getContent()), "hi");
-    assertThat(entity.getContentType().getValue()).isEqualTo("text/plain; charset=UTF-8");
   }
 
   @Test public void multipart() {

--- a/retrofit/src/test/java/retrofit/client/UrlConnectionClientTest.java
+++ b/retrofit/src/test/java/retrofit/client/UrlConnectionClientTest.java
@@ -46,10 +46,7 @@ public class UrlConnectionClientTest {
 
     assertThat(connection.getRequestMethod()).isEqualTo("POST");
     assertThat(connection.getURL().toString()).isEqualTo(HOST + "/foo/bar/");
-    assertThat(connection.getRequestProperties()).hasSize(2);
-    assertThat(connection.getRequestProperty("Content-Type")) //
-        .isEqualTo("text/plain; charset=UTF-8");
-    assertThat(connection.getRequestProperty("Content-Length")).isEqualTo("2");
+    assertThat(connection.getRequestProperties()).hasSize(0);
     assertBytes(connection.getOutputStream().toByteArray(), "hi");
   }
 
@@ -67,9 +64,7 @@ public class UrlConnectionClientTest {
 
     assertThat(connection.getRequestMethod()).isEqualTo("POST");
     assertThat(connection.getURL().toString()).isEqualTo(HOST + "/that/");
-    assertThat(connection.getRequestProperties()).hasSize(2);
-    assertThat(connection.getRequestProperty("Content-Type")).startsWith("multipart/form-data;");
-    assertThat(connection.getRequestProperty("Content-Length")).isEqualTo(String.valueOf(output.length));
+    assertThat(connection.getRequestProperties()).hasSize(0);
     assertThat(output.length).isGreaterThan(0);
   }
 


### PR DESCRIPTION
This 'Request' objects passed to a client will now have their header list pre-populated with 'Content-Type' and 'Content-Length' headers set. Previously the 'Client' implementations were responsibile for setting this data.

Closes #434.
