### PR TITLE
Add 'Logging' section to website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -223,6 +223,7 @@ RestAdapter restAdapter = new RestAdapter.Builder()
     .setLogLevel(RestAdapter.LogLevel.FULL)
     .setEndpoint("https://api.github.com")
     .build();</pre>
+            <p>This logging can be added or changed at any point in the <code>RestAdapter</code>'s lifecycle by calling the same <code>.setLogLevel()</code> method and supplying a different <code>LogLevel</code> value.</p>
 
             <h3 id="download">Download</h3>
             <p><a href="http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.squareup.retrofit&a=retrofit&v=LATEST" class="dl version-href">&darr; <span class="version-tag">Latest</span> JAR</a></p>


### PR DESCRIPTION
I think that most people will add some form of logging to their RestAdapter.
Since it is such a common action, why not have an example of this logging on the main retrofit page so developers don't have to go searching for it? 
