### PR TITLE
added @Raw annotation for retrieving the response without converting to byte[] first

### DIFF
--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -338,8 +338,10 @@ public class RestAdapter {
         if (statusCode >= 200 && statusCode < 300) { // 2XX == successful request
           // Caller requested the raw Response object directly.
           if (type.equals(Response.class)) {
-            // Read the entire stream and replace with one backed by a byte[]
-            response = Utils.readBodyToBytesIfNecessary(response);
+            if (!methodInfo.isRaw) {
+              // Read the entire stream and replace with one backed by a byte[]
+              response = Utils.readBodyToBytesIfNecessary(response);
+            }
 
             if (methodInfo.isSynchronous) {
               return response;

--- a/retrofit/src/main/java/retrofit/RestMethodInfo.java
+++ b/retrofit/src/main/java/retrofit/RestMethodInfo.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import retrofit.client.Response;
 import retrofit.http.Body;
 import retrofit.http.EncodedPath;
 import retrofit.http.EncodedQuery;
@@ -42,6 +43,7 @@ import retrofit.http.PartMap;
 import retrofit.http.Path;
 import retrofit.http.Query;
 import retrofit.http.QueryMap;
+import retrofit.http.Raw;
 import retrofit.http.RestMethod;
 import rx.Observable;
 
@@ -100,6 +102,7 @@ final class RestMethodInfo {
   String requestQuery;
   List<retrofit.client.Header> headers;
   String contentTypeHeader;
+  boolean isRaw;
 
   // Parameter-level details
   String[] requestParamNames;
@@ -178,6 +181,13 @@ final class RestMethodInfo {
           throw methodError("Only one encoding annotation is allowed.");
         }
         requestType = RequestType.FORM_URL_ENCODED;
+      } else if (annotationType == Raw.class) {
+        if (responseObjectType != Response.class) {
+          throw methodError(
+              "Only methods having %s as response data type are allowed to have @%s annotation.",
+              Response.class.getSimpleName(), Raw.class.getSimpleName());
+        }
+        isRaw = true;
       }
     }
 

--- a/retrofit/src/main/java/retrofit/http/Raw.java
+++ b/retrofit/src/main/java/retrofit/http/Raw.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit.http;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Treat the response body on methods returning {@link retrofit.client.Response} as is, i.e.
+ * without converting {@link retrofit.client.Response#getBody()} to byte[].
+ */
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface Raw {
+
+}


### PR DESCRIPTION
This is the implementation as suggests in #478.

`mvn clean verify` was successful and I've send you the CLA.

Feel free to comment and inform me about any improvements I should integrate.
