### PR TITLE
Return null as error body when response is absent

### DIFF
--- a/retrofit/src/main/java/retrofit/RetrofitError.java
+++ b/retrofit/src/main/java/retrofit/RetrofitError.java
@@ -77,6 +77,9 @@ public class RetrofitError extends RuntimeException {
    * the generic type of the supplied {@link Callback} parameter.
    */
   public Object getBody() {
+    if (response == null) {
+      return null;
+    }
     TypedInput body = response.getBody();
     if (body == null) {
       return null;
@@ -90,6 +93,9 @@ public class RetrofitError extends RuntimeException {
 
   /** HTTP response body converted to specified {@code type}. */
   public Object getBodyAs(Type type) {
+    if (response == null) {
+      return null;
+    }
     TypedInput body = response.getBody();
     if (body == null) {
       return null;


### PR DESCRIPTION
Was throwing an NPE for lack of null check on response before trying to
access the given response body.

Fixes #488
