### PR TITLE
Apply the interceptor tape at the time of subscription.

### DIFF
--- a/retrofit/src/main/java/retrofit/RxSupport.java
+++ b/retrofit/src/main/java/retrofit/RxSupport.java
@@ -1,6 +1,5 @@
 package retrofit;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.FutureTask;
 import rx.Observable;
@@ -13,21 +12,31 @@ import rx.subscriptions.Subscriptions;
  * RxJava might not be on the available to use. Check {@link Platform#HAS_RX_JAVA} before calling.
  */
 final class RxSupport {
-  private final Executor executor;
-  private final ErrorHandler errorHandler;
-
-  RxSupport(Executor executor, ErrorHandler errorHandler) {
-    this.executor = executor;
-    this.errorHandler = errorHandler;
+  /** A callback into {@link RestAdapter} to actually invoke the request. */
+  interface Invoker {
+    /** Invoke the request. The interceptor will be "tape" from the time of subscription. */
+    ResponseWrapper invoke(RequestInterceptor requestInterceptor);
   }
 
-  Observable createRequestObservable(final Callable<ResponseWrapper> request) {
+  private final Executor executor;
+  private final ErrorHandler errorHandler;
+  private final RequestInterceptor requestInterceptor;
+
+  RxSupport(Executor executor, ErrorHandler errorHandler, RequestInterceptor requestInterceptor) {
+    this.executor = executor;
+    this.errorHandler = errorHandler;
+    this.requestInterceptor = requestInterceptor;
+  }
+
+  Observable createRequestObservable(final Invoker invoker) {
     return Observable.create(new Observable.OnSubscribe<Object>() {
       @Override public void call(Subscriber<? super Object> subscriber) {
-        if (subscriber.isUnsubscribed()) {
-          return;
-        }
-        FutureTask<Void> task = new FutureTask<Void>(getRunnable(subscriber, request), null);
+        RequestInterceptorTape interceptorTape = new RequestInterceptorTape();
+        requestInterceptor.intercept(interceptorTape);
+
+        Runnable runnable = getRunnable(subscriber, invoker, interceptorTape);
+        FutureTask<Void> task = new FutureTask<Void>(runnable, null);
+
         // Subscribe to the future task of the network call allowing unsubscription.
         subscriber.add(Subscriptions.from(task));
         executor.execute(task);
@@ -35,15 +44,15 @@ final class RxSupport {
     });
   }
 
-  private Runnable getRunnable(final Subscriber<? super Object> subscriber,
-      final Callable<ResponseWrapper> request) {
+  private Runnable getRunnable(final Subscriber<? super Object> subscriber, final Invoker invoker,
+      final RequestInterceptorTape interceptorTape) {
     return new Runnable() {
       @Override public void run() {
         try {
           if (subscriber.isUnsubscribed()) {
             return;
           }
-          ResponseWrapper wrapper = request.call();
+          ResponseWrapper wrapper = invoker.invoke(interceptorTape);
           subscriber.onNext(wrapper.responseBody);
           subscriber.onCompleted();
         } catch (RetrofitError e) {


### PR DESCRIPTION
Previously the tape would only be applied when the Observable itself was created. This is counter to what you want since the Observable is a representation of an API call but not an actual invocation.

Since the tape is now applied at the time of subscription, the Observable can be long-lived while still behaving like a synchronous API call. Additionally, consumers of the Observable API that immediately called subscribe receive the same interceptor behavior since it's on the same thread.

Closes #506.

@loganj 
