### PR TITLE
More robust implementation of 'Content-Type' overriding.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,11 @@
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>${okhttp.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/retrofit/pom.xml
+++ b/retrofit/pom.xml
@@ -65,6 +65,11 @@
       <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/retrofit/src/main/java/retrofit/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilder.java
@@ -15,6 +15,8 @@
  */
 package retrofit;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
 import java.net.URLEncoder;
@@ -48,7 +50,7 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
   private String relativeUrl;
   private StringBuilder queryParams;
   private List<Header> headers;
-  private boolean hasContentTypeHeader;
+  private String contentTypeHeader;
 
   RequestBuilder(String apiUrl, RestMethodInfo methodInfo, Converter converter) {
     this.apiUrl = apiUrl;
@@ -63,7 +65,7 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
     if (methodInfo.headers != null) {
       headers = new ArrayList<Header>(methodInfo.headers);
     }
-    hasContentTypeHeader = methodInfo.hasContentTypeHeader;
+    contentTypeHeader = methodInfo.contentTypeHeader;
 
     relativeUrl = methodInfo.requestUrl;
 
@@ -97,15 +99,16 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
     if (name == null) {
       throw new IllegalArgumentException("Header name must not be null.");
     }
+    if ("Content-Type".equalsIgnoreCase(name)) {
+      contentTypeHeader = value;
+      return;
+    }
+
     List<Header> headers = this.headers;
     if (headers == null) {
       this.headers = headers = new ArrayList<Header>(2);
     }
     headers.add(new Header(name, value));
-
-    if ("Content-Type".equalsIgnoreCase(name)) {
-      hasContentTypeHeader = true;
-    }
   }
 
   @Override public void addPathParam(String name, String value) {
@@ -333,19 +336,36 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
     }
 
     TypedOutput body = this.body;
-    if (body != null) {
-      // Only add Content-Type header from the body if one is not already set.
-      if (!hasContentTypeHeader) {
-        addHeader("Content-Type", body.mimeType());
-      }
-
-      // Only add Content-Length header from the body if it is known.
-      long length = body.length();
-      if (length != -1) {
-        addHeader("Content-Length", String.valueOf(length));
-      }
+    if (body != null && contentTypeHeader != null) {
+      body = new MimeOverridingTypedOutput(body, contentTypeHeader);
     }
 
     return new Request(requestMethod, url.toString(), headers, body);
+  }
+
+  private static class MimeOverridingTypedOutput implements TypedOutput {
+    private final TypedOutput delegate;
+    private final String mimeType;
+
+    MimeOverridingTypedOutput(TypedOutput delegate, String mimeType) {
+      this.delegate = delegate;
+      this.mimeType = mimeType;
+    }
+
+    @Override public String fileName() {
+      return delegate.fileName();
+    }
+
+    @Override public String mimeType() {
+      return mimeType;
+    }
+
+    @Override public long length() {
+      return delegate.length();
+    }
+
+    @Override public void writeTo(OutputStream out) throws IOException {
+      delegate.writeTo(out);
+    }
   }
 }

--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -407,7 +407,16 @@ public class RestAdapter {
       String bodySize = "no";
       TypedOutput body = request.getBody();
       if (body != null) {
-        bodySize = body.length() + "-byte";
+        String bodyMime = body.mimeType();
+        if (bodyMime != null) {
+          log.log("Content-Type: " + bodyMime);
+        }
+
+        long bodyLength = body.length();
+        bodySize = bodyLength + "-byte";
+        if (bodyLength != -1) {
+          log.log("Content-Length: " + bodyLength);
+        }
 
         if (logLevel.ordinal() >= LogLevel.FULL.ordinal()) {
           if (!request.getHeaders().isEmpty()) {

--- a/retrofit/src/main/java/retrofit/RestMethodInfo.java
+++ b/retrofit/src/main/java/retrofit/RestMethodInfo.java
@@ -99,7 +99,7 @@ final class RestMethodInfo {
   Set<String> requestUrlParamNames;
   String requestQuery;
   List<retrofit.client.Header> headers;
-  boolean hasContentTypeHeader;
+  String contentTypeHeader;
 
   // Parameter-level details
   String[] requestParamNames;
@@ -235,9 +235,10 @@ final class RestMethodInfo {
       String headerName = header.substring(0, colon);
       String headerValue = header.substring(colon + 1).trim();
       if ("Content-Type".equalsIgnoreCase(headerName)) {
-        hasContentTypeHeader = true;
+        contentTypeHeader = headerValue;
+      } else {
+        headerList.add(new retrofit.client.Header(headerName, headerValue));
       }
-      headerList.add(new retrofit.client.Header(headerName, headerValue));
     }
     return headerList;
   }
@@ -379,10 +380,6 @@ final class RestMethodInfo {
 
             paramNames[i] = name;
             paramUsage[i] = ParamUsage.HEADER;
-
-            if ("Content-Type".equalsIgnoreCase(name)) {
-              hasContentTypeHeader = true;
-            }
           } else if (annotationType == Field.class) {
             if (requestType != RequestType.FORM_URL_ENCODED) {
               throw parameterError(i, "@Field parameters can only be used with form encoding.");

--- a/retrofit/src/main/java/retrofit/client/UrlConnectionClient.java
+++ b/retrofit/src/main/java/retrofit/client/UrlConnectionClient.java
@@ -57,9 +57,11 @@ public class UrlConnectionClient implements Client {
     TypedOutput body = request.getBody();
     if (body != null) {
       connection.setDoOutput(true);
+      connection.addRequestProperty("Content-Type", body.mimeType());
       long length = body.length();
       if (length != -1) {
         connection.setFixedLengthStreamingMode((int) length);
+        connection.addRequestProperty("Content-Length", String.valueOf(length));
       } else {
         connection.setChunkedStreamingMode(CHUNK_SIZE);
       }

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -422,9 +422,7 @@ public class RequestBuilderTest {
         .setBody(Arrays.asList("quick", "brown", "fox")) //
         .build();
     assertThat(request.getMethod()).isEqualTo("POST");
-    assertThat(request.getHeaders()).containsExactly(
-        new Header("Content-Type", "application/json; charset=UTF-8"),
-        new Header("Content-Length", "23"));
+    assertThat(request.getHeaders()).isEmpty();
     assertThat(request.getUrl()).isEqualTo("http://example.com/foo/bar/");
     assertTypedBytes(request.getBody(), "[\"quick\",\"brown\",\"fox\"]");
   }
@@ -455,9 +453,7 @@ public class RequestBuilderTest {
         .addPathParam("kit", "kat") //
         .build();
     assertThat(request.getMethod()).isEqualTo("POST");
-    assertThat(request.getHeaders()).containsExactly(
-        new Header("Content-Type", "application/json; charset=UTF-8"),
-        new Header("Content-Length", "23"));
+    assertThat(request.getHeaders()).isEmpty();
     assertThat(request.getUrl()).isEqualTo("http://example.com/foo/bar/pong/kat/");
     assertTypedBytes(request.getBody(), "[\"quick\",\"brown\",\"fox\"]");
   }
@@ -473,9 +469,7 @@ public class RequestBuilderTest {
         .addPart("kit", new TypedString("kat")) //
         .build();
     assertThat(request.getMethod()).isEqualTo("POST");
-    assertThat(request.getHeaders()).hasSize(2);
-    assertThat(request.getHeaders().get(0).getName()).isEqualTo("Content-Type");
-    assertThat(request.getHeaders().get(1)).isEqualTo(new Header("Content-Length", "414"));
+    assertThat(request.getHeaders()).isEmpty();
     assertThat(request.getUrl()).isEqualTo("http://example.com/foo/bar/");
 
     MultipartTypedOutput body = (MultipartTypedOutput) request.getBody();
@@ -505,9 +499,7 @@ public class RequestBuilderTest {
         .addPartMap("params", params) //
         .build();
     assertThat(request.getMethod()).isEqualTo("POST");
-    assertThat(request.getHeaders()).hasSize(2);
-    assertThat(request.getHeaders().get(0).getName()).isEqualTo("Content-Type");
-    assertThat(request.getHeaders().get(1)).isEqualTo(new Header("Content-Length", "414"));
+    assertThat(request.getHeaders()).isEmpty();
     assertThat(request.getUrl()).isEqualTo("http://example.com/foo/bar/");
 
     MultipartTypedOutput body = (MultipartTypedOutput) request.getBody();
@@ -534,9 +526,7 @@ public class RequestBuilderTest {
         .addPart("fizz", null) //
         .build();
     assertThat(request.getMethod()).isEqualTo("POST");
-    assertThat(request.getHeaders()).hasSize(2);
-    assertThat(request.getHeaders().get(0).getName()).isEqualTo("Content-Type");
-    assertThat(request.getHeaders().get(1)).isEqualTo(new Header("Content-Length", "228"));
+    assertThat(request.getHeaders()).isEmpty();
     assertThat(request.getUrl()).isEqualTo("http://example.com/foo/bar/");
 
     MultipartTypedOutput body = (MultipartTypedOutput) request.getBody();
@@ -761,9 +751,7 @@ public class RequestBuilderTest {
         .addHeaders("Content-Type: text/not-plain") //
         .setBody(new TypedString("Plain")) //
         .build();
-    assertThat(request.getHeaders()) //
-        .containsExactly(new Header("Content-Type", "text/not-plain"),
-            new Header("Content-Length", "5"));
+    assertThat(request.getBody().mimeType()).isEqualTo("text/not-plain");
   }
 
   @Test public void contentTypeParameterHeaderOverrides() throws Exception {
@@ -774,9 +762,7 @@ public class RequestBuilderTest {
         .addHeaderParam("Content-Type", "text/not-plain") //
         .setBody(new TypedString("Plain")) //
         .build();
-    assertThat(request.getHeaders()) //
-        .containsExactly(new Header("Content-Type", "text/not-plain"),
-            new Header("Content-Length", "5"));
+    assertThat(request.getBody().mimeType()).isEqualTo("text/not-plain");
   }
 
   private static void assertTypedBytes(TypedOutput bytes, String expected) throws IOException {

--- a/retrofit/src/test/java/retrofit/client/ClientIntegrationTest.java
+++ b/retrofit/src/test/java/retrofit/client/ClientIntegrationTest.java
@@ -1,0 +1,84 @@
+// Copyright 2014 Square, Inc.
+package retrofit.client;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import retrofit.RestAdapter;
+import retrofit.http.Body;
+import retrofit.http.GET;
+import retrofit.http.POST;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class ClientIntegrationTest {
+  @Parameterized.Parameters
+  public static List<Object[]> clients() {
+    return Arrays.asList(new Object[][] {
+        { new OkClient() },
+        { new UrlConnectionClient() },
+        { new ApacheClient() }
+    });
+  }
+
+  private final Client client;
+
+  private MockWebServer server;
+  private Service service;
+
+  public ClientIntegrationTest(Client client) {
+    this.client = client;
+  }
+
+  @Before public void setUp() throws Exception {
+    server = new MockWebServer();
+    server.play();
+
+    RestAdapter restAdapter = new RestAdapter.Builder()
+        .setEndpoint("http://" + server.getHostName() + ":" + server.getPort())
+        .setClient(client)
+        .build();
+    service = restAdapter.create(Service.class);
+  }
+
+  @After public void tearDown() throws IOException {
+    server.shutdown();
+  }
+
+  private interface Service {
+    @GET("/get")
+    Response get();
+
+    @POST("/post")
+    Response post(@Body List<String> body);
+  }
+
+  @Test public void get() throws InterruptedException {
+    server.enqueue(new MockResponse().setBody("{}"));
+    service.get();
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getPath()).isEqualTo("/get");
+    assertThat(request.getBody()).isEmpty();
+  }
+
+  @Test public void post() throws InterruptedException {
+    server.enqueue(new MockResponse().setBody("{}"));
+    service.post(Arrays.asList("Hello", "World!"));
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getPath()).isEqualTo("/post");
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
+    assertThat(request.getHeader("Content-Length")).isEqualTo("18");
+    assertThat(request.getUtf8Body()).isEqualTo("[\"Hello\",\"World!\"]");
+  }
+}

--- a/retrofit/src/test/java/retrofit/client/UrlConnectionClientTest.java
+++ b/retrofit/src/test/java/retrofit/client/UrlConnectionClientTest.java
@@ -46,7 +46,10 @@ public class UrlConnectionClientTest {
 
     assertThat(connection.getRequestMethod()).isEqualTo("POST");
     assertThat(connection.getURL().toString()).isEqualTo(HOST + "/foo/bar/");
-    assertThat(connection.getRequestProperties()).hasSize(0);
+    assertThat(connection.getRequestProperties()).hasSize(2);
+    assertThat(connection.getRequestProperty("Content-Type")) //
+        .isEqualTo("text/plain; charset=UTF-8");
+    assertThat(connection.getRequestProperty("Content-Length")).isEqualTo("2");
     assertBytes(connection.getOutputStream().toByteArray(), "hi");
   }
 
@@ -64,7 +67,9 @@ public class UrlConnectionClientTest {
 
     assertThat(connection.getRequestMethod()).isEqualTo("POST");
     assertThat(connection.getURL().toString()).isEqualTo(HOST + "/that/");
-    assertThat(connection.getRequestProperties()).hasSize(0);
+    assertThat(connection.getRequestProperties()).hasSize(2);
+    assertThat(connection.getRequestProperty("Content-Type")).startsWith("multipart/form-data;");
+    assertThat(connection.getRequestProperty("Content-Length")).isEqualTo(String.valueOf(output.length));
     assertThat(output.length).isGreaterThan(0);
   }
 


### PR DESCRIPTION
The previous approach of just including the content type and length in the regular header list was shortsighted and broken. This is basically a revert of 34d84ec3985cfd7b374bb851bd0d962c8504c31c which then adds the overridden content type directly to the TypedOutput.

Closes #454.
