### PR TITLE
Add trailing CRLF to multipart.

### DIFF
--- a/retrofit/src/main/java/retrofit/mime/MultipartTypedOutput.java
+++ b/retrofit/src/main/java/retrofit/mime/MultipartTypedOutput.java
@@ -145,9 +145,8 @@ public final class MultipartTypedOutput implements TypedOutput {
       sb.append(boundary);
       if (last) {
         sb.append("--");
-      } else {
-        sb.append("\r\n");
       }
+      sb.append("\r\n");
       return sb.toString().getBytes("UTF-8");
     } catch (IOException ex) {
       throw new RuntimeException("Unable to write multipart boundary", ex);

--- a/retrofit/src/test/java/retrofit/mime/MultipartTypedOutputTest.java
+++ b/retrofit/src/test/java/retrofit/mime/MultipartTypedOutputTest.java
@@ -16,7 +16,7 @@ public class MultipartTypedOutputTest {
         + "Content-Transfer-Encoding: binary\r\n" //
         + "\r\n" //
         + "Hello, World!\r\n" //
-        + "--123--";
+        + "--123--\r\n";
 
     MultipartTypedOutput mto = new MultipartTypedOutput("123");
     mto.addPart("greet", new TypedString("Hello, World!"));
@@ -51,7 +51,7 @@ public class MultipartTypedOutputTest {
         + "Content-Transfer-Encoding: binary\r\n"
         + "\r\n"
         + "dog\r\n"
-        + "--123--";
+        + "--123--\r\n";
 
     MultipartTypedOutput mto = new MultipartTypedOutput("123");
     mto.addPart("quick", new TypedString("brown"));


### PR DESCRIPTION
.NET's MVC 4 fails to parse multipart uploads which lack a trailing CRLF. This is safe to add to all multipart requests since it is after the final boundary which is considered part of the epilogue and is ignored (per RFC1341 section 7.2.1).

Closes #536.

@edenman 
