### PR TITLE
Always add special-cased 'Content-Type' header to request.

### DIFF
--- a/retrofit/src/main/java/retrofit/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilder.java
@@ -336,8 +336,13 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
     }
 
     TypedOutput body = this.body;
-    if (body != null && contentTypeHeader != null) {
-      body = new MimeOverridingTypedOutput(body, contentTypeHeader);
+    List<Header> headers = this.headers;
+    if (contentTypeHeader != null) {
+      if (body != null) {
+        body = new MimeOverridingTypedOutput(body, contentTypeHeader);
+      } else {
+        headers.add(new Header("Content-Type", contentTypeHeader));
+      }
     }
 
     return new Request(requestMethod, url.toString(), headers, body);

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -754,6 +754,16 @@ public class RequestBuilderTest {
     assertThat(request.getBody().mimeType()).isEqualTo("text/not-plain");
   }
 
+  @Test public void contentTypeAnnotationHeaderAddsHeaderWithNoBody() throws Exception {
+    Request request = new Helper() //
+        .setMethod("DELETE") //
+        .setUrl("http://example.com") //
+        .setPath("/") //
+        .addHeaders("Content-Type: text/not-plain") //
+        .build();
+    assertThat(request.getHeaders()).contains(new Header("Content-Type", "text/not-plain"));
+  }
+
   @Test public void contentTypeParameterHeaderOverrides() throws Exception {
     Request request = new Helper() //
         .setMethod("POST") //


### PR DESCRIPTION
Because 'Content-Type' needs special-cased to hand inside the request body's 'TypedOutput' we were erroneously omitting the header if no body was present. In the case of no body, we can just add it like any other header.

Closes #533.

@edenman 
