### PR TITLE
Correct NPE when only 'Content-Type' header is present on non-body requests.

### DIFF
--- a/retrofit/src/main/java/retrofit/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilder.java
@@ -21,6 +21,7 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import retrofit.client.Header;
@@ -341,7 +342,12 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
       if (body != null) {
         body = new MimeOverridingTypedOutput(body, contentTypeHeader);
       } else {
-        headers.add(new Header("Content-Type", contentTypeHeader));
+        Header header = new Header("Content-Type", contentTypeHeader);
+        if (headers == null) {
+          headers = Arrays.asList(header);
+        } else {
+          headers.add(header);
+        }
       }
     }
 

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -764,6 +764,16 @@ public class RequestBuilderTest {
     assertThat(request.getHeaders()).contains(new Header("Content-Type", "text/not-plain"));
   }
 
+  @Test public void contentTypeInterceptorHeaderAddsHeaderWithNoBody() throws Exception {
+    Request request = new Helper() //
+        .setMethod("DELETE") //
+        .setUrl("http://example.com") //
+        .setPath("/") //
+        .addInterceptorHeader("Content-Type", "text/not-plain") //
+        .build();
+    assertThat(request.getHeaders()).contains(new Header("Content-Type", "text/not-plain"));
+  }
+
   @Test public void contentTypeParameterHeaderOverrides() throws Exception {
     Request request = new Helper() //
         .setMethod("POST") //
@@ -957,7 +967,8 @@ public class RequestBuilderTest {
       methodInfo.requestQuery = query;
       methodInfo.requestParamNames = paramNames.toArray(new String[paramNames.size()]);
       methodInfo.requestParamUsage = paramUsages.toArray(new ParamUsage[paramUsages.size()]);
-      methodInfo.headers = methodInfo.parseHeaders(headers.toArray(new String[headers.size()]));
+      methodInfo.headers = headers.isEmpty() ? null
+          : methodInfo.parseHeaders(headers.toArray(new String[headers.size()]));
       methodInfo.loaded = true;
 
       RequestBuilder requestBuilder = new RequestBuilder(url, methodInfo, GSON);


### PR DESCRIPTION
Closes #557.

@edenman 
