### PR TITLE
Accept @Header annotation values that are objects

### DIFF
--- a/retrofit/src/main/java/retrofit/RestMethodInfo.java
+++ b/retrofit/src/main/java/retrofit/RestMethodInfo.java
@@ -383,10 +383,6 @@ final class RestMethodInfo {
             paramUsage[i] = ParamUsage.ENCODED_QUERY_MAP;
           } else if (annotationType == Header.class) {
             String name = ((Header) parameterAnnotation).value();
-            if (parameterType != String.class) {
-              throw parameterError(i, "@Header parameter type must be String. Found: %s.",
-                  parameterType.getSimpleName());
-            }
 
             paramNames[i] = name;
             paramUsage[i] = ParamUsage.HEADER;

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -715,6 +716,21 @@ public class RequestBuilderTest {
     assertThat(request.getMethod()).isEqualTo("GET");
     assertThat(request.getHeaders()) //
         .containsExactly(new Header("ping", "pong"), new Header("kit", "kat"));
+    assertThat(request.getUrl()).isEqualTo("http://example.com/foo/bar/");
+    assertThat(request.getBody()).isNull();
+  }
+
+  @Test public void headerParamToString() throws Exception {
+    Object toStringHeaderParam = new BigInteger("1234");
+    Request request = new Helper() //
+        .setMethod("GET") //
+        .setUrl("http://example.com") //
+        .setPath("/foo/bar/") //
+        .addHeaderParam("kit", toStringHeaderParam) //
+        .build();
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getHeaders()) //
+        .containsExactly(new Header("kit", "1234"));
     assertThat(request.getUrl()).isEqualTo("http://example.com/foo/bar/");
     assertThat(request.getBody()).isNull();
   }

--- a/retrofit/src/test/java/retrofit/RestMethodInfoTest.java
+++ b/retrofit/src/test/java/retrofit/RestMethodInfoTest.java
@@ -6,6 +6,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -1219,23 +1220,19 @@ public class RestMethodInfoTest {
     assertThat(methodInfo.requestParamUsage).containsExactly(HEADER, HEADER);
   }
 
-  @Test public void headerParamMustBeString() {
+  @Test public void headerConvertedToString() {
     class Example {
-      @GET("/")
-      Response a(@Header("a") TypedOutput a, @Header("b") int b) {
+      @GET("/") Response a(@Header("first") BigInteger bi) {
         return null;
       }
     }
 
     Method method = TestingUtils.getMethod(Example.class, "a");
     RestMethodInfo methodInfo = new RestMethodInfo(method);
-    try {
-      methodInfo.init();
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage(
-          "Example.a: @Header parameter type must be String. Found: TypedOutput. (parameter #1)");
-    }
+    methodInfo.init();
+
+    assertThat(methodInfo.requestParamNames).containsExactly("first");
+    assertThat(methodInfo.requestParamUsage).containsExactly(HEADER);
   }
 
   @Test public void onlyOneEncodingIsAllowedMultipartFirst() {

--- a/website/index.html
+++ b/website/index.html
@@ -114,7 +114,7 @@ List&lt;Widget> widgetList();</pre>
 @GET("/users/{username}")
 User getUser(@Path("username") String username);</pre>
             <p>Note that headers do not overwrite each other. All headers with the same name will be included in the request.</p>
-            <p>A request Header can be updated dynamically using the <code>@Header</code> annotation. A corresponding String parameter must be provided to the <code>@Header</code>. If the value is null, the header will be omitted.</p>
+            <p>A request Header can be updated dynamically using the <code>@Header</code> annotation. A corresponding parameter must be provided to the <code>@Header</code>. If the value is null, the header will be omitted. Otherwise, <code>toString</code> will be called on the value, and the result used.</p>
             <pre class="prettyprint">@GET("/user")
 void getUser(@Header("Authorization") String authorization, Callback&lt;User> callback)</pre>
             <p>Headers that need to be added to every request can be specified using a <code>RequestInterceptor</code>. The following code creates a <code>RequestInterceptor</code> that will add a <code>User-Agent</code> header to every request.</p>


### PR DESCRIPTION
toString is called on the supplied values, then used.

I included this in one of my projects that was failing, and it worked as intended.

Felt like there should've been a more end-to-end test that I could've included here, but I didn't easily see it, and I'm a bit short on time, so point it out if you feel like that needs to be added as well.
