### PR TITLE
Use charset to properly adhere to Javadoc contract.

### DIFF
--- a/retrofit/src/main/java/retrofit/converter/GsonConverter.java
+++ b/retrofit/src/main/java/retrofit/converter/GsonConverter.java
@@ -33,7 +33,7 @@ import retrofit.mime.TypedOutput;
  */
 public class GsonConverter implements Converter {
   private final Gson gson;
-  private String encoding;
+  private String charset;
 
   /**
    * Create an instance using the supplied {@link Gson} object for conversion. Encoding to JSON and
@@ -45,17 +45,17 @@ public class GsonConverter implements Converter {
 
   /**
    * Create an instance using the supplied {@link Gson} object for conversion. Encoding to JSON and
-   * decoding from JSON (when no charset is specified by a header) will use the specified encoding.
+   * decoding from JSON (when no charset is specified by a header) will use the specified charset.
    */
-  public GsonConverter(Gson gson, String encoding) {
+  public GsonConverter(Gson gson, String charset) {
     this.gson = gson;
-    this.encoding = encoding;
+    this.charset = charset;
   }
 
   @Override public Object fromBody(TypedInput body, Type type) throws ConversionException {
-    String charset = "UTF-8";
+    String charset = this.charset;
     if (body.mimeType() != null) {
-      charset = MimeUtil.parseCharset(body.mimeType());
+      charset = MimeUtil.parseCharset(body.mimeType(), charset);
     }
     InputStreamReader isr = null;
     try {
@@ -77,7 +77,7 @@ public class GsonConverter implements Converter {
 
   @Override public TypedOutput toBody(Object object) {
     try {
-      return new JsonTypedOutput(gson.toJson(object).getBytes(encoding), encoding);
+      return new JsonTypedOutput(gson.toJson(object).getBytes(charset), charset);
     } catch (UnsupportedEncodingException e) {
       throw new AssertionError(e);
     }

--- a/retrofit/src/main/java/retrofit/mime/MimeUtil.java
+++ b/retrofit/src/main/java/retrofit/mime/MimeUtil.java
@@ -23,13 +23,23 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
 public final class MimeUtil {
   private static final Pattern CHARSET = Pattern.compile("\\Wcharset=([^\\s;]+)", CASE_INSENSITIVE);
 
-  /** Parse the MIME type from a {@code Content-Type} header value. */
+  /**
+   * Parse the MIME type from a {@code Content-Type} header value or default to "UTF-8".
+   *
+   * @deprecated Use {@link #parseCharset(String, String)}.
+   */
+  @Deprecated
   public static String parseCharset(String mimeType) {
+    return parseCharset(mimeType, "UTF-8");
+  }
+
+  /** Parse the MIME type from a {@code Content-Type} header value. */
+  public static String parseCharset(String mimeType, String defaultCharset) {
     Matcher match = CHARSET.matcher(mimeType);
     if (match.find()) {
       return match.group(1).replaceAll("[\"\\\\]", "");
     }
-    return "UTF-8";
+    return defaultCharset;
   }
 
   private MimeUtil() {

--- a/retrofit/src/test/java/retrofit/mime/MimeUtilTest.java
+++ b/retrofit/src/test/java/retrofit/mime/MimeUtilTest.java
@@ -8,6 +8,20 @@ import static retrofit.mime.MimeUtil.parseCharset;
 
 public class MimeUtilTest {
   @Test public void charsetParsing() {
+    assertThat(parseCharset("text/plain;charset=utf-8", "ERROR")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; charset=utf-8", "ERROR")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain;  charset=utf-8", "ERROR")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; \tcharset=utf-8", "ERROR")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; \r\n\tcharset=utf-8", "ERROR")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; CHARSET=utf-8", "ERROR")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; charset=UTF-8", "ERROR")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; charset=\"\\u\\tf-\\8\"", "ERROR")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; charset=\"utf-8\"", "ERROR")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain;charset=utf-8;other=thing", "ERROR")).isEqualToIgnoringCase("UTF-8");
+    assertThat(parseCharset("text/plain; notthecharset=utf-16;", "UTF-8")).isEqualToIgnoringCase("UTF-8");
+  }
+
+  @Test public void oldCharsetParsing() {
     assertThat(parseCharset("text/plain;charset=utf-8")).isEqualToIgnoringCase("UTF-8");
     assertThat(parseCharset("text/plain; charset=utf-8")).isEqualToIgnoringCase("UTF-8");
     assertThat(parseCharset("text/plain;  charset=utf-8")).isEqualToIgnoringCase("UTF-8");


### PR DESCRIPTION
Closes #602.

@swankjesse 
