### PR TITLE
Add transfer encoding to multipart parts.

### DIFF
--- a/retrofit/src/main/java/retrofit/http/Part.java
+++ b/retrofit/src/main/java/retrofit/http/Part.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static retrofit.mime.MultipartTypedOutput.DEFAULT_TRANSFER_ENCODING;
 
 /**
  * Denotes a single part of a multi-part request.
@@ -53,4 +54,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 public @interface Part {
   String value();
+  /** The {@code Content-Transfer-Encoding} of this part. */
+  String encoding() default DEFAULT_TRANSFER_ENCODING;
 }

--- a/retrofit/src/main/java/retrofit/http/PartMap.java
+++ b/retrofit/src/main/java/retrofit/http/PartMap.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static retrofit.mime.MultipartTypedOutput.DEFAULT_TRANSFER_ENCODING;
 
 /**
  * Denotes name and value parts of a multi-part request
@@ -49,4 +50,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(PARAMETER)
 @Retention(RUNTIME)
 public @interface PartMap {
+  /** The {@code Content-Transfer-Encoding} of this part. */
+  String encoding() default DEFAULT_TRANSFER_ENCODING;
 }

--- a/retrofit/src/test/java/retrofit/RestMethodInfoTest.java
+++ b/retrofit/src/test/java/retrofit/RestMethodInfoTest.java
@@ -1312,6 +1312,24 @@ public class RestMethodInfoTest {
     }
   }
 
+  @Test public void multipleParameterAnnotationsNotAllowed() throws Exception {
+    class Example {
+      @GET("/") Response a(@Body @Query("nope") Object o) {
+        return null;
+      }
+    }
+
+    Method method = TestingUtils.getMethod(Example.class, "a");
+    RestMethodInfo methodInfo = new RestMethodInfo(method);
+    try {
+      methodInfo.init();
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(
+          "Example.a: Multiple Retrofit annotations found, only one allowed: @Body, @Query. (parameter #1)");
+    }
+  }
+
   private static interface ResponseCallback extends Callback<Response> {
   }
 

--- a/retrofit/src/test/java/retrofit/mime/MultipartTypedOutputTest.java
+++ b/retrofit/src/test/java/retrofit/mime/MultipartTypedOutputTest.java
@@ -28,6 +28,27 @@ public class MultipartTypedOutputTest {
     assertThat(mto.mimeType()).isEqualTo("multipart/form-data; boundary=123");
   }
 
+  @Test public void singlePartWithTransferEncoding() throws Exception {
+    String expected = "" //
+        + "--123\r\n"
+        + "Content-Disposition: form-data; name=\"greet\"\r\n"
+        + "Content-Type: text/plain; charset=UTF-8\r\n"
+        + "Content-Length: 13\r\n"
+        + "Content-Transfer-Encoding: 8-bit\r\n" //
+        + "\r\n" //
+        + "Hello, World!\r\n" //
+        + "--123--\r\n";
+
+    MultipartTypedOutput mto = new MultipartTypedOutput("123");
+    mto.addPart("greet", "8-bit", new TypedString("Hello, World!"));
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    mto.writeTo(out);
+    String actual = new String(out.toByteArray(), "UTF-8");
+    assertThat(actual).isEqualTo(expected);
+    assertThat(mto.mimeType()).isEqualTo("multipart/form-data; boundary=123");
+  }
+
   @Test public void threeParts() throws Exception {
     String expected = ""
         + "--123\r\n"


### PR DESCRIPTION
Also:
- Reject multiple annotations on method parameters.
- Pre-size StringBuilder instances to their likely size.

Closes #574.

@swankjesse 
