### PR TITLE
Support multivalues in @QueryMap and @FieldMap parameters.

### DIFF
--- a/retrofit/src/main/java/retrofit/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilder.java
@@ -185,6 +185,21 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
     if (!isSynchronous && !isObservable) {
       count -= 1;
     }
+
+    final ParamAdder queryParams = new ParamAdder() {
+      @Override
+      void addSingleParam(String name, String value, boolean urlEncodeValue) {
+        addQueryParam(name, value, urlEncodeValue);
+      }
+    };
+
+    final ParamAdder fieldParams = new ParamAdder() {
+      @Override
+      void addSingleParam(String name, String value, boolean urlEncodeValue) {
+        formBody.addField(name, value);
+      }
+    };
+
     for (int i = 0; i < count; i++) {
       String name = paramNames[i];
       Object value = args[i];
@@ -208,22 +223,7 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
         case ENCODED_QUERY:
           if (value != null) { // Skip null values.
             boolean urlEncodeValue = paramUsage == QUERY;
-            if (value instanceof Iterable) {
-              for (Object iterableValue : (Iterable<?>) value) {
-                if (iterableValue != null) { // Skip null values
-                  addQueryParam(name, iterableValue.toString(), urlEncodeValue);
-                }
-              }
-            } else if (value.getClass().isArray()) {
-              for (int x = 0, arrayLength = Array.getLength(value); x < arrayLength; x++) {
-                Object arrayValue = Array.get(value, x);
-                if (arrayValue != null) { // Skip null values
-                  addQueryParam(name, arrayValue.toString(), urlEncodeValue);
-                }
-              }
-            } else {
-              addQueryParam(name, value.toString(), urlEncodeValue);
-            }
+            queryParams.add(name, value, urlEncodeValue);
           }
           break;
         case QUERY_MAP:
@@ -233,7 +233,7 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
             for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
               Object entryValue = entry.getValue();
               if (entryValue != null) { // Skip null values.
-                addQueryParam(entry.getKey().toString(), entryValue.toString(), urlEncodeValue);
+                queryParams.add(entry.getKey().toString(), entryValue, urlEncodeValue);
               }
             }
           }
@@ -245,22 +245,7 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
           break;
         case FIELD:
           if (value != null) { // Skip null values.
-            if (value instanceof Iterable) {
-              for (Object iterableValue : (Iterable<?>) value) {
-                if (iterableValue != null) { // Skip null values.
-                  formBody.addField(name, iterableValue.toString());
-                }
-              }
-            } else if (value.getClass().isArray()) {
-              for (int x = 0, arrayLength = Array.getLength(value); x < arrayLength; x++) {
-                Object arrayValue = Array.get(value, x);
-                if (arrayValue != null) { // Skip null values.
-                  formBody.addField(name, arrayValue.toString());
-                }
-              }
-            } else {
-              formBody.addField(name, value.toString());
-            }
+            fieldParams.add(name, value);
           }
           break;
         case FIELD_MAP:
@@ -268,7 +253,7 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
             for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
               Object entryValue = entry.getValue();
               if (entryValue != null) { // Skip null values.
-                formBody.addField(entry.getKey().toString(), entryValue.toString());
+                fieldParams.add(entry.getKey().toString(), entryValue.toString());
               }
             }
           }
@@ -317,7 +302,7 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
     }
   }
 
-  Request build() throws UnsupportedEncodingException {
+  Request build() {
     if (multipartBody != null && multipartBody.getPartCount() == 0) {
       throw new IllegalStateException("Multipart requests must contain at least one part.");
     }
@@ -378,5 +363,33 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
     @Override public void writeTo(OutputStream out) throws IOException {
       delegate.writeTo(out);
     }
+  }
+
+  private abstract static class ParamAdder {
+
+    void add(String name, Object value, boolean urlEncodeValue) {
+      if (value instanceof Iterable) {
+        for (Object iterableValue : (Iterable<?>) value) {
+          if (iterableValue != null) { // Skip null values
+            addSingleParam(name, iterableValue.toString(), urlEncodeValue);
+          }
+        }
+      } else if (value.getClass().isArray()) {
+        for (int x = 0, arrayLength = Array.getLength(value); x < arrayLength; x++) {
+          Object arrayValue = Array.get(value, x);
+          if (arrayValue != null) { // Skip null values
+            addSingleParam(name, arrayValue.toString(), urlEncodeValue);
+          }
+        }
+      } else {
+        addSingleParam(name, value.toString(), urlEncodeValue);
+      }
+    }
+
+    void add(String name, Object value) {
+      add(name, value, false);
+    }
+
+    abstract void addSingleParam(String name, String value, boolean urlEncodeValue);
   }
 }

--- a/retrofit/src/main/java/retrofit/http/FieldMap.java
+++ b/retrofit/src/main/java/retrofit/http/FieldMap.java
@@ -36,6 +36,15 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </pre>
  * Calling with {@code foo.things(ImmutableMap.of("foo", "bar", "kit", "kat")} yields a request
  * body of {@code foo=bar&kit=kat}.
+ * <p>
+ * Iterable example:
+ * <pre>
+ * &#64;FormUrlEncoded
+ * &#64;POST("/things")
+ * void things(@FieldMap Map&lt;String, Iterable&lt;String&gt;&gt; fields);
+ * </pre>
+ * Calling with {@code foo.things(ImmutableMap.of("foo", ImmutableSet.of("bar", "baz")))} yields
+ * a request body of {@code foo=bar&foo=baz}.
  *
  * @see FormUrlEncoded
  * @see Field

--- a/retrofit/src/main/java/retrofit/http/QueryMap.java
+++ b/retrofit/src/main/java/retrofit/http/QueryMap.java
@@ -27,6 +27,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>
  * Both keys and values are converted to strings using {@link String#valueOf(Object)}. Values are
  * URL encoded and {@code null} will not include the query parameter in the URL.
+ * Passing an {@link java.lang.Iterable Iterable} or array as a value will result in a query
+ * parameter for each non-{@code null} item.
  * <p>
  * Simple Example:
  * <pre>
@@ -35,6 +37,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </pre>
  * Calling with {@code foo.list(ImmutableMap.of("foo", "bar", "kit", "kat"))} yields
  * {@code /search?foo=bar&kit=kat}.
+ * <p>
+ * Iterable example:
+ * <pre>
+ * &#64;GET("/search")
+ * void list(@QueryMap Map&lt;String, Iterable&lt;String&gt;&gt; filters);
+ * </pre>
+ * Calling with {@code foo.list(ImmutableMap.of("foo", ImmutableSet.of("bar", "baz")))} yields
+ * {@code /search?foo=bar&foo=baz}.
  *
  * @see Query
  * @see QueryMap

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -369,6 +369,24 @@ public class RequestBuilderTest {
     assertThat(request.getBody()).isNull();
   }
 
+  @Test public void getWithQueryParamsMap() throws Exception {
+    Map<String, Object> params = new LinkedHashMap<String, Object>();
+    params.put("k1", Arrays.asList(1, 2, null, "3"));
+    params.put("k2", new Object[] {1, 2, null, "3"});
+    params.put("k3", new int[] {1, 2});
+
+    Request request = new Helper() //
+        .setMethod("GET") //
+        .setUrl("http://example.com") //
+        .setPath("/foo/") //
+        .addQueryMapParams("options", params) //
+        .build();
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getHeaders()).isEmpty();
+    assertThat(request.getUrl()).isEqualTo("http://example.com/foo/?k1=1&k1=2&k1=3&k2=1&k2=2&k2=3&k3=1&k3=2");
+    assertThat(request.getBody()).isNull();
+  }
+
   @Test public void getWithEncodedQueryParamMap() throws Exception {
     Map<String, Object> params = new LinkedHashMap<String, Object>();
     params.put("kit", "k%20t");


### PR DESCRIPTION
Hi,

We propose the following pull-request which adds the possibility to use a Map<?, Iterable<?>> for query and/or field parameters.

Background: We have quite complex HTTP parameters and thus use Guava's Multimaps for manipulating those. Passing such values using Multimap.asMap() to Retrofit would be very convienient.

Retrofit already supports Iterables for regular Query parameters. This pull-request extends this semantics for QueryMaps too.

Thanks,
Sergiusz Urbaniak & Alex Thurm
