### PR TITLE
Added Codecov.io coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: java
 
+before_install: sudo pip install codecov
+
 branches:
   except:
     - gh-pages
 
 notifications:
   email: false
+
+after_success: codecov

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.5.8.201207111220</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Hey Friends! I'm from [Codecov.io](https://codecov.io/) and I wanted to personally add our coverage reporting tools to retrofit. 

You can see the live reports here: [codecov.io/github/stevepeak/retrofit](https://codecov.io/github/stevepeak/retrofit?ref=1e14167583a64ac3fd18adf2353af60297f4df06) 

[![codecov.io](https://codecov.io/github/stevepeak/retrofit/coverage.svg?branch=master)](https://codecov.io/github/stevepeak/retrofit?branch=master)

I'm excited to hear your feedback! Thank you for your time.
