### PR TITLE
Use the annotations directly for parameter handling.

### DIFF
--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -54,9 +54,7 @@ import retrofit.mime.TypedOutput;
  * Method parameters can be used to replace parts of the URL by annotating them with
  * {@link retrofit.http.Path @Path}. Replacement sections are denoted by an identifier surrounded
  * by curly braces (e.g., "{foo}"). To add items to the query string of a URL use
- * {@link retrofit.http.Query @Query}. If the path or query element has already been URI encoded
- * use {@link retrofit.http.EncodedPath @EncodedPath} or
- * {@link retrofit.http.EncodedQuery @EncodedQuery} to prevent repeated encoding.
+ * {@link retrofit.http.Query @Query}.
  * <p>
  * HTTP requests happen in one of two ways:
  * <ul>

--- a/retrofit/src/main/java/retrofit/http/EncodedPath.java
+++ b/retrofit/src/main/java/retrofit/http/EncodedPath.java
@@ -33,8 +33,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </pre>
  * <p>
  * Path parameters may not be {@code null}.
+ *
+ * @see Path
+ * @deprecated Use {@link Path} with {@link Path#encode() encode = false}.
  */
 @Documented
+@Deprecated
 @Retention(RUNTIME)
 @Target(PARAMETER)
 public @interface EncodedPath {

--- a/retrofit/src/main/java/retrofit/http/EncodedQuery.java
+++ b/retrofit/src/main/java/retrofit/http/EncodedQuery.java
@@ -31,9 +31,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see Query
  * @see QueryMap
- * @see EncodedQueryMap
+ * @deprecated Use {@link Query} with {@link Query#encodeValue() encodeValue = false}.
  */
 @Documented
+@Deprecated
 @Target(PARAMETER)
 @Retention(RUNTIME)
 public @interface EncodedQuery {

--- a/retrofit/src/main/java/retrofit/http/EncodedQueryMap.java
+++ b/retrofit/src/main/java/retrofit/http/EncodedQueryMap.java
@@ -31,9 +31,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see Query
  * @see QueryMap
- * @see EncodedQuery
+ * @deprecated Use {@link QueryMap} with {@link QueryMap#encodeValues() encodeValues = false}.
  */
 @Documented
+@Deprecated
 @Target(PARAMETER)
 @Retention(RUNTIME)
 public @interface EncodedQueryMap {

--- a/retrofit/src/main/java/retrofit/http/Path.java
+++ b/retrofit/src/main/java/retrofit/http/Path.java
@@ -24,12 +24,25 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Named replacement in the URL path. Values are converted to string using
- * {@link String#valueOf(Object)}. Replaced values will be URL encoded.
+ * {@link String#valueOf(Object)} and URL encoded.
  * <p>
+ * Simple example:
  * <pre>
  * &#64;GET("/image/{id}")
- * void example(@Path("id") int id, ..);
+ * void example(@Path("id") int id);
  * </pre>
+ * Calling with {@code foo.example(1)} yields {@code /image/1}.
+ * <p>
+ * Values are URL encoded by default. Disable with {@code encode=false}.
+ * <pre>
+ * &#64;GET("/user/{name}")
+ * void encoded(@Path("name") String name);
+ *
+ * &#64;GET("/user/{name}")
+ * void notEncoded(@Path(value="name", encode=false) String name);
+ * </pre>
+ * Calling {@code foo.encoded("John+Doe")} yields {@code /user/John%2BDoe} whereas
+ * {@code foo.notEncoded("John+Doe")} yields {@code /user/John+Doe}.
  * <p>
  * Path parameters may not be {@code null}.
  */
@@ -38,4 +51,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(PARAMETER)
 public @interface Path {
   String value();
+
+  /** Specifies whether the argument value to the annotated method parameter is URL encoded. */
+  boolean encode() default true;
 }

--- a/retrofit/src/main/java/retrofit/http/Query.java
+++ b/retrofit/src/main/java/retrofit/http/Query.java
@@ -50,14 +50,35 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </pre>
  * Calling with {@code foo.list("bar", "baz")} yields
  * {@code /list?category=foo&category=bar}.
+ * <p>
+ * Parameter names are not URL encoded. Specify {@link #encodeName() encodeName=true} to change
+ * this behavior.
+ * <pre>
+ * &#64;GET("/search")
+ * void list(@Query(value="foo+bar", encodeName=true) String foobar);
+ * </pre>
+ * Calling with {@code foo.list("baz")} yields {@code /search?foo%2Bbar=foo}.
+ * <p>
+ * Parameter values are URL encoded by default. Specify {@link #encodeValue() encodeValue=false} to
+ * change this behavior.
+ * <pre>
+ * &#64;GET("/search")
+ * void list(@Query(value="foo", encodeValue=false) String foo);
+ * </pre>
+ * Calling with {@code foo.list("foo+foo"))} yields {@code /search?foo=foo+bar}.
  *
- * @see EncodedQuery
  * @see QueryMap
- * @see EncodedQueryMap
  */
 @Documented
 @Target(PARAMETER)
 @Retention(RUNTIME)
 public @interface Query {
+  /** The query parameter name. */
   String value();
+
+  /** Specifies whether {@link #value()} is URL encoded. */
+  boolean encodeName() default false;
+
+  /** Specifies whether the argument value to the annotated method parameter is URL encoded. */
+  boolean encodeValue() default true;
 }

--- a/retrofit/src/main/java/retrofit/http/QueryMap.java
+++ b/retrofit/src/main/java/retrofit/http/QueryMap.java
@@ -26,7 +26,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Query parameter keys and values appended to the URL.
  * <p>
  * Both keys and values are converted to strings using {@link String#valueOf(Object)}. Values are
- * URL encoded and {@code null} will not include the query parameter in the URL.
+ * URL encoded and {@code null} will not include the query parameter in the URL. {@code null} keys
+ * are not allowed.
  * <p>
  * Simple Example:
  * <pre>
@@ -35,13 +36,34 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </pre>
  * Calling with {@code foo.list(ImmutableMap.of("foo", "bar", "kit", "kat"))} yields
  * {@code /search?foo=bar&kit=kat}.
+ * <p>
+ * Map keys representing the parameter names are not URL encoded. Specify
+ * {@link #encodeNames() encodeNames=true} to change this behavior.
+ * <pre>
+ * &#64;GET("/search")
+ * void list(@QueryMap(encodeNames=true) Map&lt;String, String&gt; filters);
+ * </pre>
+ * Calling with {@code foo.list(ImmutableMap.of("foo+bar", "foo+bar"))} yields
+ * {@code /search?foo%2Bbar=foo}.
+ * <p>
+ * Map values representing parameter values are URL encoded by default. Specify
+ * {@link #encodeValues() encodeValues=false} to change this behavior.
+ * <pre>
+ * &#64;GET("/search")
+ * void list(@QueryMap(encodeValues=false) Map&lt;String, String&gt; filters);
+ * </pre>
+ * Calling with {@code foo.list(ImmutableMap.of("foo", "foo+foo"))} yields
+ * {@code /search?foo=foo%2Bbar}.
  *
  * @see Query
- * @see QueryMap
- * @see EncodedQueryMap
  */
 @Documented
 @Target(PARAMETER)
 @Retention(RUNTIME)
 public @interface QueryMap {
+  /** Specifies whether parameter names (keys in the map) are URL encoded. */
+  boolean encodeNames() default false;
+
+  /** Specifies whether parameter values (values in the map) are URL encoded. */
+  boolean encodeValues() default true;
 }

--- a/retrofit/src/test/java/retrofit/RestMethodInfoTest.java
+++ b/retrofit/src/test/java/retrofit/RestMethodInfoTest.java
@@ -51,7 +51,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     assertThat(methodInfo.isSynchronous).isFalse();
     assertThat(methodInfo.responseObjectType).isEqualTo(Response.class);
@@ -63,7 +63,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     assertThat(methodInfo.isSynchronous).isFalse();
     assertThat(methodInfo.responseObjectType).isEqualTo(Response.class);
@@ -75,7 +75,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     assertThat(methodInfo.isSynchronous).isFalse();
     assertThat(methodInfo.responseObjectType).isEqualTo(Response.class);
@@ -87,7 +87,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     assertThat(methodInfo.isSynchronous).isFalse();
     assertThat(methodInfo.responseObjectType).isEqualTo(Response.class);
@@ -99,7 +99,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     assertThat(methodInfo.isSynchronous).isFalse();
     assertThat(methodInfo.responseObjectType).isEqualTo(Response.class);
@@ -111,7 +111,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     assertThat(methodInfo.isSynchronous).isFalse();
 
@@ -129,7 +129,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     assertThat(methodInfo.isSynchronous).isFalse();
     assertThat(methodInfo.responseObjectType).isEqualTo(
@@ -143,7 +143,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     assertThat(methodInfo.isSynchronous).isTrue();
     assertThat(methodInfo.responseObjectType).isEqualTo(Response.class);
@@ -156,7 +156,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     assertThat(methodInfo.isSynchronous).isTrue();
 
@@ -171,7 +171,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     methodInfo.init();
 
@@ -185,7 +185,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     methodInfo.init();
 
@@ -200,7 +200,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     assertThat(methodInfo.isSynchronous).isFalse();
     assertThat(methodInfo.isObservable).isTrue();
@@ -214,7 +214,7 @@ public class RestMethodInfoTest {
       }
     }
 
-    Method method = TestingUtils.getMethod(Example.class, "a");
+    Method method = TestingUtils.onlyMethod(Example.class);
     RestMethodInfo methodInfo = new RestMethodInfo(method);
     assertThat(methodInfo.isSynchronous).isFalse();
     assertThat(methodInfo.isObservable).isTrue();

--- a/retrofit/src/test/java/retrofit/TestingUtils.java
+++ b/retrofit/src/test/java/retrofit/TestingUtils.java
@@ -11,13 +11,12 @@ import retrofit.mime.TypedOutput;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class TestingUtils {
-  public static Method getMethod(Class c, String name) {
-    for (Method method : c.getDeclaredMethods()) {
-      if (method.getName().equals(name)) {
-        return method;
-      }
+  public static Method onlyMethod(Class c) {
+    Method[] declaredMethods = c.getDeclaredMethods();
+    if (declaredMethods.length == 1) {
+      return declaredMethods[0];
     }
-    throw new IllegalArgumentException("Unknown method '" + name + "' on " + c);
+    throw new IllegalArgumentException("More than one method declared.");
   }
 
   public static TypedOutput createMultipart(Map<String, TypedOutput> parts) {


### PR DESCRIPTION
Before we attempted to normalize the parameter annotations into a name and type model. The introduction of multi-part transfer encodings required something more expressive so the annotation instances themselves were used. This change removes the name and type in favor of using the annotation for everything.

Deprecate the pre-encoded annotations in favor of boolean fields on the corresponding 'regular' annotation.

@swankjesse 
