### PR TITLE
Provide explicit error kind for disambiguation of underlying cause.

### DIFF
--- a/retrofit-mock/src/main/java/retrofit/MockHttpRetrofitError.java
+++ b/retrofit-mock/src/main/java/retrofit/MockHttpRetrofitError.java
@@ -9,7 +9,7 @@ class MockHttpRetrofitError extends RetrofitError {
 
   MockHttpRetrofitError(String message, String url, Response response, Object body,
       Type responseType) {
-    super(message, url, response, null, responseType, false, null);
+    super(message, url, response, null, responseType, Kind.HTTP, null);
     this.body = body;
   }
 

--- a/retrofit-mock/src/test/java/retrofit/MockRestAdapterTest.java
+++ b/retrofit-mock/src/test/java/retrofit/MockRestAdapterTest.java
@@ -232,7 +232,7 @@ public class MockRestAdapterTest {
       mockService.doStuff();
       fail();
     } catch (RetrofitError e) {
-      assertThat(e.isNetworkError()).isTrue();
+      assertThat(e.getKind()).isEqualTo(RetrofitError.Kind.NETWORK);
       assertThat(e.getCause()).hasMessage("Mock network error!");
     }
   }
@@ -264,7 +264,7 @@ public class MockRestAdapterTest {
     verify(callbackExecutor).execute(any(Runnable.class));
 
     RetrofitError error = errorRef.get();
-    assertThat(error.isNetworkError()).isTrue();
+    assertThat(error.getKind()).isEqualTo(RetrofitError.Kind.NETWORK);
     assertThat(error.getCause()).hasMessage("Mock network error!");
   }
 
@@ -395,7 +395,7 @@ public class MockRestAdapterTest {
     } catch (RetrofitError e) {
       long tookMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
       assertThat(tookMs).isGreaterThanOrEqualTo(100);
-      assertThat(e.isNetworkError()).isFalse();
+      assertThat(e.getKind()).isEqualTo(RetrofitError.Kind.HTTP);
       assertThat(e.getResponse().getStatus()).isEqualTo(404);
       assertThat(e.getResponse().getReason()).isEqualTo("Not Found");
       assertThat(e.getBody()).isSameAs(expected);
@@ -438,7 +438,7 @@ public class MockRestAdapterTest {
 
     RetrofitError error = errorRef.get();
     assertThat(tookMs.get()).isGreaterThanOrEqualTo(100);
-    assertThat(error.isNetworkError()).isFalse();
+    assertThat(error.getKind()).isEqualTo(RetrofitError.Kind.HTTP);
     assertThat(error.getResponse().getStatus()).isEqualTo(404);
     assertThat(error.getResponse().getReason()).isEqualTo("Not Found");
     assertThat(error.getBody()).isSameAs(expected);
@@ -482,7 +482,7 @@ public class MockRestAdapterTest {
 
     RetrofitError error = errorRef.get();
     assertThat(tookMs.get()).isGreaterThanOrEqualTo(100);
-    assertThat(error.isNetworkError()).isFalse();
+    assertThat(error.getKind()).isEqualTo(RetrofitError.Kind.HTTP);
     assertThat(error.getResponse().getStatus()).isEqualTo(404);
     assertThat(error.getResponse().getReason()).isEqualTo("Not Found");
     assertThat(error.getBody()).isSameAs(expected);
@@ -523,7 +523,7 @@ public class MockRestAdapterTest {
 
     RetrofitError error = errorRef.get();
     assertThat(tookMs.get()).isGreaterThanOrEqualTo(100);
-    assertThat(error.isNetworkError()).isFalse();
+    assertThat(error.getKind()).isEqualTo(RetrofitError.Kind.HTTP);
     assertThat(error.getResponse().getStatus()).isEqualTo(400);
     assertThat(error.getResponse().getReason()).isEqualTo("Bad Request");
     assertThat(error.getBody()).isNull();

--- a/retrofit/src/test/java/retrofit/RestAdapterTest.java
+++ b/retrofit/src/test/java/retrofit/RestAdapterTest.java
@@ -446,6 +446,7 @@ public class RestAdapterTest {
       example.something();
       fail("RetrofitError expected on malformed response body.");
     } catch (RetrofitError e) {
+      assertThat(e.getKind()).isEqualTo(RetrofitError.Kind.CONVERSION);
       assertThat(e.getResponse().getStatus()).isEqualTo(200);
       assertThat(e.getCause()).isInstanceOf(ConversionException.class);
       assertThat(e.getResponse().getBody()).isNull();
@@ -460,6 +461,7 @@ public class RestAdapterTest {
       example.something();
       fail("RetrofitError expected on non-2XX response code.");
     } catch (RetrofitError e) {
+      assertThat(e.getKind()).isEqualTo(RetrofitError.Kind.HTTP);
       assertThat(e.getResponse().getStatus()).isEqualTo(500);
       assertThat(e.getSuccessType()).isEqualTo(String.class);
     }
@@ -553,6 +555,7 @@ public class RestAdapterTest {
       example.something();
       fail("RetrofitError expected when client throws exception.");
     } catch (RetrofitError e) {
+      assertThat(e.getKind()).isEqualTo(RetrofitError.Kind.NETWORK);
       assertThat(e.getCause()).isSameAs(exception);
     }
   }
@@ -573,6 +576,7 @@ public class RestAdapterTest {
       example.something();
       fail("RetrofitError expected on malformed response body.");
     } catch (RetrofitError e) {
+      assertThat(e.getKind()).isEqualTo(RetrofitError.Kind.NETWORK);
       assertThat(e.isNetworkError());
       assertThat(e.getCause()).isInstanceOf(IOException.class);
       assertThat(e.getCause()).hasMessage("I'm broken!");
@@ -587,6 +591,7 @@ public class RestAdapterTest {
       example.something();
       fail("RetrofitError expected when unexpected exception thrown.");
     } catch (RetrofitError e) {
+      assertThat(e.getKind()).isEqualTo(RetrofitError.Kind.UNEXPECTED);
       assertThat(e.getCause()).isSameAs(exception);
     }
   }


### PR DESCRIPTION
Closes #560 

@swankjesse 
