### PR TITLE
Remove endpoint names.

### DIFF
--- a/retrofit/src/main/java/retrofit/Endpoint.java
+++ b/retrofit/src/main/java/retrofit/Endpoint.java
@@ -7,11 +7,6 @@ package retrofit;
  * @author Matt Hickman (mhickman@palantir.com)
  */
 public interface Endpoint {
-
   /** The base API URL. */
   String getUrl();
-
-  /** A name for differentiating between multiple API URLs. */
-  String getName();
-
 }

--- a/retrofit/src/main/java/retrofit/Endpoints.java
+++ b/retrofit/src/main/java/retrofit/Endpoints.java
@@ -6,36 +6,15 @@ package retrofit;
  * @author Matt Hickman (mhickman@palantir.com)
  */
 public final class Endpoints {
-  private static final String DEFAULT_NAME = "default";
-
   private Endpoints() {
   }
 
   /** Create a server with the provided URL. */
-  public static Endpoint newFixedEndpoint(String url) {
-    return new FixedEndpoint(url, DEFAULT_NAME);
-  }
-
-  /** Create an endpoint with the provided URL and name. */
-  public static Endpoint newFixedEndpoint(String url, String name) {
-    return new FixedEndpoint(url, name);
-  }
-
-  private static class FixedEndpoint implements Endpoint {
-    private final String apiUrl;
-    private final String name;
-
-    FixedEndpoint(String apiUrl, String name) {
-      this.apiUrl = apiUrl;
-      this.name = name;
-    }
-
-    @Override public String getUrl() {
-      return apiUrl;
-    }
-
-    @Override public String getName() {
-      return name;
-    }
+  public static Endpoint newFixedEndpoint(final String url) {
+    return new Endpoint() {
+      @Override public String getUrl() {
+        return url;
+      }
+    };
   }
 }

--- a/retrofit/src/test/java/retrofit/EndpointsTest.java
+++ b/retrofit/src/test/java/retrofit/EndpointsTest.java
@@ -6,14 +6,8 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class EndpointsTest {
-  @Test public void endpointOnly() {
+  @Test public void endpoint() {
     Endpoint endpoint = Endpoints.newFixedEndpoint("http://example.com");
     assertThat(endpoint.getUrl()).isEqualTo("http://example.com");
-  }
-
-  @Test public void endpointAndName() {
-    Endpoint endpoint = Endpoints.newFixedEndpoint("http://example.com", "production");
-    assertThat(endpoint.getUrl()).isEqualTo("http://example.com");
-    assertThat(endpoint.getName()).isEqualTo("production");
   }
 }


### PR DESCRIPTION
This isn't the right granularity of data about an endpoint and we never exposed this anywhere in the actual library.

@swankjesse 
