### PR TITLE
Add SimpleCallback for lazzy

### DIFF
--- a/retrofit/src/main/java/retrofit/SimpleCallback.java
+++ b/retrofit/src/main/java/retrofit/SimpleCallback.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import retrofit.client.Response;
+
+/**
+ * A {@link Callback} wrapper for lazzy.
+ *
+ * Communicates responses from a server or offline requests. One and only one method will be
+ * invoked in response to a given request.
+ * <p>
+ * Callback methods are executed using the {@link RestAdapter} callback executor. When none is
+ * specified, the following defaults are used:
+ * <ul>
+ * <li>Android: Callbacks are executed on the application's main (UI) thread.</li>
+ * <li>JVM: Callbacks are executed on the background thread which performed the request.</li>
+ * </ul>
+ *
+ * @param <T> expected response type
+ * @see RestAdapter.Builder#setExecutors
+ */
+public class SimpleCallback<T> implements Callback<T> {
+
+    /** Successful HTTP response. */
+    @Override
+    public void success(T t, Response response) {
+    }
+
+    /**
+     * Unsuccessful HTTP response due to network failure, non-2XX status code, or unexpected
+     * exception.
+     */
+    @Override
+    public void failure(RetrofitError error) {
+    }
+}


### PR DESCRIPTION
For example:

```java
service.createUser(user, new SimpleCallback<User>()); // No need implementation if you are lazzy
```