### PR TITLE
Provide a setter to set SimpleXml strict mode to false

### DIFF
--- a/retrofit-converters/simplexml/src/main/java/retrofit/converter/SimpleXMLConverter.java
+++ b/retrofit-converters/simplexml/src/main/java/retrofit/converter/SimpleXMLConverter.java
@@ -23,14 +23,19 @@ public class SimpleXMLConverter implements Converter {
 
   private final Serializer serializer;
 
-  private boolean strict = true;
+  private final boolean strict;
 
   public SimpleXMLConverter() {
     this(new Persister());
   }
 
   public SimpleXMLConverter(Serializer serializer) {
-    this.serializer = serializer;
+    this(serializer, true);
+  }
+
+  public SimpleXMLConverter(Serializer serializer, boolean strict) {
+      this.serializer = serializer;
+      this.strict = strict;
   }
 
   @Override public Object fromBody(TypedInput body, Type type) throws ConversionException {
@@ -65,10 +70,6 @@ public class SimpleXMLConverter implements Converter {
 
   public boolean isStrict() {
       return strict;
-  }
-
-  public void setStrict(boolean strict) {
-      this.strict = strict;
   }
 
 }


### PR DESCRIPTION
The SimpleXMLConverter defaults to using Simple XML's strict mode. The problem with strict mode is that if a new attribute appears on the server that's not mapped on the client, an exception gets thrown. I've added a setter to allow us to set strict to false to override the default behavior. 
