### PR TITLE
Added null-check for cases when a null body is being logged

### DIFF
--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -482,7 +482,7 @@ public class RestAdapter {
   private void logResponseBody(TypedInput body, Object convert) {
     if (logLevel.ordinal() == LogLevel.HEADERS_AND_ARGS.ordinal()) {
       log.log("<--- BODY:");
-      log.log(convert.toString());
+      log.log(convert != null ? convert.toString() : "null");
     }
   }
 


### PR DESCRIPTION
I came across a NullPointerException which resulted from an attempt to log a null body. When using Retrofit with Rx, it results in whole request failing and onError() being called; turning logs off solved this problem.