### PR TITLE
shorten Thread name by removing query string

### DIFF
--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -301,8 +301,8 @@ public class RestAdapter {
 
         if (!methodInfo.isSynchronous) {
           // If we are executing asynchronously then update the current thread with a useful name.
-          int substrEnd = url.indexOf("?");
-          if (substrEnd < serverUrl.length()) {
+          int substrEnd = url.indexOf("?", serverUrl.length());
+          if (substrEnd == -1) {
             substrEnd = url.length();
           }
           Thread.currentThread().setName(THREAD_PREFIX


### PR DESCRIPTION
Services that require giant base64-encoded tokens be thrown around in the query string can make debugging threads painful when the URL isn't trimmed.
