### PR TITLE
Fixes NPE when log level set at HEADERS_AND_ARGS

### DIFF
--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -487,7 +487,7 @@ public class RestAdapter {
   private void logResponseBody(TypedInput body, Object convert) {
     if (logLevel.ordinal() == LogLevel.HEADERS_AND_ARGS.ordinal()) {
       log.log("<--- BODY:");
-      log.log(convert.toString());
+      log.log(convert == null ? "no content" : convert.toString());
     }
   }
 


### PR DESCRIPTION
The NPE is triggered receiving a response when log level is set at HEADERS_AND_ARGS and the response body is empty.

Also, should it log the body too when level is FULL?