### PR TITLE
Including Ekstazi (ekstazi.org) profile to optimize execution of the tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,38 @@
     </dependencies>
   </dependencyManagement>
 
+  <profiles>
+    <!-- Ekstazi (www.ekstazi.org) profile to optimize regression testing -->
+    <profile>
+      <id>ekstazi</id>
+      <activation>
+        <property>
+          <name>ekstazi</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.ekstazi</groupId>
+            <artifactId>ekstazi-maven-plugin</artifactId>
+            <version>4.5.2</version>
+            <configuration>
+              <forcefailing>true</forcefailing>
+            </configuration>
+            <executions>
+              <execution>
+                <id>ekstazi</id>
+                <goals>
+                  <goal>select</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
Ekstazi allows to speed up regression testing by only executing tests that were affected by the changes that were made since the last test run. To run the tests with Ekstazi with my patch to pom.xml, one should use ```mvn test -Pekstazi```.