### PR TITLE
Changing constructor and internal class visibility to protected

### DIFF
--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -157,7 +157,7 @@ public class RestAdapter {
 
   volatile LogLevel logLevel;
 
-  private RestAdapter(Endpoint server, Client client, Executor httpExecutor,
+  protected RestAdapter(Endpoint server, Client client, Executor httpExecutor,
       Executor callbackExecutor, RequestInterceptor requestInterceptor, Converter converter,
       ErrorHandler errorHandler, Log log, LogLevel logLevel) {
     this.server = server;
@@ -214,7 +214,7 @@ public class RestAdapter {
     }
   }
 
-  private class RestHandler implements InvocationHandler {
+  protected class RestHandler implements InvocationHandler {
     private final Map<Method, RestMethodInfo> methodDetailsCache;
 
     RestHandler(Map<Method, RestMethodInfo> methodDetailsCache) {


### PR DESCRIPTION
Currently the constructor is private to enforce the use of the builder, however this prevents the extension of the class, making it de facto final. Changing the visibility to protected would still require to use the builder while allowing for developers to extend the class to provide custom caching solutions for instance.