### PR TITLE
Simplify custom HTTP method implementation.

### DIFF
--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -31,6 +31,7 @@ import retrofit.client.Request;
 import retrofit.client.Response;
 import retrofit.converter.ConversionException;
 import retrofit.converter.Converter;
+import retrofit.http.HTTP;
 import retrofit.http.Header;
 import retrofit.mime.TypedInput;
 import retrofit.mime.TypedOutput;
@@ -43,10 +44,9 @@ import retrofit.mime.TypedOutput;
  * <p>
  * The relative path for a given method is obtained from an annotation on the method describing
  * the request type. The built-in methods are {@link retrofit.http.GET GET},
- * {@link retrofit.http.PUT PUT}, {@link retrofit.http.POST POST}, {@link retrofit.http.HEAD HEAD},
- * and {@link retrofit.http.DELETE DELETE}. You can define your own HTTP method by creating an
- * annotation that takes a {code String} value and itself is annotated with
- * {@link retrofit.http.RestMethod @RestMethod}.
+ * {@link retrofit.http.PUT PUT}, {@link retrofit.http.POST POST}, {@link retrofit.http.POST PATCH},
+ * {@link retrofit.http.HEAD HEAD}, and {@link retrofit.http.DELETE DELETE}. You can use a custom
+ * HTTP method with {@link HTTP @HTTP}.
  * <p>
  * Method parameters can be used to replace parts of the URL by annotating them with
  * {@link retrofit.http.Path @Path}. Replacement sections are denoted by an identifier surrounded

--- a/retrofit/src/main/java/retrofit/http/DELETE.java
+++ b/retrofit/src/main/java/retrofit/http/DELETE.java
@@ -26,7 +26,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Target(METHOD)
 @Retention(RUNTIME)
-@RestMethod("DELETE")
 public @interface DELETE {
   String value();
 }

--- a/retrofit/src/main/java/retrofit/http/GET.java
+++ b/retrofit/src/main/java/retrofit/http/GET.java
@@ -26,7 +26,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Target(METHOD)
 @Retention(RUNTIME)
-@RestMethod("GET")
 public @interface GET {
   String value();
 }

--- a/retrofit/src/main/java/retrofit/http/HEAD.java
+++ b/retrofit/src/main/java/retrofit/http/HEAD.java
@@ -26,7 +26,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Target(METHOD)
 @Retention(RUNTIME)
-@RestMethod("HEAD")
 public @interface HEAD {
   String value();
 }

--- a/retrofit/src/main/java/retrofit/http/HTTP.java
+++ b/retrofit/src/main/java/retrofit/http/HTTP.java
@@ -19,13 +19,14 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Documented
-@Target(ANNOTATION_TYPE)
+@Target(METHOD)
 @Retention(RUNTIME)
-public @interface RestMethod {
-  String value();
+public @interface HTTP {
+  String method();
+  String path();
   boolean hasBody() default false;
 }

--- a/retrofit/src/main/java/retrofit/http/PATCH.java
+++ b/retrofit/src/main/java/retrofit/http/PATCH.java
@@ -26,7 +26,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Target(METHOD)
 @Retention(RUNTIME)
-@RestMethod(value = "PATCH", hasBody = true)
 public @interface PATCH {
   String value();
 }

--- a/retrofit/src/main/java/retrofit/http/POST.java
+++ b/retrofit/src/main/java/retrofit/http/POST.java
@@ -26,7 +26,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Target(METHOD)
 @Retention(RUNTIME)
-@RestMethod(value = "POST", hasBody = true)
 public @interface POST {
   String value();
 }

--- a/retrofit/src/main/java/retrofit/http/PUT.java
+++ b/retrofit/src/main/java/retrofit/http/PUT.java
@@ -26,7 +26,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Target(METHOD)
 @Retention(RUNTIME)
-@RestMethod(value = "PUT", hasBody = true)
 public @interface PUT {
   String value();
 }

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -4,9 +4,6 @@ package retrofit;
 import com.google.gson.Gson;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -26,6 +23,7 @@ import retrofit.http.FieldMap;
 import retrofit.http.FormUrlEncoded;
 import retrofit.http.GET;
 import retrofit.http.HEAD;
+import retrofit.http.HTTP;
 import retrofit.http.Headers;
 import retrofit.http.Multipart;
 import retrofit.http.PATCH;
@@ -36,7 +34,6 @@ import retrofit.http.PartMap;
 import retrofit.http.Path;
 import retrofit.http.Query;
 import retrofit.http.QueryMap;
-import retrofit.http.RestMethod;
 import retrofit.http.Streaming;
 import retrofit.mime.MimeHelper;
 import retrofit.mime.MultipartTypedOutput;
@@ -46,8 +43,6 @@ import retrofit.mime.TypedString;
 import rx.Observable;
 
 import static com.google.common.base.Charsets.UTF_8;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
@@ -55,38 +50,9 @@ import static org.junit.Assert.fail;
 public class RequestBuilderTest {
   private RequestInterceptor interceptor;
 
-  @RestMethod("BAD")
-  @Target(METHOD) @Retention(RUNTIME)
-  private @interface BAD_CUSTOM {
-    int value();
-  }
-
-  @Test public void customWithoutRestMethod() {
-    class Example {
-      @BAD_CUSTOM(12) //
-      Response method() {
-        return null;
-      }
-    }
-
-    try {
-      buildRequest(Example.class);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage(
-          "Example.method: Failed to extract String 'value' from @BAD_CUSTOM annotation.");
-    }
-  }
-
-  @RestMethod("CUSTOM1")
-  @Target(METHOD) @Retention(RUNTIME)
-  private @interface CUSTOM1 {
-    String value();
-  }
-
   @Test public void custom1Method() {
     class Example {
-      @CUSTOM1("/foo") //
+      @HTTP(method = "CUSTOM1", path = "/foo")
       Response method() {
         return null;
       }
@@ -98,15 +64,9 @@ public class RequestBuilderTest {
     assertThat(request.getBody()).isNull();
   }
 
-  @RestMethod(value = "CUSTOM2", hasBody = true)
-  @Target(METHOD) @Retention(RUNTIME)
-  private @interface CUSTOM2 {
-    String value();
-  }
-
   @Test public void custom2Method() {
     class Example {
-      @CUSTOM2("/foo") //
+      @HTTP(method = "CUSTOM2", path = "/foo", hasBody = true)
       Response method(@Body TypedInput body) {
         return null;
       }


### PR DESCRIPTION
This is less cute, and more conducive to annotation processing.