### PR TITLE
DataPreprocessor interface added to RestAdapter to preprocess Objects

### DIFF
--- a/retrofit/src/main/java/retrofit/DataPreprocessor.java
+++ b/retrofit/src/main/java/retrofit/DataPreprocessor.java
@@ -1,0 +1,47 @@
+package retrofit;
+
+import com.squareup.okhttp.ResponseBody;
+
+import java.lang.reflect.Type;
+
+/**
+ * An interface for preprocess every outgoing or incoming request to or from a server.
+ *
+ * This can be used for example to encode every {@link retrofit.http.Body} object into the same
+ * wrapper object without the need of changing of the RestInterface's parameter.
+ * Also you can use it backwards: preprocess every response from the server before
+ * the interface call returns to you.
+ */
+public interface DataPreprocessor {
+
+  /**
+   * This method is called when a response arrives from the server.
+   *
+   * It is your duty to unwrap the data and return an Object with the given type.
+   * For example, every query returns SSL encoded data and you get an encoded key and encoded data.
+   * Then this method can decode the encoded data and should return the decoded object.
+   *
+   * @param responseBody  The response body from the server.
+   * @param type          Type of the Object that should be extracted and returned
+   *                      from the responseBody.
+   * @return An instance with the given type.
+   */
+  Object unWrapResponse(ResponseBody responseBody, Type type);
+
+
+  /**
+   * This method is called just before sending a {@link retrofit.http.Body} type parameter to the
+   * server.
+   *
+   * This method can be used to wrap every object of yours before sending it to server, without the
+   * need of changing of the RestInterface's parameter.
+   * Like {@link #unWrapResponse(com.squareup.okhttp.ResponseBody, java.lang.reflect.Type)},
+   * it can be used to wrap all of your requests with the same object for example for SSL encoding.
+   *
+   * @param object  The Object that should be wrapped.
+   * @return A new wrapper instance Object that will be actually sent to the server. This should
+   * hold the object that you got in parameter.
+   */
+  Object wrapRequest(Object object);
+
+}

--- a/retrofit/src/main/java/retrofit/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilder.java
@@ -36,6 +36,7 @@ import retrofit.http.QueryMap;
 final class RequestBuilder implements RequestInterceptor.RequestFacade {
   private static final Headers NO_HEADERS = Headers.of();
 
+  private final DataPreprocessor dataPreprocessor;
   private final Converter converter;
   private final Annotation[] paramAnnotations;
   private final String requestMethod;
@@ -49,9 +50,11 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
   private Headers.Builder headers;
   private String contentTypeHeader;
 
-  RequestBuilder(String apiUrl, MethodInfo methodInfo, Converter converter) {
+  RequestBuilder(String apiUrl, MethodInfo methodInfo, Converter converter,
+                 DataPreprocessor dataPreprocessor) {
     this.apiUrl = apiUrl;
     this.converter = converter;
+    this.dataPreprocessor = dataPreprocessor;
 
     paramAnnotations = methodInfo.requestParamAnnotations;
     requestMethod = methodInfo.requestMethod;
@@ -68,6 +71,10 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
     if (requestQuery != null) {
       queryParams = new StringBuilder().append('?').append(requestQuery);
     }
+  }
+
+  RequestBuilder(String apiUrl, MethodInfo methodInfo, Converter converter) {
+    this(apiUrl, methodInfo, converter, null);
   }
 
   @Override public void addHeader(String name, String value) {
@@ -328,12 +335,21 @@ final class RequestBuilder implements RequestInterceptor.RequestFacade {
         if (value instanceof RequestBody) {
           body = (RequestBody) value;
         } else {
-          body = converter.toBody(value, value.getClass());
+          setBodyByDataPreprocessor(value);
         }
       } else {
         throw new IllegalArgumentException(
             "Unknown annotation: " + annotationType.getCanonicalName());
       }
+    }
+  }
+
+  private void setBodyByDataPreprocessor(Object value) {
+    if (dataPreprocessor != null) {
+      Object data = dataPreprocessor.wrapRequest(value);
+      body = converter.toBody(data, data.getClass());
+    } else {
+      body = converter.toBody(value, value.getClass());
     }
   }
 

--- a/retrofit/src/test/java/retrofit/DataPreprocessorTest.java
+++ b/retrofit/src/test/java/retrofit/DataPreprocessorTest.java
@@ -1,0 +1,212 @@
+package retrofit;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.rule.MockWebServerRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import retrofit.http.Body;
+import retrofit.http.GET;
+import retrofit.http.POST;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class DataPreprocessorTest {
+
+  private interface ExampleInterface {
+    @GET("/")
+    ResponseTest something();
+
+    @GET("/")
+    void something(Callback<ResponseTest> callback);
+
+    @POST("/")
+    Object requestWrap(@Body RequestTest requestTest);
+
+  }
+
+  @Rule
+  public final MockWebServerRule serverRule = new MockWebServerRule();
+
+  private ExampleInterface exampleInterface;
+  private TestPreprocessor testProcessor;
+
+  @Before
+  public void setUp() {
+    OkHttpClient client = new OkHttpClient();
+
+    testProcessor = new TestPreprocessor();
+
+    exampleInterface = new RestAdapter.Builder() //
+            .setClient(client)
+            .setCallbackExecutor(new Utils.SynchronousExecutor())
+            .setEndpoint(serverRule.getUrl("/").toString())
+            .setDataPreprocessor(testProcessor)
+            .build()
+            .create(ExampleInterface.class);
+  }
+
+  @Test public void responseWrapTestDirect() throws Exception {
+    Gson gson = new GsonBuilder().create();
+    ResponseWrapperTest rwt = getMockResponseWrapper();
+    serverRule.enqueue(new MockResponse().setBody(gson.toJson(rwt)));
+
+    ResponseTest response = exampleInterface.something();
+    assertThat(response.a).isEqualTo(42);
+    assertThat(response.b).isEqualTo("Life");
+    assertThat(testProcessor.otherData[0]).isEqualTo("response wrapper data 1");
+  }
+
+  @Test public void responseWrapTestAsync() throws Exception {
+    Gson gson = new GsonBuilder().create();
+    ResponseWrapperTest rwt = getMockResponseWrapper();
+    serverRule.enqueue(new MockResponse().setBody(gson.toJson(rwt)));
+
+    final AtomicReference<ResponseTest> responseRef = new AtomicReference<ResponseTest>();
+    final CountDownLatch latch = new CountDownLatch(1);
+    exampleInterface.something(new Callback<ResponseTest>() {
+      @Override
+      public void success(ResponseTest responseTest, Response response) {
+        responseRef.set(responseTest);
+        latch.countDown();
+      }
+
+      @Override
+      public void failure(RetrofitError error) {
+        throw new AssertionError();
+      }
+    });
+
+    assertTrue(latch.await(1, TimeUnit.SECONDS));
+
+    assertThat(responseRef.get().a).isEqualTo(42);
+    assertThat(responseRef.get().b).isEqualTo("Life");
+    assertThat(testProcessor.otherData[0]).isEqualTo("response wrapper data 1");
+
+  }
+
+  @Test public void requestWrapTest() throws Exception {
+    Gson gson = new GsonBuilder().create();
+    RequestTest requestTest = new RequestTest(7, "Wrapping");
+    ResponseWrapperTest responseWrapperTest = getMockResponseWrapper();
+    serverRule.enqueue(new MockResponse().setBody(gson.toJson(responseWrapperTest)));
+    exampleInterface.requestWrap(requestTest);
+
+
+    String body = new String(serverRule.takeRequest().getBody(), Charset.forName("UTF-8"));
+    RequestWrapperTest serverRequestBody = gson.fromJson(body, RequestWrapperTest.class);
+    RequestTest rtRequest = gson.fromJson(serverRequestBody.mainData, RequestTest.class);
+
+    assertThat(serverRequestBody.otherData).isEqualTo("extra data 1");
+    assertThat(rtRequest.intData).isEqualTo(7);
+    assertThat(rtRequest.stringData).isEqualTo("Wrapping");
+  }
+
+  @Test public void dataProcessorNullTest() {
+    OkHttpClient client = new OkHttpClient();
+    try {
+      new RestAdapter.Builder()
+              .setClient(client)
+              .setCallbackExecutor(new Utils.SynchronousExecutor())
+              .setEndpoint(serverRule.getUrl("/").toString())
+              .setDataPreprocessor(null)
+              .build()
+              .create(ExampleInterface.class);
+      fail();
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage()).isEqualTo("DataProcessor may not be null.");
+    }
+  }
+
+  private ResponseWrapperTest getMockResponseWrapper() {
+    Gson gson = new GsonBuilder().create();
+    ResponseTest responseTest = new ResponseTest(42, "Life");
+    ResponseWrapperTest rwt = new ResponseWrapperTest("response wrapper data 1", gson.toJson(responseTest));
+
+    return rwt;
+  }
+
+  private static class TestPreprocessor implements DataPreprocessor {
+
+    String[] otherData = new String[1];
+
+    @Override
+    public Object unWrapResponse(ResponseBody responseBody, Type type) {
+      Gson gson = new GsonBuilder().create();
+      Charset charset = Charset.forName("UTF-8");
+      InputStream is = responseBody.byteStream();
+
+      ResponseWrapperTest testClass = gson.fromJson(new InputStreamReader(is, charset), ResponseWrapperTest.class);
+      otherData[0] = testClass.otherData;
+
+      return gson.fromJson(testClass.mainData, type);
+    }
+
+    @Override
+    public Object wrapRequest(Object object) {
+      Gson gson = new GsonBuilder().create();
+      RequestWrapperTest rwt = new RequestWrapperTest("extra data 1", gson.toJson(object, object.getClass()));
+      return rwt;
+    }
+  }
+
+  private static class ResponseWrapperTest {
+    String otherData;
+    String mainData;
+
+    private ResponseWrapperTest(String otherData, String mainData) {
+      this.otherData = otherData;
+      this.mainData = mainData;
+    }
+  }
+
+  private static class ResponseTest {
+    int a;
+    String b;
+
+    private ResponseTest(int a, String b) {
+      this.a = a;
+      this.b = b;
+    }
+  }
+
+  private static class RequestWrapperTest {
+    String otherData;
+    String mainData;
+
+    private RequestWrapperTest(String otherData, String mainData) {
+      this.otherData = otherData;
+      this.mainData = mainData;
+    }
+  }
+
+  private static class RequestTest {
+    int intData;
+    String stringData;
+
+    private RequestTest(int intData, String stringData) {
+      this.intData = intData;
+      this.stringData = stringData;
+    }
+  }
+
+}
+
+


### PR DESCRIPTION
In case of encrypted communication between client and server, Java Generics cannot be used to customize and create type-safe Body-param objects and return values, because encrypted data always will look like the same. (For example a base64 encoded String.)

With this small interface you can wrap all of your Body-param objects before sending to server, and unwrap all of your results before returning it - if you want - and results and params remain type-safe and self-explanatory as intended.