### PR TITLE
Improve ProtoConverter with Content-Type customization

### DIFF
--- a/retrofit-converters/protobuf/src/main/java/retrofit/converter/ProtoConverter.java
+++ b/retrofit-converters/protobuf/src/main/java/retrofit/converter/ProtoConverter.java
@@ -13,7 +13,26 @@ import java.lang.reflect.Type;
 
 /** A {@link Converter} that reads and writes protocol buffers. */
 public class ProtoConverter implements Converter {
-  private static final MediaType MEDIA_TYPE = MediaType.parse("application/x-protobuf");
+
+  private final MediaType mediaType;
+
+  /**
+   * Default constructor for converter with default Content-Type - application/x-protobuf
+   */
+  public ProtoConverter() {
+    mediaType = MediaType.parse("application/x-protobuf");
+  }
+
+  /**
+   * Constructor allowing usage of custom Content-Type - e.g. application/octet-stream,
+   * application/x-google-protobuf
+   *
+   * @param contentType Custom Content-Type
+   */
+  public ProtoConverter(String contentType) {
+    mediaType = MediaType.parse(contentType);
+  }
+
 
   @Override public Object fromBody(ResponseBody body, Type type) throws IOException {
     if (!(type instanceof Class<?>)) {
@@ -49,6 +68,6 @@ public class ProtoConverter implements Converter {
               : "null"));
     }
     byte[] bytes = ((AbstractMessageLite) object).toByteArray();
-    return RequestBody.create(MEDIA_TYPE, bytes);
+    return RequestBody.create(mediaType, bytes);
   }
 }

--- a/retrofit-converters/protobuf/src/test/java/retrofit/converter/ProtoConverterTest.java
+++ b/retrofit-converters/protobuf/src/test/java/retrofit/converter/ProtoConverterTest.java
@@ -21,10 +21,18 @@ public final class ProtoConverterTest {
   private static final String ENCODED_PROTO = "Cg4oNTE5KSA4NjctNTMwOQ==";
 
   private final ProtoConverter converter = new ProtoConverter();
+  private final ProtoConverter converterOctetStream = new ProtoConverter
+      ("application/octet-stream");
 
   @Test public void serialize() throws Exception {
     RequestBody body = converter.toBody(PROTO, Phone.class);
     assertThat(body.contentType().toString()).isEqualTo("application/x-protobuf");
+    assertBody(body).isEqualTo(ENCODED_PROTO);
+  }
+
+  @Test public void serializeCustomContentType() throws Exception {
+    RequestBody body = converterOctetStream.toBody(PROTO, Phone.class);
+    assertThat(body.contentType().toString()).isEqualTo("application/octet-stream");
     assertBody(body).isEqualTo(ENCODED_PROTO);
   }
 


### PR DESCRIPTION
Hi, I added a way to customize Content-Type in ProtoConverter. 

The reason for this change is that there are other Content-Types that are often being used for Protocol Buffers.
Besides `application/x-protobuf` you can often encounter `application/octet-stream`, `application/x-google-protobuf`, `application/vnd.google.protobuf` or even types like this `application/vnd.google.protobuf;proto=mypkg.MyMessage`.

The change keeps `application/x-protobuf` as the default value (no code change necessary).