### PR TITLE
Changes to Javadoc to remove doclint errors and warnings

### DIFF
--- a/retrofit/src/main/java/retrofit/ErrorHandler.java
+++ b/retrofit/src/main/java/retrofit/ErrorHandler.java
@@ -16,7 +16,7 @@
 package retrofit;
 
 /**
- * A hook allowing clients to customize {@link retrofit.client.Response response} exceptions.
+ * A hook allowing clients to customize {@link RetrofitError RetrofitError}.
  *
  * @author Sam Beran sberan@gmail.com
  */

--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -63,9 +63,8 @@ import retrofit.http.Header;
  * <p>
  * The body of a request is denoted by the {@link retrofit.http.Body @Body} annotation. The object
  * will be converted to request representation by a call to
- * {@link retrofit.converter.Converter#toBody(Object) toBody} on the supplied
- * {@link retrofit.converter.Converter Converter} for this instance. The body can also be a
- * {@link TypedOutput} where it will be used directly.
+ * {@link retrofit.converter.Converter#toBody(Object, java.lang.reflect.Type) toBody}
+ * on the supplied {@link retrofit.converter.Converter Converter} for this instance.
  * <p>
  * Alternative request body formats are supported by method annotations and corresponding parameter
  * annotations:

--- a/retrofit/src/main/java/retrofit/http/Body.java
+++ b/retrofit/src/main/java/retrofit/http/Body.java
@@ -25,10 +25,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Use this annotation on a service method param when you want to directly control the request body
  * of a POST/PUT request (instead of sending in as request parameters or form-style request
- * body). If the value of the parameter implements {@link retrofit.mime.TypedOutput TypedOutput},
- * the request body will be written exactly as specified by
- * {@link retrofit.mime.TypedOutput#writeTo(java.io.OutputStream)}. If the value does not implement
- * TypedOutput, the object will be serialized using the {@link retrofit.RestAdapter RestAdapter}'s
+ * body). The object will be serialized using the {@link retrofit.RestAdapter RestAdapter}'s
  * {@link retrofit.converter.Converter Converter} and the result will be set directly as the
  * request body.
  * <p>

--- a/retrofit/src/main/java/retrofit/http/Part.java
+++ b/retrofit/src/main/java/retrofit/http/Part.java
@@ -27,12 +27,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>
  * The parameter type on which this annotation exists will be processed in one of three ways:
  * <ul>
- * <li>If the type implements {@link retrofit.mime.TypedOutput TypedOutput} the headers and
- * body will be used directly.</li>
  * <li>If the type is {@link String} the value will also be used directly with a {@code text/plain}
  * content type.</li>
  * <li>Other object types will be converted to an appropriate representation by calling {@link
- * retrofit.converter.Converter#toBody(Object)}.</li>
+ * retrofit.converter.Converter#toBody(Object, java.lang.reflect.Type)}.</li>
  * </ul>
  * <p>
  * Values may be {@code null} which will omit them from the request body.

--- a/retrofit/src/main/java/retrofit/http/PartMap.java
+++ b/retrofit/src/main/java/retrofit/http/PartMap.java
@@ -27,12 +27,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>
  * Values of the map on which this annotation exists will be processed in one of three ways:
  * <ul>
- * <li>If the type implements {@link retrofit.mime.TypedOutput TypedOutput} the headers and
- * body will be used directly.</li>
  * <li>If the type is {@link String} the value will also be used directly with a {@code text/plain}
  * content type.</li>
  * <li>Other object types will be converted to an appropriate representation by calling {@link
- * retrofit.converter.Converter#toBody(Object)}.</li>
+ * retrofit.converter.Converter#toBody(Object, java.lang.reflect.Type)}.</li>
  * </ul>
  * <p>
  * <pre>
@@ -40,7 +38,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * &#64;POST("/upload")
  * void upload(&#64;Part("file") TypedFile file, &#64;PartMap Map&lt;String, String&gt; params);
  * </pre>
- * <p>
  *
  * @see Multipart
  * @see Part

--- a/retrofit/src/main/java/retrofit/http/Streaming.java
+++ b/retrofit/src/main/java/retrofit/http/Streaming.java
@@ -23,8 +23,8 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Treat the response body on methods returning {@link retrofit.client.Response Response} as is,
- * i.e. without converting {@link retrofit.client.Response#getBody() getBody()} to {@code byte[]}.
+ * Treat the response body on methods returning {@link com.squareup.okhttp.Response Response} as is,
+ * i.e. without converting {@link com.squareup.okhttp.Response#body() body()} to {@code byte[]}.
  */
 @Documented
 @Target(METHOD)


### PR DESCRIPTION
Noticed the lack of [2.0.0 snapshots](https://oss.sonatype.org/content/repositories/snapshots/com/squareup/retrofit/retrofit/) since Jan. 30th, due to the migration to JDK 8.

The addition of [doclint to JDK 8](http://openjdk.java.net/jeps/172) causes an early failure of the Maven deployment. [See build #1545.2](https://travis-ci.org/square/retrofit/jobs/49275303#L911).

Resolved the `doclint` errors and some warnings. Unfortunately, there are still quite a few warnings. Some of them are due to poor HTML and they are rather easy to fix. Others are due to missing `@param` and `@return` statements. This is frustrating besides it goes against the DRY principle when writing documentation for simple functions.

I think the best solution would be to reconfigure `doclint` and [enable only the necessary groups](https://gist.github.com/hekar/62772af5b0fe0b6731bb). Maybe `html`, `syntax` and `reference`?

Any configuration would have to be done with Maven Profiles, because [the -Xdoclint argument cannot be passed to JDK 7 or lower](http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete/22981151#22981151).

Does anyone else have any opinions on this?

Thanks
Hekar