### PR TITLE
Makes Rx Observable creation defer request interception until Observable subscription

### DIFF
--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -165,15 +165,16 @@ public class RestAdapter {
       }
 
       MethodInfo methodInfo = getMethodInfo(methodDetailsCache, method);
-      Request request = createRequest(methodInfo, args);
       switch (methodInfo.executionType) {
         case SYNC:
-          return invokeSync(methodInfo, request);
+          return invokeSync(methodInfo, createRequest(methodInfo, args));
         case ASYNC:
-          invokeAsync(methodInfo, request, (Callback) args[args.length - 1]);
+          invokeAsync(methodInfo, createRequest(methodInfo, args),
+              (Callback) args[args.length - 1]);
           return null; // Async has void return type.
         case RX:
-          return invokeRx(methodInfo, request);
+          // Request interception is deferred until subscription for Observables.
+          return invokeRx(methodInfo, createRequestBuilder(methodInfo, args), requestInterceptor);
         default:
           throw new IllegalStateException("Unknown response type: " + methodInfo.executionType);
       }
@@ -218,7 +219,8 @@ public class RestAdapter {
       });
     }
 
-    private Object invokeRx(final MethodInfo methodInfo, final Request request) {
+    private Object invokeRx(final MethodInfo methodInfo, final RequestBuilder requestBuilder,
+        final RequestInterceptor requestInterceptor) {
       if (rxSupport == null) {
         if (Platform.HAS_RX_JAVA) {
           rxSupport = new RxSupport();
@@ -227,7 +229,7 @@ public class RestAdapter {
         }
       }
       return rxSupport.createRequestObservable(new RxSupport.Invoker() {
-        @Override public void invoke(final Callback callback) {
+        @Override public void invoke(final Request request, final Callback callback) {
           Call call = client.newCall(request);
           call.enqueue(new com.squareup.okhttp.Callback() {
             @Override public void onFailure(Request request, IOException e) {
@@ -245,7 +247,7 @@ public class RestAdapter {
           });
 
         }
-      });
+      }, requestBuilder, requestInterceptor);
     }
 
     /**
@@ -335,11 +337,16 @@ public class RestAdapter {
       });
     }
 
-    private Request createRequest(MethodInfo methodInfo, Object[] args) {
+    private RequestBuilder createRequestBuilder(MethodInfo methodInfo, Object[] args) {
       String serverUrl = endpoint.url();
       RequestBuilder requestBuilder = new RequestBuilder(serverUrl, methodInfo, converter);
       requestBuilder.setArguments(args);
 
+      return requestBuilder;
+    }
+
+    private Request createRequest(MethodInfo methodInfo, Object[] args) {
+      RequestBuilder requestBuilder = createRequestBuilder(methodInfo, args);
       requestInterceptor.intercept(requestBuilder);
 
       return requestBuilder.build();

--- a/retrofit/src/test/java/retrofit/RestAdapterTest.java
+++ b/retrofit/src/test/java/retrofit/RestAdapterTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import retrofit.RequestInterceptor;
 import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.Headers;
@@ -19,6 +20,8 @@ import retrofit.http.POST;
 import retrofit.http.Streaming;
 import rx.Observable;
 import rx.functions.Action1;
+import rx.observers.TestSubscriber;
+import rx.schedulers.Schedulers;
 
 import static com.squareup.okhttp.mockwebserver.SocketPolicy.DISCONNECT_AT_START;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -195,38 +198,53 @@ public class RestAdapterTest {
   @Test public void observableCallsOnNext() throws Exception {
     server.enqueue(new MockResponse().setBody("hello"));
 
-    final AtomicReference<String> bodyRef = new AtomicReference<String>();
-    final CountDownLatch latch = new CountDownLatch(1);
-    example.observable("Howdy").subscribe(new Action1<String>() {
-      @Override public void call(String body) {
-        bodyRef.set(body);
-        latch.countDown();
-      }
-    });
-    assertTrue(latch.await(1, TimeUnit.SECONDS));
+    final TestSubscriber subscriber = new TestSubscriber();
+    example.observable("Howdy").subscribe(subscriber);
 
-    assertThat(bodyRef.get()).isEqualTo("hello");
+    subscriber.awaitTerminalEvent(1, TimeUnit.SECONDS);
+    assertThat(subscriber.getOnNextEvents()).containsExactly("hello");
+    subscriber.assertNoErrors();
   }
 
   @Test public void observableCallsOnError() throws Exception {
     server.enqueue(new MockResponse().setResponseCode(500));
 
-    final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
-    final CountDownLatch latch = new CountDownLatch(1);
-    example.observable("Howdy").subscribe(new Action1<String>() {
-      @Override public void call(String s) {
-        throw new AssertionError();
-      }
-    }, new Action1<Throwable>() {
-      @Override public void call(Throwable throwable) {
-        errorRef.set(throwable);
-        latch.countDown();
-      }
-    });
-    assertTrue(latch.await(1, TimeUnit.SECONDS));
+    final TestSubscriber subscriber = new TestSubscriber();
+    example.observable("Howdy").subscribe(subscriber);
 
-    RetrofitError error = (RetrofitError) errorRef.get();
+    subscriber.awaitTerminalEvent(1, TimeUnit.SECONDS);
+
+    RetrofitError error = (RetrofitError) subscriber.getOnErrorEvents().get(0);
     assertThat(error.getResponse().code()).isEqualTo(500);
     assertThat(error.getSuccessType()).isEqualTo(String.class);
+    assertThat(subscriber.getOnErrorEvents()).hasSize(1);
+  }
+
+  @Test public void observableDefersInterceptionUntilSubscription() throws Exception {
+    server.enqueue(new MockResponse().setBody("hello"));
+
+    final TestSubscriber subscriber = new TestSubscriber();
+    final Thread testThread = Thread.currentThread();
+
+    final Example interceptorExample = new RestAdapter.Builder()
+        .setEndpoint(server.getUrl("/").toString())
+        .setRequestInterceptor(new RequestInterceptor() {
+          @Override
+          public void intercept(RequestInterceptor.RequestFacade request) {
+            assertThat(Thread.currentThread()).isNotEqualTo(testThread);
+            request.addHeader("Nyan", "Cat");
+          }
+        })
+        .build()
+        .create(Example.class);
+
+    final Observable<String> observable = interceptorExample.observable("Howdy")
+        .subscribeOn(Schedulers.newThread());
+
+    observable.subscribe(subscriber);
+    subscriber.awaitTerminalEvent(1, TimeUnit.SECONDS);
+
+    assertThat(subscriber.getOnNextEvents()).containsExactly("hello");
+    assertThat(server.takeRequest().getHeader("Nyan")).isEqualTo("Cat");
   }
 }


### PR DESCRIPTION
Makes Rx Observable creation defer request interception until Observable subscription, allowing it to be run on a background scheduler defined via subscribeOn on the returned Observable. No scheduler is applied by default.

Adds test case for defer, and refactors the other Rx test methods to use TestSubscriber, which seems a bit easier to read and maintain than custom concurrency management w/CountdownLatch.

This helps manage cases such as getting a blocking Oauth token. OkHttp's interceptors are a good alternative if using OkHttp, but this provides an option for Rx users directly via retrofit.