### PR TITLE
Add rxpromises support

### DIFF
--- a/retrofit/pom.xml
+++ b/retrofit/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>rxjava</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+  	  <groupId>com.darylteo</groupId>
+  	  <artifactId>rxjava-promises-java</artifactId>
+  	  <version>1.2.0</version>
+ 	</dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/retrofit/src/main/java/retrofit/MethodInfo.java
+++ b/retrofit/src/main/java/retrofit/MethodInfo.java
@@ -16,6 +16,7 @@
 package retrofit;
 
 import com.squareup.okhttp.Response;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -26,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.Field;
@@ -53,7 +55,8 @@ final class MethodInfo {
   enum ExecutionType {
     ASYNC,
     RX,
-    SYNC
+    SYNC,
+    PROMISES
   }
 
   // Upper and lower characters, digits, underscores, and hyphens, starting with a character.
@@ -262,6 +265,13 @@ final class MethodInfo {
           returnType = RxSupport.getObservableType(returnType, rawReturnType);
           responseObjectType = getParameterUpperBound((ParameterizedType) returnType);
           return ExecutionType.RX;
+        } else if (rawReturnType == RetrofitPromise.class) {
+          lastArgType = Types.getSupertype(returnType, Types.getRawType(returnType),
+                    Callback.class);
+          if (lastArgType instanceof ParameterizedType) {
+            responseObjectType = getParameterUpperBound((ParameterizedType) lastArgType);
+            return ExecutionType.PROMISES;
+          }
         }
       }
       responseObjectType = returnType;

--- a/retrofit/src/main/java/retrofit/RetrofitPromise.java
+++ b/retrofit/src/main/java/retrofit/RetrofitPromise.java
@@ -1,0 +1,38 @@
+package retrofit;
+
+import com.darylteo.rx.promises.java.Promise;
+import com.squareup.okhttp.Response;
+
+public class RetrofitPromise<T> extends Promise<T> implements Callback<T> {
+
+    /**
+     * Constructor.
+     */
+
+    public RetrofitPromise() {
+
+    }
+
+    /**
+     * Executed when the request is performed with the success.
+     *
+     * @param responseObject The {@link T} object.
+     * @param response The {@link Response}.
+     */
+
+    @Override
+    public void success(T responseObject, Response response) {
+        this.fulfill(responseObject);
+    }
+
+    /**
+     * Executed when the request gives an error.
+     *
+     * @param error The {@link retrofit.RetrofitError}.
+     */
+
+    @Override
+    public void failure(RetrofitError error) {
+        this.reject(error.getCause());
+    }
+}


### PR DESCRIPTION
This pull request adds promises support to the retrofit.

Why promises support?  Mainly, because the power of chaining multiple of them together. With multiple promises in chaining we can have one single point to handle the errors and to execute the final operation. 
```java
promise.then(....).then(...).then(...).fail(....).fin(...)
```
The library of promises used was: https://github.com/darylteo/rxjava-promises

For the example project, the code adapted to the promises is:

```java
public class GitHubClient {

    private static final String API_URL = "https://api.github.com";

    static class Contributor {
        String login;
        int contributions;
    }

    interface GitHub {
        @GET("/repos/{owner}/{repo}/contributors")
        RetrofitPromise<List<Contributor>> contributors(
                @Path("owner") String owner,
                @Path("repo") String repo
        );
    }

    public static void main(String... args) {
        // Create a very simple REST adapter which points the GitHub API endpoint.
        RestAdapter restAdapter = new RestAdapter.Builder()
                .endpoint(API_URL)
                .build();

        // Create an instance of our GitHub API interface.
        GitHub github = restAdapter.create(GitHub.class);

        // Fetch and print a list of the contributors to this library.
        RetrofitPromise<List<Contributor>> promise = github.contributors("square", "retrofit");
        promise.then(new PromiseAction<List<Contributor>>() {
            @Override
            public void call(List<Contributor> contributors) {
                for (Contributor contributor : contributors) {
                    System.out.println(contributor.login + " (" + contributor.contributions + ")");
                }
            }
        }).fail(new PromiseAction<Exception>() {
            @Override
            public void call(Exception e) {

            }
        });
    }

}
```