### PR TITLE
Fix memory leak caused by MockRxSupport

### DIFF
--- a/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
+++ b/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
@@ -494,15 +494,17 @@ public final class MockRestAdapter {
       });
     }
 
-    private Runnable getRunnable(final Subscriber<? super Object> subscriber, final MockHandler mockHandler,
-        final RestMethodInfo methodInfo, final RequestInterceptor interceptor, final Object[] args) {
+    private Runnable getRunnable(final Subscriber<? super Object> subscriber,
+        final MockHandler mockHandler, final RestMethodInfo methodInfo,
+        final RequestInterceptor interceptor, final Object[] args) {
       return new Runnable() {
         @Override public void run() {
           try {
             if (subscriber.isUnsubscribed()) {
               return;
             }
-            BlockingObservable o = ((Observable) mockHandler.invokeSync(methodInfo, interceptor, args)).toBlocking();
+            BlockingObservable o = ((Observable) mockHandler
+                .invokeSync(methodInfo, interceptor, args)).toBlocking();
             subscriber.onNext(o.single());
             subscriber.onCompleted();
           } catch (RetrofitError e) {

--- a/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
+++ b/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
@@ -12,9 +12,7 @@ import java.util.concurrent.TimeUnit;
 import retrofit.client.Request;
 import retrofit.client.Response;
 import rx.Observable;
-import rx.Scheduler;
 import rx.functions.Func1;
-import rx.schedulers.Schedulers;
 
 import static retrofit.RestAdapter.LogLevel;
 import static retrofit.RetrofitError.unexpectedError;
@@ -469,11 +467,9 @@ public final class MockRestAdapter {
 
   /** Indirection to avoid VerifyError if RxJava isn't present. */
   private static class MockRxSupport {
-    private final Scheduler httpScheduler;
     private final ErrorHandler errorHandler;
 
     MockRxSupport(RestAdapter restAdapter) {
-      httpScheduler = Schedulers.from(restAdapter.httpExecutor);
       errorHandler = restAdapter.errorHandler;
     }
 
@@ -490,7 +486,7 @@ public final class MockRestAdapter {
                 return Observable.error(throwable);
               }
             }
-          }).subscribeOn(httpScheduler);
+          });
     }
   }
 }


### PR DESCRIPTION
subscribeOn(httpScheduler) is causing occasional memory leak to show up in LeakCanary. Is there a reason for having this here? Everything seems to work fine without it and it fixes the memory leak issues I am running into. 