### PR TITLE
Add a default mock service implementation

### DIFF
--- a/retrofit-mock/src/main/java/retrofit/MockService.java
+++ b/retrofit-mock/src/main/java/retrofit/MockService.java
@@ -1,0 +1,80 @@
+package retrofit;
+
+import rx.Observable;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class MockService {
+
+    public interface Dispatcher {
+        <T> T getResponse(Class<T> returnType, Method method, final Object[] args);
+    }
+
+    static public <T> T create(final MockRestAdapter mockRestAdapter, final Class<T> retrofitApi, final Dispatcher dispatcher) {
+        return mockRestAdapter.create(retrofitApi, create(retrofitApi,dispatcher));
+    }
+
+    @SuppressWarnings("unchecked")
+    static private <T> T create(final Class<T> retrofitApi, final Dispatcher dispatcher) {
+        return (T) Proxy.newProxyInstance(retrofitApi.getClassLoader(), new Class<?>[] {retrofitApi},
+                                          new MockServiceHandler(dispatcher));
+    }
+
+    static public class MockServiceHandler implements InvocationHandler {
+        private final Map<Method, MethodInfo> methodInfoCache;
+        private final Dispatcher dispatcher;
+
+        public MockServiceHandler(final Dispatcher dispatcher) {
+            this(new HashMap<Method, MethodInfo>(), dispatcher);
+        }
+
+        public MockServiceHandler(final Map<Method, MethodInfo> methodInfoCache, final Dispatcher dispatcher) {
+            this.methodInfoCache = methodInfoCache;
+            this.dispatcher = dispatcher;
+        }
+
+        private MethodInfo getMethodInfo(Method method) {
+            synchronized (methodInfoCache) {
+                MethodInfo methodInfo = methodInfoCache.get(method);
+                if (methodInfo == null) {
+                    methodInfo = new MethodInfo(method);
+                    methodInfoCache.put(method, methodInfo);
+                }
+                return methodInfo;
+            }
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, final Object[] args) throws Throwable {
+            // If the method is a method from Object then defer to normal invocation.
+            if (method.getDeclaringClass() == Object.class) {
+                return method.invoke(this, args);
+            }
+
+            // Load or create the details cache for the current method.
+            final MethodInfo methodInfo = getMethodInfo(method);
+            final Object response;
+            if (methodInfo.responseObjectType instanceof Class) {
+                response = dispatcher.getResponse((Class) (methodInfo.responseObjectType), method, args);
+            } else {
+                throw new ClassCastException("'methodInfo.responseObjectType' is not an instance of 'Class'");
+            }
+            if (methodInfo.executionType == MethodInfo.ExecutionType.SYNC) {
+                return response;
+            }
+            if (methodInfo.executionType == MethodInfo.ExecutionType.ASYNC) {
+                final Callback callback = (Callback) args[args.length - 1];
+                callback.success(response, null);
+                return null;
+            }
+            if (methodInfo.executionType == MethodInfo.ExecutionType.RX) {
+                return Observable.just(response);
+            }
+            throw new IllegalArgumentException("executionType must be one of: SYNC, ASYNC, RX");
+        }
+    }
+}

--- a/retrofit-mock/src/main/java/retrofit/SimpleResponseDispatcher.java
+++ b/retrofit-mock/src/main/java/retrofit/SimpleResponseDispatcher.java
@@ -1,0 +1,21 @@
+package retrofit;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SimpleResponseDispatcher implements MockService.Dispatcher {
+
+    private Map<Class<?>, Object> responses = new ConcurrentHashMap<Class<?>, Object>();
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getResponse(final Class<T> returnType, final Method method, final Object[] args) {
+        return (T) responses.get(returnType);
+    }
+
+    public <T> void setResponse(final Class<T> responseType, final T response) {
+        responses.put(responseType, response);
+    }
+
+}

--- a/retrofit-mock/src/test/java/retrofit/MockServiceTest.java
+++ b/retrofit-mock/src/test/java/retrofit/MockServiceTest.java
@@ -1,0 +1,181 @@
+package retrofit;
+
+import com.squareup.okhttp.Response;
+import org.junit.Before;
+import org.junit.Test;
+import retrofit.http.GET;
+import rx.Observable;
+import rx.functions.Action1;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class MockServiceTest {
+    interface SyncExample {
+        @GET("/")
+        Object doStuff();
+    }
+
+
+    interface AsyncExample {
+        @GET("/")
+        void doStuff(Callback<String> cb);
+    }
+
+
+    interface AsyncCallbackSubtypeExample {
+        abstract class Foo implements Callback<String> {
+        }
+
+        @GET("/")
+        void doStuff(Foo foo);
+    }
+
+
+    interface ObservableExample {
+        @GET("/")
+        Observable<String> doStuff();
+    }
+
+
+    private Executor httpExecutor;
+    private Executor callbackExecutor;
+    private RestAdapter restAdapter;
+    private MockRestAdapter mockRestAdapter;
+    private MockRestAdapter.ValueChangeListener valueChangeListener;
+    private Throwable nextError;
+
+    @Before
+    public void setUp() throws IOException {
+        httpExecutor = spy(new Utils.SynchronousExecutor());
+        callbackExecutor = spy(new Utils.SynchronousExecutor());
+
+        restAdapter = new RestAdapter.Builder() //
+            .callbackExecutor(callbackExecutor)
+            .endpoint("http://example.com")
+            .errorHandler(new ErrorHandler() {
+                @Override
+                public Throwable handleError(RetrofitError cause) {
+                    if (nextError != null) {
+                        Throwable error = nextError;
+                        nextError = null;
+                        return error;
+                    }
+                    return cause;
+                }
+            })
+            .build();
+
+        valueChangeListener = mock(MockRestAdapter.ValueChangeListener.class);
+
+        mockRestAdapter = MockRestAdapter.from(restAdapter, httpExecutor);
+        mockRestAdapter.setValueChangeListener(valueChangeListener);
+
+        // Seed the random with a value so the tests are deterministic.
+        mockRestAdapter.random.setSeed(2847);
+        mockRestAdapter.setDelay(0);
+        mockRestAdapter.setVariancePercentage(0);
+        mockRestAdapter.setErrorPercentage(0);
+    }
+
+    @Test
+    public void syncCall() {
+        final Object expected = "Hi";
+        final SimpleResponseDispatcher responseDispatcher = new SimpleResponseDispatcher();
+        SyncExample mockService = MockService.create(mockRestAdapter, SyncExample.class, responseDispatcher);
+        responseDispatcher.setResponse(Object.class, expected);
+
+        final AtomicReference<Object> actual = new AtomicReference<Object>();
+        actual.set(mockService.doStuff());
+        assertThat(actual.get()).isNotNull().isSameAs(expected);
+    }
+
+    @Test
+    public void asyncCall() {
+        final String expected = "Hi";
+
+        final SimpleResponseDispatcher responseDispatcher = new SimpleResponseDispatcher();
+        AsyncExample mockService = MockService.create(mockRestAdapter, AsyncExample.class, responseDispatcher);
+        responseDispatcher.setResponse(String.class, expected);
+
+        final AtomicReference<Object> actual = new AtomicReference<Object>();
+        mockService.doStuff(new Callback<String>() {
+            @Override
+            public void success(String result, Response response) {
+                actual.set(result);
+            }
+
+            @Override
+            public void failure(RetrofitError error) {
+                throw new AssertionError();
+            }
+        });
+
+        verify(httpExecutor).execute(any(Runnable.class));
+        verify(callbackExecutor).execute(any(Runnable.class));
+
+        assertThat(actual.get()).isNotNull().isSameAs(expected);
+    }
+
+    @Test
+    public void observableCall() {
+        final String expected = "Hi";
+        final SimpleResponseDispatcher responseDispatcher = new SimpleResponseDispatcher();
+        ObservableExample mockService = MockService.create(mockRestAdapter, ObservableExample.class, responseDispatcher);
+        responseDispatcher.setResponse(String.class, expected);
+
+        final AtomicReference<Object> actual = new AtomicReference<Object>();
+        Action1<Object> onSuccess = new Action1<Object>() {
+            @Override
+            public void call(Object o) {
+                actual.set(o);
+            }
+        };
+        Action1<Throwable> onError = new Action1<Throwable>() {
+            @Override
+            public void call(Throwable throwable) {
+                throw new AssertionError();
+            }
+        };
+
+        mockService.doStuff().subscribe(onSuccess, onError);
+
+        verify(httpExecutor, atLeastOnce()).execute(any(Runnable.class));
+        verifyZeroInteractions(callbackExecutor);
+
+        assertThat(actual.get()).isNotNull().isSameAs(expected);
+    }
+
+    @Test
+    public void asyncCanUseCallbackSubtype() {
+        final String expected = "Hi";
+        final SimpleResponseDispatcher responseDispatcher = new SimpleResponseDispatcher();
+        AsyncExample mockService = MockService.create(mockRestAdapter, AsyncExample.class, responseDispatcher);
+        responseDispatcher.setResponse(String.class, expected);
+
+        final AtomicReference<Object> actual = new AtomicReference<Object>();
+
+        mockService.doStuff(new AsyncCallbackSubtypeExample.Foo() {
+            @Override
+            public void success(String result, Response response) {
+                actual.set(result);
+            }
+
+            @Override
+            public void failure(RetrofitError error) {
+                throw new AssertionError();
+            }
+        });
+
+        assertThat(actual.get()).isNotNull().isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
This request is similar to #528, but only requires pure retrofit.

By providing a default mock service implementation, the need for manually implementing the retrofit service api is eliminated. Making offline testing a lot easier.
The mock service implementation takes a MocksService.Dispatcher to allow dispatching of custom responses.

unit tests that illustrate the usage are provided