### PR TITLE
Remove okhttp-urlconnection Gradle dependency

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,6 @@ compile 'com.squareup.retrofit:retrofit:<span class="version pln"><em>(insert la
 </pre>
             <h4>Gradle</h4>
 <pre class="prettyprint">
-compile 'com.squareup.okhttp:okhttp-urlconnection:2.0.0'
 compile 'com.squareup.okhttp:okhttp:2.0.0'
 </pre>
             <h4>ProGuard</h4>


### PR DESCRIPTION
The previous commit removed the dependency from the Maven declaration but left it in the Gradle declaration.