### PR TITLE
Remove okhttp-urlconnection Gradle dependency

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -251,7 +251,6 @@ compile 'com.squareup.retrofit:retrofit:<span class="version pln"><em>(insert la
 </pre>
             <h4>Gradle</h4>
 <pre class="prettyprint">
-compile 'com.squareup.okhttp:okhttp-urlconnection:2.0.0'
 compile 'com.squareup.okhttp:okhttp:2.0.0'
 </pre>
             <h4>ProGuard</h4>


### PR DESCRIPTION
The dependency was removed from the Maven declaration in 79a2a501b5964bd831bd3c4b9554d35fb2e584c2 but was left in the Gradle declaration.

Terribly sorry about the confusion in #868.