### PR TITLE
Resolve mixed-content resources

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -8,7 +8,7 @@
     <link href="static/bootstrap-combined.min.css" rel="stylesheet">
     <link href="static/app.css" rel="stylesheet">
     <link href="static/app-theme.css" rel="stylesheet">
-    <link href="http://fonts.googleapis.com/css?family=Roboto:400,300italic,100,100italic,300" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:400,300italic,100,100italic,300" rel="stylesheet" type="text/css">
     <!--[if lt IE 9]><script src="static/html5shiv.min.js"></script><![endif]-->
   </head>
   <body data-target=".content-nav">
@@ -305,7 +305,7 @@ limitations under the License.</pre>
         </div>
       </div>
     </section>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="static/bootstrap.min.js"></script>
     <script src="static/jquery.smooth-scroll.min.js"></script>
     <script src="static/jquery-maven-artifact.min.js"></script>


### PR DESCRIPTION
jQuery is served over HTTP, which causes issues with [blocked mixed content](https://developer.mozilla.org/en-US/docs/Security/MixedContent), in particular preventing loading the latest version number. This PR ensures external content is served over HTTPS.

Three HTTP anchors to GitHub-owned domains are left unchanged. Let me know if you want those updated as well.