### PR TITLE
Do not bring the converter along into the response.

### DIFF
--- a/retrofit-adapters/rxjava/src/test/java/retrofit/ObservableCallAdapterFactoryTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit/ObservableCallAdapterFactoryTest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
 import org.junit.Test;
-import retrofit.converter.GsonConverter;
 import rx.Observable;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,8 +48,7 @@ public final class ObservableCallAdapterFactoryTest {
     Observable<String> observable = (Observable<String>) adapter.adapt(new EmptyCall() {
       @Override public void enqueue(Callback<Object> callback) {
         callback.success(
-            Response.fromError(404, ResponseBody.create(MediaType.parse("application/json"), "Hi"),
-                new GsonConverter()));
+            Response.fromError(404, ResponseBody.create(MediaType.parse("application/json"), "Hi")));
       }
     });
     try {

--- a/retrofit/src/main/java/retrofit/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit/OkHttpCall.java
@@ -147,7 +147,7 @@ final class OkHttpCall<T> implements Call<T> {
       rawBody.close();
     }
 
-    return new Response<>(rawResponse, converted, body, converter);
+    return new Response<>(rawResponse, converted, body);
   }
 
   public void cancel() {

--- a/retrofit/src/test/java/retrofit/CallTest.java
+++ b/retrofit/src/test/java/retrofit/CallTest.java
@@ -98,10 +98,10 @@ public final class CallTest {
     Response<String> response = example.getMethod().execute();
     assertThat(response.isSuccess()).isFalse();
     assertThat(response.code()).isEqualTo(404);
-    assertThat(response.errorBodyAs(String.class)).isEqualTo("Hi");
+    assertThat(response.errorBody().string()).isEqualTo("Hi");
   }
 
-  @Test public void http404Async() throws InterruptedException {
+  @Test public void http404Async() throws InterruptedException, IOException {
     RestAdapter ra = new RestAdapter.Builder()
         .endpoint(server.getUrl("/").toString())
         .build();
@@ -126,7 +126,7 @@ public final class CallTest {
     Response<String> response = responseRef.get();
     assertThat(response.isSuccess()).isFalse();
     assertThat(response.code()).isEqualTo(404);
-    assertThat(response.errorBodyAs(String.class)).isEqualTo("Hi");
+    assertThat(response.errorBody().string()).isEqualTo("Hi");
   }
 
   @Test public void transportProblemSync() {


### PR DESCRIPTION
We used to do this with RetrofitError and it was always very strange. We cannot guarantee the contents of the error body let alone the serialization mechanism. The semantics of conversion only make sense for successful responses. If you want to deserialize the error body, bring your converter instance which access the ResponseBody that Response already has.

@swankjesse 