### PR TITLE
Adds retrofit-typedrequest optional module for builder style requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <module>retrofit-adapters</module>
     <module>retrofit-converters</module>
     <module>retrofit-mock</module>
+    <module>retrofit-typedrequest</module>
     <module>samples</module>
   </modules>
 

--- a/retrofit-adapters/rxjava/src/test/java/retrofit/RxJavaCallAdapterFactoryTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit/RxJavaCallAdapterFactoryTest.java
@@ -21,13 +21,16 @@ import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+
 import retrofit.http.GET;
 import rx.Observable;
 import rx.Single;

--- a/retrofit-converters/gson/src/test/java/retrofit/GsonConverterFactoryTest.java
+++ b/retrofit-converters/gson/src/test/java/retrofit/GsonConverterFactoryTest.java
@@ -24,10 +24,13 @@ import com.google.gson.stream.JsonWriter;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
-import java.io.IOException;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.IOException;
+
 import retrofit.http.Body;
 import retrofit.http.POST;
 

--- a/retrofit-converters/jackson/src/test/java/retrofit/JacksonConverterFactoryTest.java
+++ b/retrofit-converters/jackson/src/test/java/retrofit/JacksonConverterFactoryTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import retrofit.http.Body;
 import retrofit.http.POST;
 

--- a/retrofit-converters/moshi/src/test/java/retrofit/MoshiConverterFactoryTest.java
+++ b/retrofit-converters/moshi/src/test/java/retrofit/MoshiConverterFactoryTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import retrofit.http.Body;
 import retrofit.http.POST;
 

--- a/retrofit-converters/protobuf/src/test/java/retrofit/ProtoConverterFactoryTest.java
+++ b/retrofit-converters/protobuf/src/test/java/retrofit/ProtoConverterFactoryTest.java
@@ -19,13 +19,16 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
-import java.io.IOException;
-import java.util.List;
-import okio.Buffer;
-import okio.ByteString;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import okio.Buffer;
+import okio.ByteString;
 import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.POST;

--- a/retrofit-converters/simplexml/src/test/java/retrofit/SimpleXmlConverterFactoryTest.java
+++ b/retrofit-converters/simplexml/src/test/java/retrofit/SimpleXmlConverterFactoryTest.java
@@ -27,6 +27,7 @@ import org.simpleframework.xml.core.Persister;
 import org.simpleframework.xml.stream.Format;
 import org.simpleframework.xml.stream.HyphenStyle;
 import org.simpleframework.xml.stream.Verbosity;
+
 import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.POST;

--- a/retrofit-converters/wire/src/test/java/retrofit/WireConverterFactoryTest.java
+++ b/retrofit-converters/wire/src/test/java/retrofit/WireConverterFactoryTest.java
@@ -18,14 +18,17 @@ package retrofit;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
-import java.io.EOFException;
-import java.io.IOException;
-import java.util.List;
-import okio.Buffer;
-import okio.ByteString;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.List;
+
+import okio.Buffer;
+import okio.ByteString;
 import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.POST;

--- a/retrofit-typedrequest/pom.xml
+++ b/retrofit-typedrequest/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.squareup.retrofit</groupId>
+        <artifactId>parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>retrofit-typedrequest</artifactId>
+    <name>Typed Request</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.squareup.retrofit</groupId>
+            <artifactId>retrofit</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit</groupId>
+            <artifactId>adapter-rxjava</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit</groupId>
+            <artifactId>converter-gson</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex</groupId>
+            <artifactId>rxjava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/retrofit-typedrequest/src/main/java/retrofit/CallableRequest.java
+++ b/retrofit-typedrequest/src/main/java/retrofit/CallableRequest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+public final class CallableRequest extends TypedRequest {
+  private CallableRequest(Retrofit retrofit, ParameterizedType returnType,
+      BodyEncoding bodyEncoding, String path, Method method, Object body, Object tag,
+      List<Query> query, Map<String, String> headers, List<Part> parts, List<Field> fields) {
+    super(retrofit, returnType, bodyEncoding, path,
+        method, body, tag, query, headers, parts, fields);
+  }
+
+  public Builder newBuilder(Retrofit retrofit) {
+    return new Builder(retrofit, this);
+  }
+
+  public static final class Builder extends TypedRequest.Builder {
+
+    public Builder(Retrofit retrofit) {
+      super(retrofit);
+    }
+
+    public Builder(Retrofit retrofit, CallableRequest callableRequest) {
+      super(retrofit, callableRequest);
+    }
+
+    @Override protected TypedRequest newRequest() {
+      ParameterizedType returnType = new ParameterizedType() {
+        @Override public Type[] getActualTypeArguments() {
+          return new Type[] { responseType };
+        }
+
+        @Override public Type getRawType() {
+          return Call.class;
+        }
+
+        @Override public Type getOwnerType() {
+          return null;
+        }
+      };
+      return new CallableRequest(retrofit, returnType, bodyEncoding, path, method, body, tag, query,
+          headers, parts, fields);
+    }
+
+    @Override public Builder path(String path) {
+      return (Builder) super.path(path);
+    }
+
+    @Override public Builder method(Method method) {
+      return (Builder) super.method(method);
+    }
+
+    @Override public Builder tag(Object tag) {
+      return (Builder) super.tag(tag);
+    }
+
+    @Override public Builder body(Object body) {
+      return (Builder) super.body(body);
+    }
+
+    @Override public Builder queryParams(List<Query> query) {
+      return (Builder) super.queryParams(query);
+    }
+
+    @Override public Builder headers(Map<String, String> headers) {
+      return (Builder) super.headers(headers);
+    }
+
+    @Override public Builder parts(List<Part> parts) {
+      return (Builder) super.parts(parts);
+    }
+
+    @Override public Builder fields(List<Field> fields) {
+      return (Builder) super.fields(fields);
+    }
+
+    @Override public Builder responseType(Type responseType) {
+      return (Builder) super.responseType(responseType);
+    }
+
+    @Override public CallableRequest build() {
+      return (CallableRequest) super.build();
+    }
+  }
+}

--- a/retrofit-typedrequest/src/main/java/retrofit/Field.java
+++ b/retrofit-typedrequest/src/main/java/retrofit/Field.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+public class Field {
+  private final String name;
+  private final Object value;
+  private final boolean encoded;
+
+  public Field(String name, Object value, boolean encoded) {
+    this.name = name;
+    this.value = value;
+    this.encoded = encoded;
+  }
+
+  public Field(String name, Object value) {
+    this(name, value, false);
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public Object value() {
+    return value;
+  }
+
+  public boolean encoded() {
+    return encoded;
+  }
+}

--- a/retrofit-typedrequest/src/main/java/retrofit/Method.java
+++ b/retrofit-typedrequest/src/main/java/retrofit/Method.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+public enum Method {
+  GET, POST, PUT, PATCH, HEAD, DELETE, OPTIONS, TRACE
+}

--- a/retrofit-typedrequest/src/main/java/retrofit/ObservableRequest.java
+++ b/retrofit-typedrequest/src/main/java/retrofit/ObservableRequest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+import rx.Observable;
+
+public final class ObservableRequest extends TypedRequest {
+  ObservableRequest(Retrofit retrofit, ParameterizedType returnType, BodyEncoding bodyEncoding,
+      String path, Method method, Object body, Object tag, List<Query> query,
+      Map<String, String> headers, List<Part> parts, List<Field> fields) {
+    super(retrofit, returnType, bodyEncoding,
+        path, method, body, tag, query, headers, parts, fields);
+  }
+
+  public Builder newBuilder(Retrofit retrofit) {
+    return new Builder(retrofit, this);
+  }
+
+  public static final class Builder extends TypedRequest.Builder {
+
+    public Builder(Retrofit retrofit) {
+      super(retrofit);
+    }
+
+    public Builder(Retrofit retrofit, ObservableRequest observableRequest) {
+      super(retrofit, observableRequest);
+    }
+
+    @Override protected TypedRequest newRequest() {
+      ParameterizedType returnType = new ParameterizedType() {
+        @Override public Type[] getActualTypeArguments() {
+          return new Type[] { responseType };
+        }
+
+        @Override public Type getRawType() {
+          return Observable.class;
+        }
+
+        @Override public Type getOwnerType() {
+          return null;
+        }
+      };
+      return new ObservableRequest(retrofit, returnType, bodyEncoding, path, method, body, tag,
+          query, headers, parts, fields);
+    }
+
+    @Override public Builder path(String path) {
+      return (Builder) super.path(path);
+    }
+
+    @Override public Builder method(Method method) {
+      return (Builder) super.method(method);
+    }
+
+    @Override public Builder tag(Object tag) {
+      return (Builder) super.tag(tag);
+    }
+
+    @Override public Builder body(Object body) {
+      return (Builder) super.body(body);
+    }
+
+    @Override public Builder queryParams(List<Query> query) {
+      return (Builder) super.queryParams(query);
+    }
+
+    @Override public Builder headers(Map<String, String> headers) {
+      return (Builder) super.headers(headers);
+    }
+
+    @Override public Builder parts(List<Part> parts) {
+      return (Builder) super.parts(parts);
+    }
+
+    @Override public Builder fields(List<Field> fields) {
+      return (Builder) super.fields(fields);
+    }
+
+    @Override public Builder responseType(Type responseType) {
+      return (Builder) super.responseType(responseType);
+    }
+
+    @Override public ObservableRequest build() {
+      return (ObservableRequest) super.build();
+    }
+  }
+}

--- a/retrofit-typedrequest/src/main/java/retrofit/Part.java
+++ b/retrofit-typedrequest/src/main/java/retrofit/Part.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+public class Part {
+  private final String name;
+  private final Object value;
+  private final String encoding;
+  private final String filename;
+
+  public Part(String name, Object value, String encoding, String filename) {
+    this.name = name;
+    this.value = value;
+    this.encoding = encoding;
+    this.filename = filename;
+  }
+
+  public Part(String name, Object value, String encoding) {
+    this(name, value, encoding, null);
+  }
+
+  public Part(String name, Object value) {
+    this(name, value, "binary");
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public Object value() {
+    return value;
+  }
+
+  public String encoding() {
+    return encoding;
+  }
+
+  public String filename() {
+    return filename;
+  }
+}

--- a/retrofit-typedrequest/src/main/java/retrofit/Query.java
+++ b/retrofit-typedrequest/src/main/java/retrofit/Query.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+public class Query {
+
+  private final String name;
+  private final String value;
+  private final boolean encoded;
+
+  public Query(String name, String value) {
+    this(name, value, false);
+  }
+
+  public Query(String name, String value, boolean encoded) {
+    this.name = name;
+    this.value = value;
+    this.encoded = encoded;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public String value() {
+    return value;
+  }
+
+  public boolean encoded() {
+    return encoded;
+  }
+
+  @Override public String toString() {
+    return "Query{name: " + name + ", value: " + value + ", encoded: " + encoded + "}";
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Query query = (Query) o;
+
+    if (encoded != query.encoded) {
+      return false;
+    }
+    //noinspection SimplifiableIfStatement
+    if (name != null ? !name.equals(query.name) : query.name != null) {
+      return false;
+    }
+    return !(value != null ? !value.equals(query.value) : query.value != null);
+
+  }
+
+  @Override public int hashCode() {
+    int result = name != null ? name.hashCode() : 0;
+    result = 31 * result + (value != null ? value.hashCode() : 0);
+    result = 31 * result + (encoded ? 1 : 0);
+    return result;
+  }
+}

--- a/retrofit-typedrequest/src/main/java/retrofit/TypedRawRequestFactory.java
+++ b/retrofit-typedrequest/src/main/java/retrofit/TypedRawRequestFactory.java
@@ -1,0 +1,19 @@
+package retrofit;
+
+import com.squareup.okhttp.Request;
+
+class TypedRawRequestFactory implements RequestFactory {
+  private final Retrofit retrofit;
+  private final TypedRequest request;
+
+  TypedRawRequestFactory(Retrofit retrofit, TypedRequest request) {
+    this.retrofit = retrofit;
+    this.request = request;
+  }
+
+  @Override public Request create(Object... args) {
+    TypedRequestRawRequestBuilder requestBuilder =
+        new TypedRequestRawRequestBuilder(retrofit, request);
+    return requestBuilder.build();
+  }
+}

--- a/retrofit-typedrequest/src/main/java/retrofit/TypedRequest.java
+++ b/retrofit-typedrequest/src/main/java/retrofit/TypedRequest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.squareup.okhttp.ResponseBody;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static retrofit.Utils.checkNotNull;
+
+public abstract class TypedRequest {
+
+  enum BodyEncoding {
+    NONE,
+    MULTIPART,
+    FORM_URL_ENCODED
+  }
+
+  private final Retrofit retrofit;
+  protected final ParameterizedType returnType;
+  protected final BodyEncoding bodyEncoding;
+  protected final String path;
+  protected final Method method;
+  protected final Object body;
+  protected final Object tag;
+  protected final List<Query> query;
+  protected final Map<String, String> headers;
+  protected final List<Part> parts;
+  protected final List<Field> fields;
+  protected final CallAdapter callAdapter;
+  protected final TypedRawRequestFactory requestFactory;
+  protected final Converter<ResponseBody, Object> converter;
+  protected boolean isCancelled;
+
+  TypedRequest(Retrofit retrofit, ParameterizedType returnType,
+      BodyEncoding bodyEncoding, String path, Method method, Object body, Object tag,
+      List<Query> query, Map<String, String> headers, List<Part> parts, List<Field> fields) {
+    this.retrofit = retrofit;
+    this.returnType = returnType;
+    this.path = path;
+    this.method = method;
+    this.body = body;
+    this.tag = tag;
+    this.query = query;
+    this.headers = headers;
+    this.parts = parts;
+    this.fields = fields;
+    this.bodyEncoding = bodyEncoding;
+    this.callAdapter = retrofit.callAdapter(returnType, new Annotation[0]);
+    this.requestFactory = new TypedRawRequestFactory(retrofit, this);
+    this.converter = retrofit.responseConverter(callAdapter.responseType(), new Annotation[0]);
+  }
+
+  public String path() {
+    return path;
+  }
+
+  public Method method() {
+    return method;
+  }
+
+  public Object body() {
+    return body;
+  }
+
+  public Object tag() {
+    return tag;
+  }
+
+  public List<Query> queryParams() {
+    return query;
+  }
+
+  public Map<String, String> headers() {
+    return headers;
+  }
+
+  public List<Part> parts() {
+    return parts;
+  }
+
+  public List<Field> fields() {
+    return fields;
+  }
+
+  public BodyEncoding bodyEncoding() {
+    return bodyEncoding;
+  }
+
+  public void cancel() {
+    isCancelled = true;
+  }
+
+  public boolean isCancelled() {
+    return isCancelled;
+  }
+
+  public ParameterizedType returnType() {
+    return returnType;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> T newCall() {
+    return (T) callAdapter.adapt(new OkHttpCall(retrofit, requestFactory, converter, null));
+  }
+
+  private RuntimeException requestError(String message, Object... args) {
+    if (args.length > 0) {
+      message = String.format(message, args);
+    }
+    return new IllegalArgumentException(getClass().getSimpleName() + ": " + message);
+  }
+
+  public abstract static class Builder {
+    protected final Retrofit retrofit;
+    protected Type responseType;
+    protected BodyEncoding bodyEncoding = BodyEncoding.NONE;
+    protected String path;
+    protected Method method;
+    protected Object body;
+    protected Object tag;
+    protected List<Query> query = Collections.emptyList();
+    protected Map<String, String> headers = Collections.emptyMap();
+    protected List<Part> parts = Collections.emptyList();
+    protected List<Field> fields = Collections.emptyList();
+
+    public Builder(Retrofit retrofit, TypedRequest request) {
+      this(retrofit);
+      path = request.path;
+      method = request.method;
+      tag = request.tag;
+      body = request.body;
+      responseType = request.returnType.getActualTypeArguments()[0];
+
+      if (query != null && !query.isEmpty()) {
+        query = request.query;
+      }
+      if (headers != null && !headers.isEmpty()) {
+        headers = request.headers;
+      }
+      if (fields != null && !fields.isEmpty()) {
+        fields = request.fields;
+        bodyEncoding = BodyEncoding.FORM_URL_ENCODED;
+      }
+      if (parts != null && !parts.isEmpty()) {
+        parts = request.parts;
+        bodyEncoding = BodyEncoding.MULTIPART;
+      }
+    }
+
+    public Builder(Retrofit retrofit) {
+      this.retrofit = retrofit;
+    }
+
+    public Builder path(String path) {
+      this.path = path;
+      return this;
+    }
+
+    public Builder method(Method method) {
+      this.method = checkNotNull(method, "method == null");
+      return this;
+    }
+
+    public Builder tag(Object tag) {
+      this.tag = tag;
+      return this;
+    }
+
+    public Builder body(Object body) {
+      this.body = body;
+      return this;
+    }
+
+    public Builder queryParams(List<Query> query) {
+      this.query = Utils.checkNotNull(query, "query == null");
+      return this;
+    }
+
+    public Builder headers(Map<String, String> headers) {
+      this.headers = checkNotNull(headers, "headers == null");
+      return this;
+    }
+
+    public Builder parts(List<Part> parts) {
+      this.parts = checkNotNull(parts, "parts == null");
+      bodyEncoding = BodyEncoding.MULTIPART;
+      return this;
+    }
+
+    public Builder fields(List<Field> fields) {
+      this.fields = checkNotNull(fields, "fields == null");
+      bodyEncoding = BodyEncoding.FORM_URL_ENCODED;
+      return this;
+    }
+
+    public Builder responseType(Type responseType) {
+      this.responseType = responseType;
+      return this;
+    }
+
+    public TypedRequest build() {
+      checkNotNull(path, "path == null");
+      checkNotNull(method, "method == null");
+      checkNotNull(responseType, "responseType == null");
+
+      if (path.length() == 0 || path.charAt(0) != '/') {
+        throw new IllegalArgumentException("URL path \"" + path + "\" must start with '/'.");
+      }
+
+      boolean requestHasBody =
+          method == Method.PATCH || method == Method.POST || method == Method.PUT;
+
+      boolean gotBody = body != null;
+      boolean gotField = !fields.isEmpty();
+      boolean gotPart = !parts.isEmpty();
+
+      if (bodyEncoding == BodyEncoding.NONE && !requestHasBody && gotBody) {
+        throw new IllegalArgumentException("Non-body HTTP method cannot contain body.");
+      }
+      if (bodyEncoding == BodyEncoding.FORM_URL_ENCODED && !gotField) {
+        throw new IllegalArgumentException("Form-encoded method must contain at least one field.");
+      }
+      if (bodyEncoding == BodyEncoding.MULTIPART && !gotPart) {
+        throw new IllegalArgumentException("Multipart method must contain at least one part.");
+      }
+
+      return newRequest();
+    }
+
+    protected abstract TypedRequest newRequest();
+  }
+}

--- a/retrofit-typedrequest/src/main/java/retrofit/TypedRequestRawRequestBuilder.java
+++ b/retrofit-typedrequest/src/main/java/retrofit/TypedRequestRawRequestBuilder.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.squareup.okhttp.FormEncodingBuilder;
+import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.HttpUrl;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.MultipartBuilder;
+import com.squareup.okhttp.RequestBody;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.lang.annotation.Annotation;
+import java.net.URLEncoder;
+import java.util.Map;
+
+import okio.BufferedSink;
+
+final class TypedRequestRawRequestBuilder {
+
+  private static final Headers NO_HEADERS = Headers.of();
+
+  private final String requestMethod;
+  private final HttpUrl.Builder urlBuilder;
+  private final TypedRequest request;
+  private final boolean hasBody;
+  private final Retrofit retrofit;
+
+  private MultipartBuilder multipartBuilder;
+  private FormEncodingBuilder formEncodingBuilder;
+  private RequestBody body;
+
+  private String relativeUrl;
+  private StringBuilder queryParams;
+  private Headers.Builder headers;
+  private String contentTypeHeader;
+
+  TypedRequestRawRequestBuilder(Retrofit retrofit, TypedRequest request) {
+    this.retrofit = retrofit;
+    this.urlBuilder = retrofit.baseUrl().url().newBuilder();
+    this.request = request;
+    this.requestMethod = request.method().name();
+    this.hasBody = "PATCH".equals(requestMethod) || "POST".equals(requestMethod)
+        || "PUT".equals(requestMethod);
+
+    if (request.bodyEncoding() == TypedRequest.BodyEncoding.FORM_URL_ENCODED) {
+      // Will be set to 'body' in 'build'.
+      formEncodingBuilder = new FormEncodingBuilder();
+    } else if (request.bodyEncoding() == TypedRequest.BodyEncoding.MULTIPART) {
+      // Will be set to 'body' in 'build'.
+      multipartBuilder = new MultipartBuilder().type(MultipartBuilder.FORM);
+    }
+
+    addPath();
+    addBody();
+    addHeaders();
+    addQueryParams();
+    addFields();
+    addParts();
+  }
+
+  private void addFields() {
+    if (!(request.bodyEncoding() == TypedRequest.BodyEncoding.FORM_URL_ENCODED)) {
+      return;
+    }
+
+    for (Field field : request.fields()) {
+      String entryKey = field.name();
+      if (entryKey == null) {
+        throw new IllegalArgumentException("Parameter field map contained null key.");
+      }
+      Object entryValue = field.value();
+      if (entryValue != null) { // Skip null values.
+        if (!field.encoded()) {
+          formEncodingBuilder.add(entryKey, entryValue.toString());
+        } else {
+          formEncodingBuilder.addEncoded(entryKey, entryValue.toString());
+        }
+      }
+    }
+  }
+
+  private void addParts() {
+    if (!(request.bodyEncoding() == TypedRequest.BodyEncoding.MULTIPART)) {
+      return;
+    }
+    for (Part part : request.parts()) {
+      String entryKey = part.name();
+      if (entryKey == null) {
+        throw new IllegalArgumentException("Part map contained null key.");
+      }
+      Object entryValue = part.value();
+      StringBuilder contentDisposition = new StringBuilder();
+      contentDisposition.append("form-data; name=\"");
+      contentDisposition.append(entryKey);
+      contentDisposition.append("\"");
+      if (part.filename() != null) {
+        contentDisposition.append("; filename=\"");
+        contentDisposition.append(part.filename());
+        contentDisposition.append("\"");
+      }
+      Headers headers = Headers.of(
+          "Content-Disposition", contentDisposition.toString(),
+          "Content-Transfer-Encoding", part.encoding());
+      if (entryValue != null) { // Skip null values.
+        if (entryValue instanceof RequestBody) {
+          multipartBuilder.addPart(headers, (RequestBody) entryValue);
+        } else if (entryValue instanceof String) {
+          multipartBuilder.addPart(headers, RequestBody.create(
+              MediaType.parse("text/plain"), (String) entryValue));
+        } else {
+          //noinspection unchecked
+          Converter<Object, RequestBody> converter =
+              retrofit.requestConverter(entryValue.getClass(), new Annotation[0]);
+          RequestBody body;
+          try {
+            //noinspection unchecked
+            body = converter.convert(entryValue);
+          } catch (IOException e) {
+            throw new RuntimeException("Unable to convert " + entryValue + " to RequestBody");
+          }
+          multipartBuilder.addPart(headers, body);
+        }
+      }
+    }
+  }
+
+  private void addPath() {
+    String url = request.path();
+    String query = null;
+    int question = request.path().indexOf('?');
+    if (question != -1 && question < request.path().length() - 1) {
+      url = request.path().substring(0, question);
+      query = request.path().substring(question + 1);
+    }
+
+    relativeUrl = url;
+
+    if (query != null) {
+      queryParams = new StringBuilder().append('?').append(query);
+    }
+  }
+
+  private void addBody() {
+    Object body = request.body();
+    if (body instanceof RequestBody) {
+      this.body = (RequestBody) body;
+    } else if (body != null) {
+      //noinspection unchecked
+      Converter<Object, RequestBody> converter =
+          retrofit.requestConverter(body.getClass(), new Annotation[0]);
+      RequestBody requestBody;
+      try {
+        //noinspection unchecked
+        requestBody = converter.convert(body);
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to convert " + body + " to RequestBody");
+      }
+      this.body = requestBody;
+    }
+  }
+
+  private void addHeaders() {
+    Map<String, String> headers = request.headers();
+    if (headers != null) {
+      this.headers = parseHeaders(headers).newBuilder();
+    }
+  }
+
+  com.squareup.okhttp.Headers parseHeaders(Map<String, String> headers) {
+    com.squareup.okhttp.Headers.Builder builder = new com.squareup.okhttp.Headers.Builder();
+    for (Map.Entry<String, String> entry : headers.entrySet()) {
+      String entryKey = entry.getKey();
+      if (entryKey == null) {
+        throw new IllegalArgumentException("Header map contained null key.");
+      }
+      String entryValue = entry.getValue();
+      if (entryValue != null) {
+        if ("Content-Type".equalsIgnoreCase(entryKey)) {
+          contentTypeHeader = entryValue;
+        } else {
+          builder.add(entryKey, entryValue);
+        }
+      }
+    }
+    return builder.build();
+  }
+
+  private void addQueryParam(String name, String value, boolean encoded) {
+    if (name == null) {
+      throw new IllegalArgumentException("Query param name must not be null.");
+    }
+    if (value == null) {
+      throw new IllegalArgumentException("Query param \"" + name + "\" value must not be null.");
+    }
+    try {
+      StringBuilder queryParams = this.queryParams;
+      if (queryParams == null) {
+        this.queryParams = queryParams = new StringBuilder();
+      }
+
+      queryParams.append(queryParams.length() > 0 ? '&' : '?');
+
+      if (!encoded) {
+        name = URLEncoder.encode(name, "UTF-8");
+        value = URLEncoder.encode(value, "UTF-8");
+      }
+      queryParams.append(name).append('=').append(value);
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(
+          "Unable to convert query parameter \"" + name + "\" value to UTF-8: " + value, e);
+    }
+  }
+
+  private void addQueryParams() {
+    for (Query query : request.queryParams()) {
+      String entryKey = query.name();
+      if (entryKey == null) {
+        throw new IllegalArgumentException("Parameter query map contained null key.");
+      }
+      String entryValue = query.value();
+      if (entryValue != null) { // Skip null values.
+        addQueryParam(entryKey, entryValue, query.encoded());
+      }
+    }
+  }
+
+  com.squareup.okhttp.Request build() {
+    String apiUrl = urlBuilder.build().toString();
+    StringBuilder url = new StringBuilder(apiUrl);
+    if (apiUrl.endsWith("/")) {
+      // We require relative paths to start with '/'. Prevent a double-slash.
+      url.deleteCharAt(url.length() - 1);
+    }
+
+    url.append(relativeUrl);
+
+    StringBuilder queryParams = this.queryParams;
+    if (queryParams != null) {
+      url.append(queryParams);
+    }
+
+    RequestBody body = this.body;
+    if (body == null) {
+      // Try to pull from one of the builders.
+      if (formEncodingBuilder != null) {
+        body = formEncodingBuilder.build();
+      } else if (multipartBuilder != null) {
+        body = multipartBuilder.build();
+      } else if (hasBody) {
+        // Body is absent, make an empty body.
+        body = RequestBody.create(null, new byte[0]);
+      }
+    }
+
+    Headers.Builder headerBuilder = this.headers;
+    if (contentTypeHeader != null) {
+      if (body != null) {
+        body = new MediaTypeOverridingRequestBody(body, contentTypeHeader);
+      } else {
+        if (headerBuilder == null) {
+          headerBuilder = new Headers.Builder();
+        }
+        headerBuilder.add("Content-Type", contentTypeHeader);
+      }
+    }
+    Headers headers = headerBuilder != null ? headerBuilder.build() : NO_HEADERS;
+
+    return new com.squareup.okhttp.Request.Builder()
+        .url(url.toString())
+        .method(requestMethod, body)
+        .headers(headers)
+        .tag(request.tag())
+        .build();
+  }
+
+  private static class MediaTypeOverridingRequestBody extends RequestBody {
+
+    private final RequestBody delegate;
+    private final MediaType mediaType;
+
+    MediaTypeOverridingRequestBody(RequestBody delegate, String mediaType) {
+      this.delegate = delegate;
+      this.mediaType = MediaType.parse(mediaType);
+    }
+
+    @Override public MediaType contentType() {
+      return mediaType;
+    }
+
+    @Override public long contentLength() throws IOException {
+      return delegate.contentLength();
+    }
+
+    @Override public void writeTo(BufferedSink sink) throws IOException {
+      delegate.writeTo(sink);
+    }
+  }
+}

--- a/retrofit-typedrequest/src/test/java/retrofit/CallableRequestBuilderTest.java
+++ b/retrofit-typedrequest/src/test/java/retrofit/CallableRequestBuilderTest.java
@@ -1,0 +1,65 @@
+package retrofit;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+
+import org.junit.Test;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CallableRequestBuilderTest {
+  @Test public void testTypes() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl("http://example.com")
+        .addConverterFactory(new StringListConverterFactory())
+        .build();
+
+    Type responseType = new TypeToken<List<String>>(getClass()) { }.getType();
+    CallableRequest request = new CallableRequest.Builder(retrofit)
+        .path("/")
+        .responseType(responseType)
+        .method(Method.GET)
+        .build();
+
+    Type returnType = request.returnType();
+    assertThat(returnType).isInstanceOf(ParameterizedType.class);
+    ParameterizedType parameterizedType = (ParameterizedType) returnType;
+    assertThat(parameterizedType.getRawType()).isEqualTo(Call.class);
+    assertThat(parameterizedType.getActualTypeArguments()[0]).isEqualTo(responseType);
+  }
+
+  @Test public void newBuilder() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl("http://example.com")
+        .addConverterFactory(new StringListConverterFactory())
+        .build();
+
+    CallableRequest request = new CallableRequest.Builder(retrofit)
+        .path("/")
+        .responseType(
+            new TypeToken<List<String>>(CallableRequestBuilderTest.this.getClass()) {
+            }.getType())
+        .method(Method.GET)
+        .build();
+
+    ImmutableList<Query> params = ImmutableList.of(new Query("foo", "bar"));
+    ImmutableList<Part> parts = ImmutableList.of(new Part("kit", "kat"));
+    CallableRequest newRequest = request.newBuilder(retrofit)
+        .path("/abc")
+        .method(Method.POST)
+        .queryParams(params)
+        .body(123)
+        .parts(parts)
+        .build();
+
+    assertThat(newRequest.path()).isEqualTo("/abc");
+    assertThat(newRequest.method()).isEqualTo(Method.POST);
+    assertThat(newRequest.queryParams()).isEqualTo(params);
+    assertThat(newRequest.body()).isEqualTo(123);
+    assertThat(newRequest.parts()).isEqualTo(parts);
+  }
+}

--- a/retrofit-typedrequest/src/test/java/retrofit/CallableRequestTest.java
+++ b/retrofit-typedrequest/src/test/java/retrofit/CallableRequestTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class CallableRequestTest {
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  @Test public void http200Sync() throws IOException {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/").toString())
+        .addConverterFactory(new StringConverterFactory())
+        .build();
+
+    CallableRequest request = new CallableRequest.Builder(retrofit)
+        .path("/")
+        .responseType(String.class)
+        .method(Method.GET)
+        .build();
+
+    Call<String> call = request.newCall();
+
+    Response<String> response = call.execute();
+    assertThat(response.isSuccess()).isTrue();
+    assertThat(response.body()).isEqualTo("Hi");
+  }
+
+  @Test public void http200Async() throws InterruptedException {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/").toString())
+        .addConverterFactory(new StringConverterFactory())
+        .build();
+
+    CallableRequest request = new CallableRequest.Builder(retrofit)
+        .path("/")
+        .responseType(String.class)
+        .method(Method.GET)
+        .build();
+
+    Call<String> call = request.newCall();
+
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    final AtomicReference<Response<String>> responseRef = new AtomicReference<>();
+    final CountDownLatch latch = new CountDownLatch(1);
+    call.enqueue(new Callback<String>() {
+      @Override public void onResponse(Response<String> response, Retrofit retrofit) {
+        responseRef.set(response);
+        latch.countDown();
+      }
+
+      @Override public void onFailure(Throwable t) {
+        t.printStackTrace();
+      }
+    });
+    assertTrue(latch.await(2, SECONDS));
+
+    Response<String> response = responseRef.get();
+    assertThat(response.isSuccess()).isTrue();
+    assertThat(response.body()).isEqualTo("Hi");
+  }
+}

--- a/retrofit-typedrequest/src/test/java/retrofit/GsonConverterFactory.java
+++ b/retrofit-typedrequest/src/test/java/retrofit/GsonConverterFactory.java
@@ -1,0 +1,54 @@
+package retrofit;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.ResponseBody;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * A {@linkplain Converter.Factory converter} which uses Gson for JSON.
+ * <p>
+ * Because Gson is so flexible in the types it supports, this converter assumes that it can handle
+ * all types. If you are mixing JSON serialization with something else (such as protocol buffers),
+ * you must {@linkplain Retrofit.Builder#addConverterFactory(Converter.Factory) add this instance}
+ * last to allow the other converters a chance to see their types.
+ */
+public final class GsonConverterFactory extends Converter.Factory {
+  /**
+   * Create an instance using a default {@link Gson} instance for conversion. Encoding to JSON and
+   * decoding from JSON (when no charset is specified by a header) will use UTF-8.
+   */
+  public static GsonConverterFactory create() {
+    return create(new Gson());
+  }
+
+  /**
+   * Create an instance using {@code gson} for conversion. Encoding to JSON and
+   * decoding from JSON (when no charset is specified by a header) will use UTF-8.
+   */
+  public static GsonConverterFactory create(Gson gson) {
+    return new GsonConverterFactory(gson);
+  }
+
+  private final Gson gson;
+
+  private GsonConverterFactory(Gson gson) {
+    if (gson == null) throw new NullPointerException("gson == null");
+    this.gson = gson;
+  }
+
+  @Override
+  public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+    TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
+    return new GsonResponseBodyConverter<>(adapter);
+  }
+
+  @Override public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+    TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
+    return new GsonRequestBodyConverter<>(gson, adapter);
+  }
+}

--- a/retrofit-typedrequest/src/test/java/retrofit/ObservableRequestBuilderTest.java
+++ b/retrofit-typedrequest/src/test/java/retrofit/ObservableRequestBuilderTest.java
@@ -1,0 +1,36 @@
+package retrofit;
+
+import com.google.common.reflect.TypeToken;
+
+import org.junit.Test;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import rx.Observable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObservableRequestBuilderTest {
+  @Test public void testTypes() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl("http://example.com")
+        .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+        .addConverterFactory(new StringListConverterFactory())
+        .build();
+
+    Type responseType = new TypeToken<List<String>>(getClass()) { }.getType();
+    ObservableRequest request = new ObservableRequest.Builder(retrofit)
+        .path("/")
+        .responseType(responseType)
+        .method(Method.GET)
+        .build();
+
+    Type returnType = request.returnType();
+    assertThat(returnType).isInstanceOf(ParameterizedType.class);
+    ParameterizedType parameterizedType = (ParameterizedType) returnType;
+    assertThat(parameterizedType.getRawType()).isEqualTo(Observable.class);
+    assertThat(parameterizedType.getActualTypeArguments()[0]).isEqualTo(responseType);
+  }
+}

--- a/retrofit-typedrequest/src/test/java/retrofit/ObservableRequestTest.java
+++ b/retrofit-typedrequest/src/test/java/retrofit/ObservableRequestTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.google.common.reflect.TypeToken;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import rx.Observable;
+import rx.observables.BlockingObservable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObservableRequestTest {
+
+  @Rule public final MockWebServer server = new MockWebServer();
+  private Retrofit retrofit;
+
+  @Before public void setUp() {
+    retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/").toString())
+        .addConverterFactory(new StringConverterFactory())
+        .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+        .build();
+  }
+
+  @Test public void bodySuccess200() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    ObservableRequest request = new ObservableRequest.Builder(retrofit)
+        .path("/")
+        .responseType(String.class)
+        .method(Method.GET)
+        .build();
+
+    Observable<String> observable = request.newCall();
+    BlockingObservable<String> o = observable.toBlocking();
+    assertThat(o.first()).isEqualTo("Hi");
+  }
+
+  @Test public void responseSuccess200() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    ObservableRequest request =
+        new ObservableRequest.Builder(retrofit)
+            .path("/")
+            .responseType(new TypeToken<Response<String>>(getClass()) {}.getType())
+            .method(Method.GET)
+            .build();
+
+    Observable<Response<String>> observable = request.newCall();
+    BlockingObservable<Response<String>> o = observable.toBlocking();
+    Response<String> response = o.first();
+    assertThat(response.isSuccess()).isTrue();
+    assertThat(response.body()).isEqualTo("Hi");
+  }
+}

--- a/retrofit-typedrequest/src/test/java/retrofit/StringConverterFactory.java
+++ b/retrofit-typedrequest/src/test/java/retrofit/StringConverterFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.ResponseBody;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+class StringConverterFactory extends Converter.Factory {
+  private static final MediaType MEDIA_TYPE = MediaType.parse("text/plain");
+
+  @Override
+  public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+    if (String.class.equals(type)) {
+      return new Converter<ResponseBody, String>() {
+        @Override public String convert(ResponseBody value) throws IOException {
+          return value.string();
+        }
+      };
+    }
+    return null;
+  }
+
+  @Override public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+    if (String.class.equals(type)) {
+      return new Converter<String, RequestBody>() {
+        @Override public RequestBody convert(String value) throws IOException {
+          return RequestBody.create(MEDIA_TYPE, value);
+        }
+      };
+    }
+    return null;
+  }
+}

--- a/retrofit-typedrequest/src/test/java/retrofit/StringListConverterFactory.java
+++ b/retrofit-typedrequest/src/test/java/retrofit/StringListConverterFactory.java
@@ -1,0 +1,34 @@
+package retrofit;
+
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.ResponseBody;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+
+public class StringListConverterFactory extends Converter.Factory {
+  private static final MediaType MEDIA_TYPE = MediaType.parse("text/plain");
+
+  @Override
+  public Converter<ResponseBody, List<String>> fromResponseBody(Type type,
+      Annotation[] annotations) {
+    return new Converter<ResponseBody, List<String>>() {
+      @Override public List<String> convert(ResponseBody value) throws IOException {
+        return Collections.singletonList(value.string());
+      }
+    };
+  }
+
+  @Override public Converter<List<String>, RequestBody> toRequestBody(Type type,
+      Annotation[] annotations) {
+    return new Converter<List<String>, RequestBody>() {
+      @Override public RequestBody convert(List<String> value) throws IOException {
+        return RequestBody.create(MEDIA_TYPE, value.toString());
+      }
+    };
+  }
+}

--- a/retrofit-typedrequest/src/test/java/retrofit/TypedRequestRawRequestBuilderTest.java
+++ b/retrofit-typedrequest/src/test/java/retrofit/TypedRequestRawRequestBuilderTest.java
@@ -1,0 +1,493 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.GsonBuilder;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import okio.Buffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class TypedRequestRawRequestBuilderTest {
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  private Retrofit retrofit;
+
+  @Before public void setUp() {
+    retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/").toString())
+        .addConverterFactory(new StringConverterFactory())
+        .addConverterFactory(GsonConverterFactory.create(new GsonBuilder().create()))
+        .build();
+  }
+
+  @Test public void get() {
+    com.squareup.okhttp.Request request = buildRequest();
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void delete() {
+    com.squareup.okhttp.Request request = buildRequest(Method.DELETE);
+    assertThat(request.method()).isEqualTo("DELETE");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void head() {
+    com.squareup.okhttp.Request request = buildRequest(Method.HEAD);
+    assertThat(request.method()).isEqualTo("HEAD");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void post() {
+    RequestBody body = RequestBody.create(MediaType.parse("text/plain"), "hi");
+    com.squareup.okhttp.Request request = buildRequest(Method.POST, body);
+    assertThat(request.method()).isEqualTo("POST");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertBody(request.body(), "hi");
+  }
+
+  @Test public void put() {
+    RequestBody body = RequestBody.create(MediaType.parse("text/plain"), "hi");
+    com.squareup.okhttp.Request request = buildRequest(Method.PUT, body);
+    assertThat(request.method()).isEqualTo("PUT");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertBody(request.body(), "hi");
+  }
+
+  @Test public void patch() {
+    RequestBody body = RequestBody.create(MediaType.parse("text/plain"), "hi");
+    com.squareup.okhttp.Request request = buildRequest(Method.PATCH, body);
+    assertThat(request.method()).isEqualTo("PATCH");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertBody(request.body(), "hi");
+  }
+
+  @Test public void getWithPathParam() {
+    com.squareup.okhttp.Request request = buildRequest(Method.GET, null, "/foo/bar/po ng/");
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/po%20ng/").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void getWithEncodedPathParam() {
+    com.squareup.okhttp.Request request = buildRequest(Method.GET, null, "/foo/bar/po%20ng/");
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/po%20ng/").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void getWithQueryParam() {
+    com.squareup.okhttp.Request request =
+        buildRequest(Method.GET, null, "/foo/bar/", ImmutableList.of(new Query("ping", "pong")));
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/?ping=pong").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void getWithEncodeQueryParam() {
+    com.squareup.okhttp.Request request = buildRequest(
+        Method.GET, null, "/foo/bar/", ImmutableList.of(new Query("pi ng", "p o n g", false)));
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(
+        server.url("/foo/bar/?pi%20ng=p%20o%20n%20g").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void getWithEncodedQueryParam() {
+    com.squareup.okhttp.Request request = buildRequest(
+        Method.GET, null, "/foo/bar/",
+        ImmutableList.of(new Query("pi%20ng", "p%20o%20n%20g", true)));
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(
+        server.url("/foo/bar/?pi%20ng=p%20o%20n%20g").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void getWithQueryUrlAndParam() {
+    com.squareup.okhttp.Request request = buildRequest(
+        Method.GET, null, "/foo/bar/?hi=mom", ImmutableList.of(new Query("ping", "pong")));
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/?hi=mom&ping=pong").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void getWithQuery() {
+    com.squareup.okhttp.Request request = buildRequest(Method.GET, null, "/foo/bar/?hi=mom");
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/?hi=mom").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void queryParamOptionalOmitsQuery() {
+    com.squareup.okhttp.Request request = buildRequest(
+        Method.GET, null, "/foo/bar/", ImmutableList.of(new Query("ping", null)));
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+  }
+
+  @Test public void queryParamOptional() {
+    com.squareup.okhttp.Request request = buildRequest(
+        Method.GET, null, "/foo/bar/", ImmutableList.of(new Query("foo", "bar"),
+            new Query("ping", null),
+            new Query("kit", "kat")));
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/?foo=bar&kit=kat").toString());
+  }
+
+  @Test public void bodyGson() {
+    com.squareup.okhttp.Request request =
+        buildRequest(Method.POST, Arrays.asList("quick", "brown", "fox"));
+    assertThat(request.method()).isEqualTo("POST");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertBody(request.body(), "[\"quick\",\"brown\",\"fox\"]");
+  }
+
+  @Test public void emptyBody() {
+    com.squareup.okhttp.Request request = buildRequest(Method.POST, null);
+    assertThat(request.method()).isEqualTo("POST");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertBody(request.body(), "");
+  }
+
+  @Test public void bodyRequestBody() {
+    RequestBody body = RequestBody.create(MediaType.parse("text/plain"), "hi");
+    com.squareup.okhttp.Request request = buildRequest(Method.POST, body);
+    assertThat(request.method()).isEqualTo("POST");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertBody(request.body(), "hi");
+  }
+
+  @Test public void simpleMultipart() throws IOException {
+    CallableRequest multipartRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.POST)
+        .path("/foo/bar/")
+        .responseType(String.class)
+        .parts(ImmutableList.of(
+            new Part("ping", "pong"),
+            new Part("kit", RequestBody.create(MediaType.parse("text/plain"), "kat"))))
+        .build();
+    com.squareup.okhttp.Request request = buildRequest(multipartRequest);
+    assertThat(request.method()).isEqualTo("POST");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+
+    RequestBody body = request.body();
+    Buffer buffer = new Buffer();
+    body.writeTo(buffer);
+    String bodyString = buffer.readUtf8();
+
+    assertThat(body.contentType().toString()).contains("multipart/form-data; boundary=");
+
+    assertThat(bodyString)
+        .contains("Content-Disposition: form-data; name=\"ping\"\r\n")
+        .contains("\r\npong\r\n--");
+
+    assertThat(bodyString)
+        .contains("Content-Disposition: form-data; name=\"kit\"")
+        .contains("\r\nkat\r\n--");
+  }
+
+  @Test public void multipartWithEncoding() throws IOException {
+    CallableRequest multipartRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.POST)
+        .path("/foo/bar/")
+        .responseType(String.class)
+        .parts(ImmutableList.of(
+            new Part("ping", "pong", "8-bit"),
+            new Part("kit", RequestBody.create(MediaType.parse("text/plain"), "kat"), "7-bit")))
+        .build();
+
+    com.squareup.okhttp.Request request = buildRequest(multipartRequest);
+    assertThat(request.method()).isEqualTo("POST");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+
+    RequestBody body = request.body();
+    Buffer buffer = new Buffer();
+    body.writeTo(buffer);
+    String bodyString = buffer.readUtf8();
+
+    assertThat(body.contentType().toString()).contains("multipart/form-data; boundary=");
+
+    assertThat(bodyString)
+        .contains("Content-Disposition: form-data; name=\"ping\"\r\n")
+        .contains("Content-Transfer-Encoding: 8-bit")
+        .contains("\r\npong\r\n--");
+
+    assertThat(bodyString)
+        .contains("Content-Disposition: form-data; name=\"kit\"")
+        .contains("Content-Transfer-Encoding: 7-bit")
+        .contains("\r\nkat\r\n--");
+  }
+
+  @Test public void multipartWithFilename() throws IOException {
+    CallableRequest multipartRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.POST)
+        .path("/foo/bar/")
+        .responseType(String.class)
+        .parts(ImmutableList.of(
+            new Part("a", RequestBody.create(MediaType.parse("text/plain"), "b"), "binary", "bam")))
+        .build();
+
+    com.squareup.okhttp.Request request = buildRequest(multipartRequest);
+    assertThat(request.method()).isEqualTo("POST");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+
+    RequestBody body = request.body();
+    Buffer buffer = new Buffer();
+    body.writeTo(buffer);
+    String bodyString = buffer.readUtf8();
+
+    assertThat(body.contentType().toString()).contains("multipart/form-data; boundary=");
+
+    assertThat(bodyString)
+        .contains("Content-Disposition: form-data; name=\"a\"; filename=\"bam\"")
+        .contains("\r\nb\r\n--");
+  }
+
+  @Test public void multipartPartMapRejectsNullKeys() {
+    CallableRequest multipartRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.POST)
+        .path("/foo")
+        .responseType(String.class)
+        .parts(ImmutableList.of(
+            new Part("ping", "pong"),
+            new Part(null, RequestBody.create(MediaType.parse("text/plain"), "kat"))))
+        .build();
+    try {
+      buildRequest(multipartRequest);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("Part map contained null key.");
+    }
+  }
+
+  @Test public void multipartPartOptional() {
+    try {
+      new CallableRequest.Builder(retrofit)
+          .method(Method.POST)
+          .path("/foo")
+          .responseType(String.class)
+          .parts(Lists.<Part>emptyList())
+          .build();
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).isEqualTo("Multipart method must contain at least one part.");
+    }
+  }
+
+  @Test public void formEncodedFieldMap() {
+    CallableRequest urlEncodedRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.POST)
+        .path("/foo")
+        .responseType(String.class)
+        .fields(ImmutableList.of(
+            new Field("kit", "kat"),
+            new Field("foo", null),
+            new Field("ping", "pong")))
+        .build();
+
+    com.squareup.okhttp.Request request = buildRequest(urlEncodedRequest);
+    assertBody(request.body(), "kit=kat&ping=pong");
+  }
+
+  @Test public void formEncodedWithEncodedFieldParamMap() {
+    CallableRequest urlEncodedRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.POST)
+        .path("/foo")
+        .responseType(String.class)
+        .fields(ImmutableList.of(
+            new Field("k%20it", "k%20at", true), new Field("pin%20g", "po%20ng", true)))
+        .build();
+    com.squareup.okhttp.Request request = buildRequest(urlEncodedRequest);
+    assertBody(request.body(), "k%20it=k%20at&pin%20g=po%20ng");
+  }
+
+  @Test public void formEncodedWithNonEncodedFieldParamMap() {
+    CallableRequest urlEncodedRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.POST)
+        .path("/foo")
+        .responseType(String.class)
+        .fields(ImmutableList.of(
+            new Field("k it", "k at", false), new Field("pin g", "po ng", false)))
+        .build();
+    com.squareup.okhttp.Request request = buildRequest(urlEncodedRequest);
+    assertBody(request.body(), "k%20it=k%20at&pin%20g=po%20ng");
+  }
+
+  @Test public void fieldMapRejectsNullKeys() {
+    CallableRequest urlEncodedRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.POST)
+        .path("/foo")
+        .responseType(String.class)
+        .fields(ImmutableList.of(
+            new Field("kit", "kat"), new Field("foo", null), new Field(null, "pong")))
+        .build();
+    try {
+      buildRequest(urlEncodedRequest);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("Parameter field map contained null key.");
+    }
+  }
+
+  @Test public void simpleHeaders() {
+    CallableRequest simpleRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.GET)
+        .path("/foo/bar/")
+        .responseType(String.class)
+        .headers(ImmutableMap.of("ping", "pong", "kit", "kat"))
+        .build();
+    com.squareup.okhttp.Request request = buildRequest(simpleRequest);
+    assertThat(request.method()).isEqualTo("GET");
+    com.squareup.okhttp.Headers headers = request.headers();
+    assertThat(headers.size()).isEqualTo(2);
+    assertThat(headers.get("ping")).isEqualTo("pong");
+    assertThat(headers.get("kit")).isEqualTo("kat");
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void tags() {
+    CallableRequest simpleRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.GET)
+        .path("/foo/bar/")
+        .tag("hello")
+        .responseType(String.class)
+        .build();
+    com.squareup.okhttp.Request request = buildRequest(simpleRequest);
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertThat(request.tag()).isEqualTo("hello");
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void headerParamToString() {
+    CallableRequest simpleRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.GET)
+        .path("/foo/bar/")
+        .responseType(String.class)
+        .headers(ImmutableMap.of("kit", "1234"))
+        .build();
+    com.squareup.okhttp.Request request = buildRequest(simpleRequest);
+    assertThat(request.method()).isEqualTo("GET");
+    com.squareup.okhttp.Headers headers = request.headers();
+    assertThat(headers.size()).isEqualTo(1);
+    assertThat(headers.get("kit")).isEqualTo("1234");
+    assertThat(request.urlString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void contentTypeAnnotationHeaderOverrides() {
+    CallableRequest simpleRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.POST)
+        .path("/foo/bar/")
+        .responseType(String.class)
+        .headers(ImmutableMap.of("Content-Type", "text/not-plain"))
+        .body(RequestBody.create(MediaType.parse("text/plain"), "hi"))
+        .build();
+    com.squareup.okhttp.Request request = buildRequest(simpleRequest);
+    assertThat(request.body().contentType().toString()).isEqualTo("text/not-plain");
+  }
+
+  @Test public void contentTypeAnnotationHeaderAddsHeaderWithNoBody() {
+    CallableRequest simpleRequest = new CallableRequest.Builder(retrofit)
+        .method(Method.DELETE)
+        .path("/foo/bar/")
+        .responseType(String.class)
+        .headers(ImmutableMap.of("Content-Type", "text/not-plain"))
+        .build();
+    com.squareup.okhttp.Request request = buildRequest(simpleRequest);
+    assertThat(request.headers().get("Content-Type")).isEqualTo("text/not-plain");
+  }
+
+  private static void assertBody(RequestBody body, String expected) {
+    assertThat(body).isNotNull();
+    Buffer buffer = new Buffer();
+    try {
+      body.writeTo(buffer);
+      assertThat(buffer.readUtf8()).isEqualTo(expected);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private com.squareup.okhttp.Request buildRequest() {
+    return buildRequest(Method.GET);
+  }
+
+  private com.squareup.okhttp.Request buildRequest(Method method) {
+    return buildRequest(method, null);
+  }
+
+  private com.squareup.okhttp.Request buildRequest(Method method, Object body) {
+    return buildRequest(method, body, "/foo/bar/");
+  }
+
+  private com.squareup.okhttp.Request buildRequest(Method method, Object body, String path) {
+    return buildRequest(method, body, path, Collections.<Query>emptyList());
+  }
+
+  private com.squareup.okhttp.Request buildRequest(Method method, Object body, String path,
+      List<Query> query) {
+    return buildRequest(new CallableRequest.Builder(retrofit)
+        .method(method)
+        .body(body)
+        .path(path)
+        .responseType(String.class)
+        .queryParams(query)
+        .build());
+  }
+
+  private com.squareup.okhttp.Request buildRequest(TypedRequest request) {
+    return new TypedRequestRawRequestBuilder(retrofit, request).build();
+  }
+}

--- a/retrofit/src/main/java/retrofit/MethodHandler.java
+++ b/retrofit/src/main/java/retrofit/MethodHandler.java
@@ -16,11 +16,12 @@
 package retrofit;
 
 import com.squareup.okhttp.ResponseBody;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
-final class MethodHandler<T> {
+final class MethodHandler<T> implements CallAdapter<T> {
   @SuppressWarnings("unchecked")
   static MethodHandler<?> create(Retrofit retrofit, Method method) {
     CallAdapter<Object> callAdapter = (CallAdapter<Object>) createCallAdapter(method, retrofit);
@@ -72,6 +73,14 @@ final class MethodHandler<T> {
   }
 
   Object invoke(Object... args) {
-    return callAdapter.adapt(new OkHttpCall<>(retrofit, requestFactory, responseConverter, args));
+    return adapt(new OkHttpCall<>(retrofit, requestFactory, responseConverter, args));
+  }
+
+  @Override public Type responseType() {
+    return callAdapter.responseType();
+  }
+
+  @Override public <R> T adapt(Call<R> call) {
+    return callAdapter.adapt(call);
   }
 }

--- a/retrofit/src/main/java/retrofit/RequestBuilderAction.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilderAction.java
@@ -25,10 +25,10 @@ import java.util.Map;
 import static retrofit.Utils.checkNotNull;
 
 abstract class RequestBuilderAction {
-  abstract void perform(RequestBuilder builder, Object value);
+  abstract void perform(RestAdapterRawRequestBuilder builder, Object value);
 
   static final class Url extends RequestBuilderAction {
-    @Override void perform(RequestBuilder builder, Object value) {
+    @Override void perform(RestAdapterRawRequestBuilder builder, Object value) {
       builder.setRelativeUrl((String) value);
     }
   }
@@ -40,7 +40,7 @@ abstract class RequestBuilderAction {
       this.name = checkNotNull(name, "name == null");
     }
 
-    @Override void perform(RequestBuilder builder, Object value) {
+    @Override void perform(RestAdapterRawRequestBuilder builder, Object value) {
       if (value == null) return; // Skip null values.
 
       if (value instanceof Iterable) {
@@ -71,7 +71,7 @@ abstract class RequestBuilderAction {
       this.encoded = encoded;
     }
 
-    @Override void perform(RequestBuilder builder, Object value) {
+    @Override void perform(RestAdapterRawRequestBuilder builder, Object value) {
       if (value == null) {
         throw new IllegalArgumentException(
             "Path parameter \"" + name + "\" value must not be null.");
@@ -89,7 +89,7 @@ abstract class RequestBuilderAction {
       this.encoded = encoded;
     }
 
-    @Override void perform(RequestBuilder builder, Object value) {
+    @Override void perform(RestAdapterRawRequestBuilder builder, Object value) {
       if (value == null) return; // Skip null values.
 
       if (value instanceof Iterable) {
@@ -118,7 +118,7 @@ abstract class RequestBuilderAction {
       this.encoded = encoded;
     }
 
-    @Override void perform(RequestBuilder builder, Object value) {
+    @Override void perform(RestAdapterRawRequestBuilder builder, Object value) {
       if (value == null) return; // Skip null values.
 
       Map<?, ?> map = (Map<?, ?>) value;
@@ -144,7 +144,7 @@ abstract class RequestBuilderAction {
       this.encoded = encoded;
     }
 
-    @Override void perform(RequestBuilder builder, Object value) {
+    @Override void perform(RestAdapterRawRequestBuilder builder, Object value) {
       if (value == null) return; // Skip null values.
 
       if (value instanceof Iterable) {
@@ -173,7 +173,7 @@ abstract class RequestBuilderAction {
       this.encoded = encoded;
     }
 
-    @Override void perform(RequestBuilder builder, Object value) {
+    @Override void perform(RestAdapterRawRequestBuilder builder, Object value) {
       if (value == null) return; // Skip null values.
 
       Map<?, ?> map = (Map<?, ?>) value;
@@ -199,7 +199,7 @@ abstract class RequestBuilderAction {
       this.converter = converter;
     }
 
-    @Override void perform(RequestBuilder builder, Object value) {
+    @Override void perform(RestAdapterRawRequestBuilder builder, Object value) {
       if (value == null) return; // Skip null values.
 
       RequestBody body;
@@ -224,7 +224,7 @@ abstract class RequestBuilderAction {
       this.annotations = annotations;
     }
 
-    @Override void perform(RequestBuilder builder, Object value) {
+    @Override void perform(RestAdapterRawRequestBuilder builder, Object value) {
       if (value == null) return; // Skip null values.
 
       Map<?, ?> map = (Map<?, ?>) value;
@@ -264,7 +264,7 @@ abstract class RequestBuilderAction {
       this.converter = converter;
     }
 
-    @Override void perform(RequestBuilder builder, Object value) {
+    @Override void perform(RestAdapterRawRequestBuilder builder, Object value) {
       if (value == null) {
         throw new IllegalArgumentException("Body parameter value must not be null.");
       }

--- a/retrofit/src/main/java/retrofit/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit/RequestFactory.java
@@ -1,68 +1,7 @@
-/*
- * Copyright (C) 2015 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package retrofit;
 
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.Request;
 
-final class RequestFactory {
-  private final String method;
-  private final BaseUrl baseUrl;
-  private final String relativeUrl;
-  private final Headers headers;
-  private final MediaType contentType;
-  private final boolean hasBody;
-  private final boolean isFormEncoded;
-  private final boolean isMultipart;
-  private final RequestBuilderAction[] requestBuilderActions;
-
-  RequestFactory(String method, BaseUrl baseUrl, String relativeUrl, Headers headers,
-      MediaType contentType, boolean hasBody, boolean isFormEncoded, boolean isMultipart,
-      RequestBuilderAction[] requestBuilderActions) {
-    this.method = method;
-    this.baseUrl = baseUrl;
-    this.relativeUrl = relativeUrl;
-    this.headers = headers;
-    this.contentType = contentType;
-    this.hasBody = hasBody;
-    this.isFormEncoded = isFormEncoded;
-    this.isMultipart = isMultipart;
-    this.requestBuilderActions = requestBuilderActions;
-  }
-
-  Request create(Object... args) {
-    RequestBuilder requestBuilder =
-        new RequestBuilder(method, baseUrl.url(), relativeUrl, headers, contentType, hasBody,
-            isFormEncoded, isMultipart);
-
-    if (args != null) {
-      RequestBuilderAction[] actions = requestBuilderActions;
-      if (actions.length != args.length) {
-        throw new IllegalArgumentException("Argument count ("
-            + args.length
-            + ") doesn't match action count ("
-            + actions.length
-            + ")");
-      }
-      for (int i = 0, count = args.length; i < count; i++) {
-        actions[i].perform(requestBuilder, args[i]);
-      }
-    }
-
-    return requestBuilder.build();
-  }
+public interface RequestFactory {
+  Request create(Object... args);
 }

--- a/retrofit/src/main/java/retrofit/RequestFactoryParser.java
+++ b/retrofit/src/main/java/retrofit/RequestFactoryParser.java
@@ -54,7 +54,7 @@ final class RequestFactoryParser {
   private static final Pattern PARAM_NAME_REGEX = Pattern.compile(PARAM);
   private static final Pattern PARAM_URL_REGEX = Pattern.compile("\\{(" + PARAM + ")\\}");
 
-  static RequestFactory parse(Method method, Type responseType, Retrofit retrofit) {
+  static RestAdapterRawRequestFactory parse(Method method, Type responseType, Retrofit retrofit) {
     RequestFactoryParser parser = new RequestFactoryParser(method);
     parser.parseMethodAnnotations(responseType);
     parser.parseParameters(retrofit);
@@ -78,9 +78,9 @@ final class RequestFactoryParser {
     this.method = method;
   }
 
-  private RequestFactory toRequestFactory(BaseUrl baseUrl) {
-    return new RequestFactory(httpMethod, baseUrl, relativeUrl, headers, contentType, hasBody,
-        isFormEncoded, isMultipart, requestBuilderActions);
+  private RestAdapterRawRequestFactory toRequestFactory(BaseUrl baseUrl) {
+    return new RestAdapterRawRequestFactory(httpMethod, baseUrl, relativeUrl, headers, contentType,
+        hasBody, isFormEncoded, isMultipart, requestBuilderActions);
   }
 
   private RuntimeException parameterError(Throwable cause, int index, String message,

--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -1,0 +1,125 @@
+package retrofit;
+
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.ResponseBody;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import retrofit.http.HTTP;
+import retrofit.http.Header;
+
+
+/**
+ * Adapts a Java interface to a REST API.
+ * <p>
+ * API endpoints are defined as methods on an interface with annotations providing metadata about
+ * the form in which the HTTP call should be made.
+ * <p>
+ * The relative path for a given method is obtained from an annotation on the method describing
+ * the request type. The built-in methods are {@link retrofit.http.GET GET},
+ * {@link retrofit.http.PUT PUT}, {@link retrofit.http.POST POST}, {@link retrofit.http.PATCH
+ * PATCH}, {@link retrofit.http.HEAD HEAD}, and {@link retrofit.http.DELETE DELETE}. You can use a
+ * custom HTTP method with {@link HTTP @HTTP}.
+ * <p>
+ * Method parameters can be used to replace parts of the URL by annotating them with
+ * {@link retrofit.http.Path @Path}. Replacement sections are denoted by an identifier surrounded
+ * by curly braces (e.g., "{foo}"). To add items to the query string of a URL use
+ * {@link retrofit.http.Query @Query}.
+ * <p>
+ * The body of a request is denoted by the {@link retrofit.http.Body @Body} annotation. The object
+ * will be converted to request representation by a call to
+ * {@link Converter#toBody(Object, java.lang.reflect.Type) toBody}
+ * on the supplied {@link Converter} for this instance. A {@link RequestBody} can also be used
+ * which will not use the {@code Converter}.
+ * <p>
+ * Alternative request body formats are supported by method annotations and corresponding parameter
+ * annotations:
+ * <ul>
+ * <li>{@link retrofit.http.FormUrlEncoded @FormUrlEncoded} - Form-encoded data with key-value
+ * pairs specified by the {@link retrofit.http.Field @Field} parameter annotation.
+ * <li>{@link retrofit.http.Multipart @Multipart} - RFC 2387-compliant multi-part data with parts
+ * specified by the {@link retrofit.http.Part @Part} parameter annotation.
+ * </ul>
+ * <p>
+ * Additional static headers can be added for an endpoint using the
+ * {@link retrofit.http.Headers @Headers} method annotation. For per-request control over a header
+ * annotate a parameter with {@link Header @Header}.
+ * <p>
+ * By default, methods return a {@link Call} which represents the HTTP request. The generic
+ * parameter of the call is the response body type and will be converted by a call to
+ * {@link Converter#fromBody(ResponseBody, Type) fromBody} on the supplied {@link Converter} for
+ * this instance. {@link ResponseBody} can also be used which will not use the {@code Converter}.
+ * <p>
+ * For example:
+ * <pre>
+ * public interface CategoryService {
+ *   &#64;POST("/category/{cat}")
+ *   Call&lt;List&lt;Item&gt;&gt; categoryList(@Path("cat") String a, @Query("page") int b);
+ * }
+ * </pre>
+ * <p>
+ * Calling {@link #create(Class) create()} with {@code CategoryService.class} will validate the
+ * annotations and create a new implementation of the service definition.
+ *
+ * @author Bob Lee (bob@squareup.com)
+ * @author Jake Wharton (jw@squareup.com)
+ */
+public final class RestAdapter {
+  private final Map<Method, MethodHandler<?>> methodHandlerCache = new LinkedHashMap<>();
+  private final Retrofit retrofit;
+  private final boolean validateEagerly;
+
+  public RestAdapter(Retrofit retrofit, boolean validateEagerly) {
+    this.retrofit = retrofit;
+    this.validateEagerly = validateEagerly;
+  }
+
+  /** Create an implementation of the API defined by the {@code service} interface. */
+  @SuppressWarnings("unchecked") // Single-interface proxy creation guarded by parameter safety.
+  public <T> T create(final Class<T> service) {
+    Utils.validateServiceInterface(service);
+    if (validateEagerly) {
+      eagerlyValidateMethods(service);
+    }
+    return (T) Proxy.newProxyInstance(service.getClassLoader(), new Class<?>[] { service },
+        new InvocationHandler() {
+          private final Platform platform = Platform.get();
+
+          @Override public Object invoke(Object proxy, Method method, Object... args)
+              throws Throwable {
+            // If the method is a method from Object then defer to normal invocation.
+            if (method.getDeclaringClass() == Object.class) {
+              return method.invoke(this, args);
+            }
+            if (platform.isDefaultMethod(method)) {
+              return platform.invokeDefaultMethod(method, service, proxy, args);
+            }
+            return loadMethodHandler(method).invoke(args);
+          }
+        });
+  }
+
+  private void eagerlyValidateMethods(Class<?> service) {
+    Platform platform = Platform.get();
+    for (Method method : service.getDeclaredMethods()) {
+      if (!platform.isDefaultMethod(method)) {
+        loadMethodHandler(method);
+      }
+    }
+  }
+
+  MethodHandler<?> loadMethodHandler(Method method) {
+    MethodHandler<?> handler;
+    synchronized (methodHandlerCache) {
+      handler = methodHandlerCache.get(method);
+      if (handler == null) {
+        handler = MethodHandler.create(retrofit, method);
+        methodHandlerCache.put(method, handler);
+      }
+    }
+    return handler;
+  }
+}

--- a/retrofit/src/main/java/retrofit/RestAdapterRawRequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RestAdapterRawRequestBuilder.java
@@ -26,11 +26,10 @@ import java.io.IOException;
 import okio.Buffer;
 import okio.BufferedSink;
 
-final class RequestBuilder {
+final class RestAdapterRawRequestBuilder {
   private static final char[] HEX_DIGITS =
       { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
   private static final String PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|/\\?#";
-
   private final String method;
 
   private final HttpUrl baseUrl;
@@ -45,7 +44,7 @@ final class RequestBuilder {
   private FormEncodingBuilder formEncodingBuilder;
   private RequestBody body;
 
-  RequestBuilder(String method, HttpUrl baseUrl, String relativeUrl, Headers headers,
+  RestAdapterRawRequestBuilder(String method, HttpUrl baseUrl, String relativeUrl, Headers headers,
       MediaType contentType, boolean hasBody, boolean isFormEncoded, boolean isMultipart) {
     this.method = method;
     this.baseUrl = baseUrl;

--- a/retrofit/src/main/java/retrofit/RestAdapterRawRequestFactory.java
+++ b/retrofit/src/main/java/retrofit/RestAdapterRawRequestFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.Request;
+
+final class RestAdapterRawRequestFactory implements RequestFactory {
+  private final String method;
+  private final BaseUrl baseUrl;
+  private final String relativeUrl;
+  private final Headers headers;
+  private final MediaType contentType;
+  private final boolean hasBody;
+  private final boolean isFormEncoded;
+  private final boolean isMultipart;
+  private final RequestBuilderAction[] requestBuilderActions;
+
+  RestAdapterRawRequestFactory(String method, BaseUrl baseUrl, String relativeUrl, Headers headers,
+      MediaType contentType, boolean hasBody, boolean isFormEncoded, boolean isMultipart,
+      RequestBuilderAction[] requestBuilderActions) {
+    this.method = method;
+    this.baseUrl = baseUrl;
+    this.relativeUrl = relativeUrl;
+    this.headers = headers;
+    this.contentType = contentType;
+    this.hasBody = hasBody;
+    this.isFormEncoded = isFormEncoded;
+    this.isMultipart = isMultipart;
+    this.requestBuilderActions = requestBuilderActions;
+  }
+
+  public Request create(Object... args) {
+    RestAdapterRawRequestBuilder requestBuilder =
+        new RestAdapterRawRequestBuilder(method, baseUrl.url(), relativeUrl, headers, contentType,
+            hasBody, isFormEncoded, isMultipart);
+
+    if (args != null) {
+      RequestBuilderAction[] actions = requestBuilderActions;
+      if (actions.length != args.length) {
+        throw new IllegalArgumentException("Argument count ("
+            + args.length
+            + ") doesn't match action count ("
+            + actions.length
+            + ")");
+      }
+      for (int i = 0, count = args.length; i < count; i++) {
+        actions[i].perform(requestBuilder, args[i]);
+      }
+    }
+
+    return requestBuilder.build();
+  }
+}

--- a/retrofit/src/main/java/retrofit/http/Body.java
+++ b/retrofit/src/main/java/retrofit/http/Body.java
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Use this annotation on a service method param when you want to directly control the request body
  * of a POST/PUT request (instead of sending in as request parameters or form-style request
- * body). The object will be serialized using the {@link Retrofit Retrofit} instance
+ * body). The object will be serialized using the {@link Retrofit RestAdapter}'s
  * {@link Converter Converter} and the result will be set directly as the
  * request body.
  * <p>

--- a/retrofit/src/test/java/retrofit/CallTest.java
+++ b/retrofit/src/test/java/retrofit/CallTest.java
@@ -22,6 +22,10 @@ import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.SocketPolicy;
+
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -31,8 +35,6 @@ import okio.Buffer;
 import okio.BufferedSource;
 import okio.ForwardingSource;
 import okio.Okio;
-import org.junit.Rule;
-import org.junit.Test;
 import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.POST;

--- a/retrofit/src/test/java/retrofit/RestAdapterRawRequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RestAdapterRawRequestBuilderTest.java
@@ -8,6 +8,12 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
 import com.squareup.okhttp.ResponseBody;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
@@ -17,9 +23,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+
 import okio.Buffer;
-import org.junit.Ignore;
-import org.junit.Test;
 import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.Field;
@@ -46,7 +51,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 @SuppressWarnings({"UnusedParameters", "unused"}) // Parameters inspected reflectively.
-public final class RequestBuilderTest {
+public final class RestAdapterRawRequestBuilderTest {
+  @Rule public final MockWebServer server = new MockWebServer();
+
   private static final MediaType TEXT_PLAIN = MediaType.parse("text/plain");
 
   @Test public void customMethodNoBody() {
@@ -1702,8 +1709,10 @@ public final class RequestBuilderTest {
         .client(client)
         .build();
 
+    RestAdapter restAdapter = new RestAdapter(retrofit, false);
+
     Method method = TestingUtils.onlyMethod(cls);
-    MethodHandler<?> handler = retrofit.loadMethodHandler(method);
+    MethodHandler<?> handler = restAdapter.loadMethodHandler(method);
     Call<?> invoke = (Call<?>) handler.invoke(args);
     try {
       invoke.execute();

--- a/retrofit/src/test/java/retrofit/RestAdapterRawRequestFactoryParserTest.java
+++ b/retrofit/src/test/java/retrofit/RestAdapterRawRequestFactoryParserTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public final class RequestFactoryParserTest {
+public final class RestAdapterRawRequestFactoryParserTest {
   @Test public void pathParameterParsing() throws Exception {
     expectParams("/");
     expectParams("/foo");

--- a/retrofit/src/test/java/retrofit/RestAdapterTest.java
+++ b/retrofit/src/test/java/retrofit/RestAdapterTest.java
@@ -8,6 +8,10 @@ import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
@@ -22,8 +26,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Rule;
-import org.junit.Test;
+
 import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.POST;
@@ -40,7 +43,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public final class RetrofitTest {
+public final class RestAdapterTest {
   @Rule public final MockWebServer server = new MockWebServer();
 
   interface CallMethod {
@@ -332,7 +335,7 @@ public final class RetrofitTest {
       assertThat(e.getCause()).hasMessage(
           "Could not locate ResponseBody converter for class java.lang.String. Tried:\n"
               + " * retrofit.BuiltInConverters\n"
-              + " * retrofit.RetrofitTest$1");
+              + " * retrofit.RestAdapterTest$1");
     }
   }
 

--- a/samples/src/main/java/com/example/retrofit/CustomCallAdapter.java
+++ b/samples/src/main/java/com/example/retrofit/CustomCallAdapter.java
@@ -18,11 +18,13 @@ package com.example.retrofit;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+
 import retrofit.Call;
 import retrofit.CallAdapter;
 import retrofit.Callback;

--- a/samples/src/main/java/com/example/retrofit/SimpleService.java
+++ b/samples/src/main/java/com/example/retrofit/SimpleService.java
@@ -17,6 +17,7 @@ package com.example.retrofit;
 
 import java.io.IOException;
 import java.util.List;
+
 import retrofit.Call;
 import retrofit.GsonConverterFactory;
 import retrofit.Retrofit;


### PR DESCRIPTION
This pull request separates `MethodInfo` and `RestAdapter` from `Retrofit` (formerly `RestAdapter`), allowing different ways of declaring services. A new module retrofit-typedrequest has been added with a different implementation.
I know this is a pretty radical change and might not be within the interest of you guys to integrate into the library, however I figured that this kind of abstraction/extensibility could be useful in other scenarios.
In my particular case, the app already has **a lot** of "Volley style" request classes, each with their own classes and logic. This makes it virtually impossible to migrate to Retrofit given the way it requires you to define your "service" using an interface and annotations.
This change gives us that ability by simply implementing the new `Request` interface, which is just `CallAdapter` with an additional method.