### PR TITLE
Require Endpoint as a constructor argument to RestAdapter.Builder

### DIFF
--- a/retrofit-adapters/rxjava/src/test/java/retrofit/ObservableCallAdapterFactoryTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit/ObservableCallAdapterFactoryTest.java
@@ -47,8 +47,7 @@ public final class ObservableCallAdapterFactoryTest {
   private Service service;
 
   @Before public void setUp() {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter())
         .callAdapterFactory(ObservableCallAdapterFactory.create())
         .build();

--- a/retrofit/src/main/java/retrofit/Endpoint.java
+++ b/retrofit/src/main/java/retrofit/Endpoint.java
@@ -9,6 +9,9 @@ public abstract class Endpoint {
   /** Create an endpoint with the provided {@code url}. */
   public static Endpoint createFixed(String url) {
     checkNotNull(url, "url == null");
+    if (url.trim().length() == 0) {
+      throw new IllegalArgumentException("Empty URL");
+    }
     final HttpUrl httpUrl = HttpUrl.parse(url);
     if (httpUrl == null) {
       throw new IllegalArgumentException("Invalid URL: " + url);

--- a/retrofit/src/main/java/retrofit/RestAdapter.java
+++ b/retrofit/src/main/java/retrofit/RestAdapter.java
@@ -91,6 +91,15 @@ public final class RestAdapter {
   private final Converter converter;
   private final CallAdapter.Factory adapterFactory;
 
+  public static Builder builder(Endpoint endpoint) {
+    checkNotNull(endpoint, "endpoint == null");
+    return new Builder(endpoint);
+  }
+
+  public static Builder builder(String url) {
+    return new Builder(Endpoint.createFixed(url));
+  }
+
   private RestAdapter(OkHttpClient client, Endpoint endpoint, Converter converter,
       CallAdapter.Factory adapterFactory) {
     this.client = client;
@@ -159,32 +168,20 @@ public final class RestAdapter {
     return adapterFactory;
   }
 
-  /**
-   * Build a new {@link RestAdapter}.
-   * <p>
-   * Calling {@link #endpoint} is required before calling {@link #build()}. All other methods
-   * are optional.
-   */
+  /** Build a new {@link RestAdapter}. */
   public static class Builder {
+    private final Endpoint endpoint;
     private OkHttpClient client;
-    private Endpoint endpoint;
     private Converter converter;
     private CallAdapter.Factory adapterFactory;
+
+    private Builder(Endpoint endpoint) {
+      this.endpoint = endpoint;
+    }
 
     /** The HTTP client used for requests. */
     public Builder client(OkHttpClient client) {
       this.client = checkNotNull(client, "client == null");
-      return this;
-    }
-
-    /** API endpoint URL. */
-    public Builder endpoint(String url) {
-      return endpoint(Endpoint.createFixed(url));
-    }
-
-    /** API endpoint. */
-    public Builder endpoint(Endpoint endpoint) {
-      this.endpoint = checkNotNull(endpoint, "endpoint == null");
       return this;
     }
 

--- a/retrofit/src/test/java/retrofit/CallTest.java
+++ b/retrofit/src/test/java/retrofit/CallTest.java
@@ -46,8 +46,7 @@ public final class CallTest {
   }
 
   @Test public void http200Sync() throws IOException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter())
         .build();
     Service example = ra.create(Service.class);
@@ -60,8 +59,7 @@ public final class CallTest {
   }
 
   @Test public void http200Async() throws InterruptedException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter())
         .build();
     Service example = ra.create(Service.class);
@@ -88,8 +86,7 @@ public final class CallTest {
   }
 
   @Test public void http404Sync() throws IOException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter())
         .build();
     Service example = ra.create(Service.class);
@@ -103,8 +100,7 @@ public final class CallTest {
   }
 
   @Test public void http404Async() throws InterruptedException, IOException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter())
         .build();
     Service example = ra.create(Service.class);
@@ -132,8 +128,7 @@ public final class CallTest {
   }
 
   @Test public void transportProblemSync() {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter())
         .build();
     Service example = ra.create(Service.class);
@@ -149,8 +144,7 @@ public final class CallTest {
   }
 
   @Test public void transportProblemAsync() throws InterruptedException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter())
         .build();
     Service example = ra.create(Service.class);
@@ -176,8 +170,7 @@ public final class CallTest {
   }
 
   @Test public void conversionProblemOutgoingSync() throws IOException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter() {
           @Override public RequestBody toBody(Object object, Type type) {
             throw new UnsupportedOperationException("I am broken!");
@@ -196,8 +189,7 @@ public final class CallTest {
   }
 
   @Test public void conversionProblemOutgoingAsync() throws InterruptedException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter() {
           @Override public RequestBody toBody(Object object, Type type) {
             throw new UnsupportedOperationException("I am broken!");
@@ -225,8 +217,7 @@ public final class CallTest {
   }
 
   @Test public void conversionProblemIncomingSync() throws IOException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter() {
           @Override public Object fromBody(ResponseBody body, Type type) throws IOException {
             throw new UnsupportedOperationException("I am broken!");
@@ -247,8 +238,7 @@ public final class CallTest {
   }
 
   @Test public void conversionProblemIncomingAsync() throws InterruptedException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter() {
           @Override public Object fromBody(ResponseBody body, Type type) throws IOException {
             throw new UnsupportedOperationException("I am broken!");
@@ -279,8 +269,7 @@ public final class CallTest {
 
   @Test public void http204SkipsConverter() throws IOException {
     Converter converter = spy(new StringConverter());
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(converter)
         .build();
     Service example = ra.create(Service.class);
@@ -295,8 +284,7 @@ public final class CallTest {
 
   @Test public void http205SkipsConverter() throws IOException {
     Converter converter = spy(new StringConverter());
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(converter)
         .build();
     Service example = ra.create(Service.class);
@@ -310,8 +298,7 @@ public final class CallTest {
   }
 
   @Test public void successfulRequestResponseWhenMimeTypeMissing() throws Exception {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter())
         .build();
     Service example = ra.create(Service.class);

--- a/retrofit/src/test/java/retrofit/EndpointsTest.java
+++ b/retrofit/src/test/java/retrofit/EndpointsTest.java
@@ -21,4 +21,22 @@ public final class EndpointsTest {
       assertThat(e).hasMessage("Invalid URL: ftp://foo");
     }
   }
+
+  @Test public void nullUrlThrows() {
+    try {
+      Endpoint.createFixed(null);
+      fail();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("url == null");
+    }
+  }
+
+  @Test public void emptyUrlThrows() {
+    try {
+      Endpoint.createFixed(" ");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("Empty URL");
+    }
+  }
 }

--- a/retrofit/src/test/java/retrofit/RestAdapterTest.java
+++ b/retrofit/src/test/java/retrofit/RestAdapterTest.java
@@ -50,8 +50,7 @@ public final class RestAdapterTest {
 
   @SuppressWarnings("EqualsBetweenInconvertibleTypes") // We are explicitly testing this behavior.
   @Test public void objectMethodsStillWork() {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .build();
     CallMethod example = ra.create(CallMethod.class);
 
@@ -61,8 +60,7 @@ public final class RestAdapterTest {
   }
 
   @Test public void interfaceWithExtendIsNotSupported() {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .build();
     try {
       ra.create(Extending.class);
@@ -73,8 +71,7 @@ public final class RestAdapterTest {
   }
 
   @Test public void callReturnTypeAdapterAddedByDefault() {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .build();
     CallMethod example = ra.create(CallMethod.class);
     assertThat(example.allowed()).isNotNull();
@@ -102,8 +99,7 @@ public final class RestAdapterTest {
       }
     }
 
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .callAdapterFactory(new MyCallAdapterFactory())
         .build();
     CallMethod example = ra.create(CallMethod.class);
@@ -130,8 +126,7 @@ public final class RestAdapterTest {
       }
     }
 
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter())
         .callAdapterFactory(new GreetingCallAdapterFactory())
         .build();
@@ -140,8 +135,7 @@ public final class RestAdapterTest {
   }
 
   @Test public void customReturnTypeAdapterMissingThrows() {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .build();
     FutureMethod example = ra.create(FutureMethod.class);
     try {
@@ -153,8 +147,7 @@ public final class RestAdapterTest {
   }
 
   @Test public void missingConverterThrowsOnNonRequestBody() throws IOException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .build();
     CallMethod example = ra.create(CallMethod.class);
     try {
@@ -168,8 +161,7 @@ public final class RestAdapterTest {
   }
 
   @Test public void missingConverterThrowsOnNonResponseBody() throws IOException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .build();
     CallMethod example = ra.create(CallMethod.class);
 
@@ -186,8 +178,7 @@ public final class RestAdapterTest {
   }
 
   @Test public void requestBodyOutgoingAllowed() throws IOException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .build();
     CallMethod example = ra.create(CallMethod.class);
 
@@ -198,8 +189,7 @@ public final class RestAdapterTest {
   }
 
   @Test public void responseBodyIncomingAllowed() throws IOException, InterruptedException {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .build();
     CallMethod example = ra.create(CallMethod.class);
 
@@ -213,8 +203,7 @@ public final class RestAdapterTest {
   }
 
   @Test public void unresolvableTypeThrows() {
-    RestAdapter ra = new RestAdapter.Builder()
-        .endpoint(server.getUrl("/").toString())
+    RestAdapter ra = RestAdapter.builder(server.getUrl("/").toString())
         .converter(new StringConverter())
         .build();
     Unresolvable example = ra.create(Unresolvable.class);

--- a/samples/src/main/java/com/example/retrofit/CustomCallAdapter.java
+++ b/samples/src/main/java/com/example/retrofit/CustomCallAdapter.java
@@ -95,8 +95,7 @@ public final class CustomCallAdapter {
   }
 
   public static void main(String... args) {
-    RestAdapter restAdapter = new RestAdapter.Builder()
-        .endpoint("http://httpbin.org")
+    RestAdapter restAdapter = RestAdapter.builder("http://httpbin.org")
         .callAdapterFactory(new ListenableFutureCallAdapterFactory())
         .build();
 

--- a/samples/src/main/java/com/example/retrofit/SimpleService.java
+++ b/samples/src/main/java/com/example/retrofit/SimpleService.java
@@ -44,8 +44,7 @@ public final class SimpleService {
 
   public static void main(String... args) throws IOException {
     // Create a very simple REST adapter which points the GitHub API endpoint.
-    RestAdapter restAdapter = new RestAdapter.Builder()
-        .endpoint(API_URL)
+    RestAdapter restAdapter = RestAdapter.builder(API_URL)
         .build();
 
     // Create an instance of our GitHub API interface.

--- a/samples/src/main/not_java/SimpleMockService.java
+++ b/samples/src/main/not_java/SimpleMockService.java
@@ -61,7 +61,7 @@ public final class SimpleMockService {
 
   public static void main(String... args) {
     // Create a very simple REST adapter which points the GitHub API endpoint.
-    RestAdapter restAdapter = new RestAdapter.Builder()
+    RestAdapter restAdapter = new RestAdapter.Builder(endpoint)
         .endpoint(SimpleService.API_URL)
         .build();
 


### PR DESCRIPTION
Given that Endpoint is a required parameter, this makes it a required parameter when creating RestAdapter.Builder.

Also simplifies the construction for the dominant use case from `new RestAdapter.Builder().endpoint(ENDPOINT).build();` to `RestAdapter.builder(ENDPOINT).build();`.