### PR TITLE
Rewrite response parsing for more simple control flow.

### DIFF
--- a/retrofit-adapters/rxjava/src/test/java/retrofit/ResultTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit/ResultTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
 
 public final class ResultTest {
   @Test public void response() {
-    Response<String> response = Response.fromBody("Hi");
+    Response<String> response = Response.fakeSuccess("Hi");
     Result<String> result = Result.fromResponse(response);
     assertThat(result.isError()).isFalse();
     assertThat(result.error()).isNull();

--- a/retrofit/src/main/java/retrofit/ExceptionCatchingRequestBody.java
+++ b/retrofit/src/main/java/retrofit/ExceptionCatchingRequestBody.java
@@ -53,11 +53,9 @@ final class ExceptionCatchingRequestBody extends ResponseBody {
     delegate.close();
   }
 
-  IOException getThrownException() {
-    return thrownException;
-  }
-
-  boolean threwException() {
-    return thrownException != null;
+  void throwIfCaught() throws IOException {
+    if (thrownException != null) {
+      throw thrownException;
+    }
   }
 }

--- a/retrofit/src/main/java/retrofit/Response.java
+++ b/retrofit/src/main/java/retrofit/Response.java
@@ -29,8 +29,8 @@ public final class Response<T> {
   /**
    * TODO
    */
-  public static <T, B extends T> Response<T> fromBody(B body) {
-    return fromBody(body, new com.squareup.okhttp.Response.Builder() //
+  public static <T, B extends T> Response<T> fakeSuccess(B body) {
+    return success(body, new com.squareup.okhttp.Response.Builder() //
         .code(200)
         .protocol(Protocol.HTTP_1_1)
         .request(new com.squareup.okhttp.Request.Builder().url(HttpUrl.parse("http://localhost"))
@@ -41,7 +41,7 @@ public final class Response<T> {
   /**
    * TODO
    */
-  public static <T, B extends T> Response<T> fromBody(B body,
+  public static <T, B extends T> Response<T> success(B body,
       com.squareup.okhttp.Response rawResponse) {
     return new Response<T>(rawResponse, body, null);
   }
@@ -49,11 +49,10 @@ public final class Response<T> {
   /**
    * TODO
    */
-  public static Response<Object> fromError(int code, ResponseBody body) {
-    return fromError(new com.squareup.okhttp.Response.Builder() //
+  public static <T> Response<T> fakeError(int code, ResponseBody body) {
+    return error(body, new com.squareup.okhttp.Response.Builder() //
         .code(code)
         .protocol(Protocol.HTTP_1_1)
-        .body(body)
         .request(new com.squareup.okhttp.Request.Builder().url(HttpUrl.parse("http://localhost"))
             .build())
         .build());
@@ -62,18 +61,18 @@ public final class Response<T> {
   /**
    * TODO
    */
-  public static Response<Object> fromError(com.squareup.okhttp.Response rawResponse) {
-    ResponseBody errorBody = rawResponse.body();
-    if (errorBody == null) throw new IllegalArgumentException("Raw response must have body.");
-    rawResponse = rawResponse.newBuilder().body(null).build();
-    return new Response<>(rawResponse, null, errorBody);
+  public static <T> Response<T> error(ResponseBody body, com.squareup.okhttp.Response rawResponse) {
+    if (rawResponse.body() != null) {
+      throw new IllegalArgumentException("Raw response must not have body.");
+    }
+    return new Response<>(rawResponse, null, body);
   }
 
   private final com.squareup.okhttp.Response rawResponse;
   private final T body;
   private final ResponseBody errorBody;
 
-  Response(com.squareup.okhttp.Response rawResponse, T body, ResponseBody errorBody) {
+  private Response(com.squareup.okhttp.Response rawResponse, T body, ResponseBody errorBody) {
     this.rawResponse = checkNotNull(rawResponse, "rawResponse == null");
     this.body = body;
     this.errorBody = errorBody;

--- a/retrofit/src/main/java/retrofit/Utils.java
+++ b/retrofit/src/main/java/retrofit/Utils.java
@@ -18,6 +18,7 @@ package retrofit;
 
 import com.squareup.okhttp.Response;
 import com.squareup.okhttp.ResponseBody;
+import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
@@ -37,6 +38,14 @@ final class Utils {
       throw new NullPointerException(message);
     }
     return object;
+  }
+
+  static void closeQueitly(Closeable closeable) {
+    if (closeable == null) return;
+    try {
+      closeable.close();
+    } catch (IOException ignored) {
+    }
   }
 
   /**

--- a/retrofit/src/test/java/retrofit/DefaultCallAdapterFactoryTest.java
+++ b/retrofit/src/test/java/retrofit/DefaultCallAdapterFactoryTest.java
@@ -69,7 +69,7 @@ public final class DefaultCallAdapterFactoryTest {
   @Test public void adaptedCallExecute() throws IOException {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
     CallAdapter adapter = factory.get(returnType);
-    final Response<Object> response = Response.fromBody("Hi");
+    final Response<Object> response = Response.fakeSuccess("Hi");
     Call call = (Call) adapter.adapt(new EmptyCall() {
       @Override public Response<Object> execute() throws IOException {
         return response;
@@ -81,7 +81,7 @@ public final class DefaultCallAdapterFactoryTest {
   @Test public void adaptedCallEnqueueUsesExecutorForSuccessCallback() {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
     CallAdapter adapter = factory.get(returnType);
-    final Response<Object> response = Response.fromBody("Hi");
+    final Response<Object> response = Response.fakeSuccess("Hi");
     Call call = (Call) adapter.adapt(new EmptyCall() {
       @Override public void enqueue(Callback<Object> callback) {
         callback.success(response);


### PR DESCRIPTION
This also re-adds support for the @Streaming ResponseBody behavior along with tests for it. Tests are also added for the non-streaming ResponseBody the infamous IOException wrapping converter handling cases.