### PR TITLE
Bugfix/mock/calculate delay for error

### DIFF
--- a/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
+++ b/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
@@ -90,6 +90,16 @@ public final class MockRetrofit {
     if (delayMs > Integer.MAX_VALUE) {
       throw new IllegalArgumentException("Delay value too large. Max: " + Integer.MAX_VALUE);
     }
+    if (delayMs == 0) {
+      /**
+       * It seems reasonable to want to set the delay to 0, but this could cause problems when
+       * calls to random.nextInt are called. random.nextInt 0 would throw a
+       * {@link IllegalArgException).
+       *
+       * Settings it internally to 1ms should avoid this, but shouldn't be noticable for the user.
+       */
+      delayMs = 1;
+    }
     this.delayMs = (int) delayMs;
   }
 

--- a/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
+++ b/retrofit-mock/src/main/java/retrofit/MockRestAdapter.java
@@ -90,16 +90,6 @@ public final class MockRetrofit {
     if (delayMs > Integer.MAX_VALUE) {
       throw new IllegalArgumentException("Delay value too large. Max: " + Integer.MAX_VALUE);
     }
-    if (delayMs == 0) {
-      /**
-       * It seems reasonable to want to set the delay to 0, but this could cause problems when
-       * calls to random.nextInt are called. random.nextInt 0 would throw a
-       * {@link IllegalArgException).
-       *
-       * Settings it internally to 1ms should avoid this, but shouldn't be noticable for the user.
-       */
-      delayMs = 1;
-    }
     this.delayMs = (int) delayMs;
   }
 
@@ -157,6 +147,8 @@ public final class MockRetrofit {
    * using {@link #create(Class, Object)}.
    */
   public int calculateDelayForError() {
+    if (delayMs == 0) return 0;
+
     return random.nextInt(delayMs * ERROR_DELAY_FACTOR);
   }
 


### PR DESCRIPTION
If you call `MockRestAdapter.setDelay(0)`, you see an `IllegalArgumentException` thrown from the `calculateDelayForError()` method. This fix stops 0 being passed in to random.nextInt.