### PR TITLE
Include a request body for content type and length.

### DIFF
--- a/retrofit/src/main/java/retrofit/NoContentResponseBody.java
+++ b/retrofit/src/main/java/retrofit/NoContentResponseBody.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.ResponseBody;
+import java.io.IOException;
+import okio.BufferedSource;
+
+final class NoContentResponseBody extends ResponseBody {
+  private final MediaType contentType;
+  private final long contentLength;
+
+  NoContentResponseBody(MediaType contentType, long contentLength) {
+    this.contentType = contentType;
+    this.contentLength = contentLength;
+  }
+
+  @Override public MediaType contentType() {
+    return contentType;
+  }
+
+  @Override public long contentLength() throws IOException {
+    return contentLength;
+  }
+
+  @Override public BufferedSource source() throws IOException {
+    throw new IllegalStateException("Cannot read raw response body of a converted body.");
+  }
+}

--- a/retrofit/src/main/java/retrofit/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit/OkHttpCall.java
@@ -120,8 +120,11 @@ final class OkHttpCall<T> implements Call<T> {
 
   private Response<T> parseResponse(com.squareup.okhttp.Response rawResponse) throws IOException {
     ResponseBody rawBody = rawResponse.body();
-    // Remove the body (the only stateful object) so we can pass the response along.
-    rawResponse = rawResponse.newBuilder().body(null).build();
+
+    // Remove the body's source (the only stateful object) so we can pass the response along.
+    rawResponse = rawResponse.newBuilder()
+        .body(new NoContentResponseBody(rawBody.contentType(), rawBody.contentLength()))
+        .build();
 
     int code = rawResponse.code();
     if (code < 200 || code >= 300) {

--- a/retrofit/src/main/java/retrofit/Response.java
+++ b/retrofit/src/main/java/retrofit/Response.java
@@ -62,9 +62,6 @@ public final class Response<T> {
    * TODO
    */
   public static <T> Response<T> error(ResponseBody body, com.squareup.okhttp.Response rawResponse) {
-    if (rawResponse.body() != null) {
-      throw new IllegalArgumentException("Raw response must not have body.");
-    }
     return new Response<>(rawResponse, null, body);
   }
 

--- a/retrofit/src/test/java/retrofit/CallTest.java
+++ b/retrofit/src/test/java/retrofit/CallTest.java
@@ -430,4 +430,26 @@ public final class CallTest {
     assertThat(readTook).isGreaterThan(MILLISECONDS.toNanos(1000));
     assertThat(body).isEqualTo("1234");
   }
+
+  @Test public void rawResponseContentTypeAndLengthButNoSource() throws IOException {
+    Retrofit retrofit = new Retrofit.Builder()
+        .endpoint(server.getUrl("/").toString())
+        .converter(new StringConverter())
+        .build();
+    Service example = retrofit.create(Service.class);
+
+    server.enqueue(new MockResponse().setBody("Hi").addHeader("Content-Type", "text/greeting"));
+
+    Response<String> response = example.getString().execute();
+    assertThat(response.body()).isEqualTo("Hi");
+    ResponseBody rawBody = response.raw().body();
+    assertThat(rawBody.contentLength()).isEqualTo(2);
+    assertThat(rawBody.contentType().toString()).isEqualTo("text/greeting");
+    try {
+      rawBody.source();
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Cannot read raw response body of a converted body.");
+    }
+  }
 }

--- a/retrofit/src/test/java/retrofit/CallTest.java
+++ b/retrofit/src/test/java/retrofit/CallTest.java
@@ -452,4 +452,20 @@ public final class CallTest {
       assertThat(e).hasMessage("Cannot read raw response body of a converted body.");
     }
   }
+
+  @Test public void emptyResponse() throws IOException {
+    Retrofit retrofit = new Retrofit.Builder()
+        .endpoint(server.getUrl("/").toString())
+        .converter(new StringConverter())
+        .build();
+    Service example = retrofit.create(Service.class);
+
+    server.enqueue(new MockResponse().setBody("").addHeader("Content-Type", "text/stringy"));
+
+    Response<String> response = example.getString().execute();
+    assertThat(response.body()).isEqualTo("");
+    ResponseBody rawBody = response.raw().body();
+    assertThat(rawBody.contentLength()).isEqualTo(0);
+    assertThat(rawBody.contentType().toString()).isEqualTo("text/stringy");
+  }
 }


### PR DESCRIPTION
Second commit closes #698.