### PR TITLE
Refactor the core of request builder into parameter actions.

### DIFF
--- a/retrofit/src/main/java/retrofit/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit/OkHttpCall.java
@@ -111,7 +111,15 @@ final class OkHttpCall<T> implements Call<T> {
   private com.squareup.okhttp.Call createRawCall() {
     HttpUrl url = endpoint.url();
     RequestBuilder requestBuilder = new RequestBuilder(url, methodInfo);
-    requestBuilder.setArguments(args);
+
+    Object[] args = this.args;
+    if (args != null) {
+      RequestBuilderAction[] actions = methodInfo.requestBuilderActions;
+      for (int i = 0, count = args.length; i < count; i++) {
+        actions[i].perform(requestBuilder, args[i]);
+      }
+    }
+
     Request request = requestBuilder.build();
 
     return client.newCall(request);

--- a/retrofit/src/main/java/retrofit/OkHttpRequestBodyConverter.java
+++ b/retrofit/src/main/java/retrofit/OkHttpRequestBodyConverter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.ResponseBody;
+import java.io.IOException;
+
+final class OkHttpRequestBodyConverter implements Converter<RequestBody> {
+  @Override public RequestBody fromBody(ResponseBody body) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public RequestBody toBody(RequestBody value) {
+    return value;
+  }
+}

--- a/retrofit/src/main/java/retrofit/RequestBuilderAction.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilderAction.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.squareup.okhttp.Headers;
+import java.lang.reflect.Array;
+import java.util.Map;
+
+import static retrofit.Utils.checkNotNull;
+
+abstract class RequestBuilderAction {
+  abstract void perform(RequestBuilder builder, Object value);
+
+  static final class Header extends RequestBuilderAction {
+    private final String name;
+
+    Header(String name) {
+      this.name = checkNotNull(name, "name == null");
+    }
+
+    @Override void perform(RequestBuilder builder, Object value) {
+      if (value == null) return; // Skip null values.
+
+      if (value instanceof Iterable) {
+        for (Object iterableValue : (Iterable<?>) value) {
+          if (iterableValue != null) { // Skip null values.
+            builder.addHeader(name, iterableValue.toString());
+          }
+        }
+      } else if (value.getClass().isArray()) {
+        for (int x = 0, arrayLength = Array.getLength(value); x < arrayLength; x++) {
+          Object arrayValue = Array.get(value, x);
+          if (arrayValue != null) { // Skip null values.
+            builder.addHeader(name, arrayValue.toString());
+          }
+        }
+      } else {
+        builder.addHeader(name, value.toString());
+      }
+    }
+  }
+
+  static final class Path extends RequestBuilderAction {
+    private final String name;
+    private final boolean encoded;
+
+    Path(String name, boolean encoded) {
+      this.name = checkNotNull(name, "name == null");
+      this.encoded = encoded;
+    }
+
+    @Override void perform(RequestBuilder builder, Object value) {
+      if (value == null) {
+        throw new IllegalArgumentException(
+            "Path parameter \"" + name + "\" value must not be null.");
+      }
+      builder.addPathParam(name, value.toString(), encoded);
+    }
+  }
+
+  static final class Query extends RequestBuilderAction {
+    private final String name;
+    private final boolean encoded;
+
+    Query(String name, boolean encoded) {
+      this.name = checkNotNull(name, "name == null");
+      this.encoded = encoded;
+    }
+
+    @Override void perform(RequestBuilder builder, Object value) {
+      if (value == null) return; // Skip null values.
+
+      if (value instanceof Iterable) {
+        for (Object iterableValue : (Iterable<?>) value) {
+          if (iterableValue != null) { // Skip null values.
+            builder.addQueryParam(name, iterableValue.toString(), encoded);
+          }
+        }
+      } else if (value.getClass().isArray()) {
+        for (int x = 0, arrayLength = Array.getLength(value); x < arrayLength; x++) {
+          Object arrayValue = Array.get(value, x);
+          if (arrayValue != null) { // Skip null values.
+            builder.addQueryParam(name, arrayValue.toString(), encoded);
+          }
+        }
+      } else {
+        builder.addQueryParam(name, value.toString(), encoded);
+      }
+    }
+  }
+
+  static final class QueryMap extends RequestBuilderAction {
+    private final boolean encoded;
+
+    QueryMap(boolean encoded) {
+      this.encoded = encoded;
+    }
+
+    @Override void perform(RequestBuilder builder, Object value) {
+      if (value == null) return; // Skip null values.
+
+      Map<?, ?> map = (Map<?, ?>) value;
+      for (Map.Entry<?, ?> entry : map.entrySet()) {
+        Object entryKey = entry.getKey();
+        if (entryKey == null) {
+          throw new IllegalArgumentException("Query map contained null key.");
+        }
+        Object entryValue = entry.getValue();
+        if (entryValue != null) { // Skip null values.
+          builder.addQueryParam(entryKey.toString(), entryValue.toString(), encoded);
+        }
+      }
+    }
+  }
+
+  static final class Field extends RequestBuilderAction {
+    private final String name;
+    private final boolean encoded;
+
+    Field(String name, boolean encoded) {
+      this.name = checkNotNull(name, "name == null");
+      this.encoded = encoded;
+    }
+
+    @Override void perform(RequestBuilder builder, Object value) {
+      if (value == null) return; // Skip null values.
+
+      if (value instanceof Iterable) {
+        for (Object iterableValue : (Iterable<?>) value) {
+          if (iterableValue != null) { // Skip null values.
+            builder.addFormField(name, iterableValue.toString(), encoded);
+          }
+        }
+      } else if (value.getClass().isArray()) {
+        for (int x = 0, arrayLength = Array.getLength(value); x < arrayLength; x++) {
+          Object arrayValue = Array.get(value, x);
+          if (arrayValue != null) { // Skip null values.
+            builder.addFormField(name, arrayValue.toString(), encoded);
+          }
+        }
+      } else {
+        builder.addFormField(name, value.toString(), encoded);
+      }
+    }
+  }
+
+  static final class FieldMap extends RequestBuilderAction {
+    private final boolean encoded;
+
+    FieldMap(boolean encoded) {
+      this.encoded = encoded;
+    }
+
+    @Override void perform(RequestBuilder builder, Object value) {
+      if (value == null) return; // Skip null values.
+
+      Map<?, ?> map = (Map<?, ?>) value;
+      for (Map.Entry<?, ?> entry : map.entrySet()) {
+        Object entryKey = entry.getKey();
+        if (entryKey == null) {
+          throw new IllegalArgumentException("Field map contained null key.");
+        }
+        Object entryValue = entry.getValue();
+        if (entryValue != null) { // Skip null values.
+          builder.addFormField(entryKey.toString(), entryValue.toString(), encoded);
+        }
+      }
+    }
+  }
+
+  static final class Part<T> extends RequestBuilderAction {
+    private final Headers headers;
+    private final Converter<T> converter;
+
+    Part(Headers headers, Converter<T> converter) {
+      this.headers = headers;
+      this.converter = converter;
+    }
+
+    @Override void perform(RequestBuilder builder, Object value) {
+      if (value == null) return; // Skip null values.
+
+      //noinspection unchecked
+      builder.addPart(headers, converter.toBody((T) value));
+    }
+  }
+
+  static final class PartMap extends RequestBuilderAction {
+    private final Converter.Factory converterFactory;
+    private final String transferEncoding;
+
+    PartMap(Converter.Factory converterFactory, String transferEncoding) {
+      this.converterFactory = converterFactory;
+      this.transferEncoding = transferEncoding;
+    }
+
+    @Override void perform(RequestBuilder builder, Object value) {
+      if (value == null) return; // Skip null values.
+
+      Map<?, ?> map = (Map<?, ?>) value;
+      for (Map.Entry<?, ?> entry : map.entrySet()) {
+        Object entryKey = entry.getKey();
+        if (entryKey == null) {
+          throw new IllegalArgumentException("Part map contained null key.");
+        }
+        Object entryValue = entry.getValue();
+        if (entryValue == null) {
+          continue; // Skip null values.
+        }
+
+        Headers headers = Headers.of(
+            "Content-Disposition", "name=\"" + entryKey + "\"",
+            "Content-Transfer-Encoding", transferEncoding);
+        //noinspection unchecked
+        Converter<Object> converter =
+            (Converter<Object>) converterFactory.get(entryValue.getClass());
+        builder.addPart(headers, converter.toBody(entryValue));
+      }
+    }
+  }
+
+  static final class Body<T> extends RequestBuilderAction {
+    private final Converter<T> converter;
+
+    Body(Converter<T> converter) {
+      this.converter = converter;
+    }
+
+    @Override void perform(RequestBuilder builder, Object value) {
+      if (value == null) {
+        throw new IllegalArgumentException("Body parameter value must not be null.");
+      }
+      //noinspection unchecked
+      builder.setBody(converter.toBody((T) value));
+    }
+  }
+}

--- a/retrofit/src/test/java/retrofit/DefaultCallAdapterFactoryTest.java
+++ b/retrofit/src/test/java/retrofit/DefaultCallAdapterFactoryTest.java
@@ -70,7 +70,7 @@ public final class DefaultCallAdapterFactoryTest {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
     CallAdapter adapter = factory.get(returnType);
     final Response<Object> response = Response.fakeSuccess("Hi");
-    Call call = (Call) adapter.adapt(new EmptyCall() {
+    Call<Object> call = (Call<Object>) adapter.adapt(new EmptyCall() {
       @Override public Response<Object> execute() throws IOException {
         return response;
       }

--- a/retrofit/src/test/java/retrofit/MethodInfoTest.java
+++ b/retrofit/src/test/java/retrofit/MethodInfoTest.java
@@ -1,24 +1,12 @@
 // Copyright 2013 Square, Inc.
 package retrofit;
 
-import com.google.common.reflect.TypeToken;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Executors;
 import org.junit.Test;
-import retrofit.http.Body;
-import retrofit.http.POST;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings("unused") // Lots of unused parameters for example code.
 public final class MethodInfoTest {
-  private static CallAdapter.Factory CALL_ADAPTER_FACTORY =
-      new DefaultCallAdapterFactory(Executors.newSingleThreadExecutor());
-  private static Converter.Factory CONVERTER_FACTORY = new ToStringConverterFactory();
-
   @Test public void pathParameterParsing() throws Exception {
     expectParams("/");
     expectParams("/foo");
@@ -44,46 +32,5 @@ public final class MethodInfoTest {
     if (expected.length > 0) {
       assertThat(calculated).containsExactly(expected);
     }
-  }
-
-  static class Dummy {
-  }
-
-  @Test public void concreteBodyType() {
-    class Example {
-      @POST("/foo") Call<Object> a(@Body Dummy body) {
-        return null;
-      }
-    }
-
-    Method method = TestingUtils.onlyMethod(Example.class);
-    MethodInfo methodInfo = new MethodInfo(method, CALL_ADAPTER_FACTORY, CONVERTER_FACTORY);
-    assertThat(methodInfo.requestType).isEqualTo(Dummy.class);
-  }
-
-  @Test public void genericBodyType() {
-    class Example {
-      @POST("/foo") Call<Object> a(@Body List<Dummy> body) {
-        return null;
-      }
-    }
-
-    Method method = TestingUtils.onlyMethod(Example.class);
-    MethodInfo methodInfo = new MethodInfo(method, CALL_ADAPTER_FACTORY, CONVERTER_FACTORY);
-    Type expected = new TypeToken<List<Dummy>>() {}.getType();
-    assertThat(methodInfo.requestType).isEqualTo(expected);
-  }
-
-  @Test public void wildcardBodyType() {
-    class Example {
-      @POST("/foo") Call<Object> a(@Body List<? super String> body) {
-        return null;
-      }
-    }
-
-    Method method = TestingUtils.onlyMethod(Example.class);
-    MethodInfo methodInfo = new MethodInfo(method, CALL_ADAPTER_FACTORY, CONVERTER_FACTORY);
-    Type expected = new TypeToken<List<? super String>>() {}.getType();
-    assertThat(methodInfo.requestType).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
This pushes a ton of work forward into the method parsing step so that when a request is needed its assembly has almost no logic.

Still work to do around killing `MethodInfo`'s mutableness.