### PR TITLE
Allow passing in an executor on which callback methods are invoked.

### DIFF
--- a/retrofit/src/test/java/retrofit/ExecutorCallAdapterFactoryTest.java
+++ b/retrofit/src/test/java/retrofit/ExecutorCallAdapterFactoryTest.java
@@ -31,10 +31,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @SuppressWarnings("unchecked")
-public final class DefaultCallAdapterFactoryTest {
+public final class ExecutorCallAdapterFactoryTest {
   private final Callback<String> callback = mock(Callback.class);
-  private final Executor callbackExecutor = spy(new Utils.SynchronousExecutor());
-  private final CallAdapter.Factory factory = new DefaultCallAdapterFactory(callbackExecutor);
+  private final Executor callbackExecutor = spy(new Executor() {
+    @Override public void execute(Runnable runnable) {
+      runnable.run();
+    }
+  });
+  private final CallAdapter.Factory factory = new ExecutorCallAdapterFactory(callbackExecutor);
 
   @Test public void rawTypeThrows() {
     try {


### PR DESCRIPTION
This only has an effect when Call is the return type of a service method. This does not affect the callback methods of a Call passed to a CallAdapter.

We also change the non-Android call adapter factory to be a simple implementation that returns the original instance rather than needlessly wrapping it in the executor factory with a synchronous executor.