### PR TITLE
Use rx.Single instead of rx.Observable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <okhttp.version>2.5.0-SNAPSHOT</okhttp.version>
 
     <!-- Adapter Dependencies -->
-    <rxjava.version>1.0.10</rxjava.version>
+    <rxjava.version>1.0.13</rxjava.version>
 
     <!-- Converter Dependencies -->
     <gson.version>2.3.1</gson.version>


### PR DESCRIPTION
This simplifies the API in my opinion. All of the network calls have
either a single success or an error so a Single works perfecly.
It is also easy to convert back to an Observable by calling toObservable.