### PR TITLE
Add optional support for RxJava's experimental Single type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <okhttp.version>2.5.0-SNAPSHOT</okhttp.version>
 
     <!-- Adapter Dependencies -->
-    <rxjava.version>1.0.10</rxjava.version>
+    <rxjava.version>1.0.13</rxjava.version>
 
     <!-- Converter Dependencies -->
     <gson.version>2.3.1</gson.version>

--- a/retrofit-adapters/rxjava-mock/src/main/java/retrofit/mock/SingleHelper.java
+++ b/retrofit-adapters/rxjava-mock/src/main/java/retrofit/mock/SingleHelper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit.mock;
+
+import rx.Observable;
+import rx.Single;
+import rx.functions.Func1;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+final class SingleHelper {
+  @SuppressWarnings("unchecked") // Caller must instanceof / getClass() verify 'value' is Single.
+  public static Object applySingleBehavior(final Behavior behavior, Object value) {
+    final Single<Object> single = (Single<Object>) value;
+    return Observable.timer(behavior.calculateDelay(MILLISECONDS), MILLISECONDS)
+        .flatMap(new Func1<Long, Observable<?>>() {
+          @Override public Observable<?> call(Long ignored) {
+            if (behavior.calculateIsFailure()) {
+              return Observable.error(behavior.failureException());
+            }
+            return single.toObservable();
+          }
+        })
+        .toSingle();
+  }
+}

--- a/retrofit-adapters/rxjava/src/main/java/retrofit/SingleHelper.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/SingleHelper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import java.lang.reflect.Type;
+import rx.Observable;
+import rx.Single;
+
+final class SingleHelper {
+  static CallAdapter<Object> makeSingle(final CallAdapter<Object> callAdapter) {
+    return new CallAdapter<Object>() {
+      @Override public Type responseType() {
+        return callAdapter.responseType();
+      }
+
+      @Override public Single<?> adapt(Call<Object> call) {
+        Observable<?> observable = (Observable<?>) callAdapter.adapt(call);
+        return observable.toSingle();
+      }
+    };
+  }
+}


### PR DESCRIPTION
Because this API is not stable the interactions are isolated to a separate class which is only loaded when the Single type is detected as being used.

Closes #979. Closes #969.