### PR TITLE
HTTP-specific exception for the simple Observable case.

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit/HttpException.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/HttpException.java
@@ -1,0 +1,34 @@
+package retrofit;
+
+import java.io.IOException;
+
+/** Exception for an unexpected, non-2xx HTTP response. */
+public final class HttpException extends IOException {
+  private final int code;
+  private final String message;
+  private final transient Response<?> response;
+
+  public HttpException(Response<?> response) {
+    super("HTTP " + response.code() + " " + response.message());
+    this.code = response.code();
+    this.message = response.message();
+    this.response = response;
+  }
+
+  /** HTTP status code. */
+  public int code() {
+    return code;
+  }
+
+  /** HTTP status message. */
+  public String message() {
+    return message;
+  }
+
+  /**
+   * The full HTTP response. This may be null if the exception was serialized.
+   */
+  public Response<?> response() {
+    return response;
+  }
+}

--- a/retrofit-adapters/rxjava/src/main/java/retrofit/ObservableCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/ObservableCallAdapterFactory.java
@@ -15,7 +15,6 @@
  */
 package retrofit;
 
-import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import rx.Observable;
@@ -151,7 +150,7 @@ public final class ObservableCallAdapterFactory implements CallAdapter.Factory {
               if (response.isSuccess()) {
                 return Observable.just(response.body());
               }
-              return Observable.error(new IOException()); // TODO non-suck message.
+              return Observable.error(new HttpException(response));
             }
           });
     }

--- a/retrofit-adapters/rxjava/src/test/java/retrofit/ObservableCallAdapterFactoryTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit/ObservableCallAdapterFactoryTest.java
@@ -70,7 +70,8 @@ public final class ObservableCallAdapterFactoryTest {
       o.first();
       fail();
     } catch (RuntimeException e) {
-      // TODO assert on some indicator of 404.
+      Throwable cause = e.getCause();
+      assertThat(cause).isInstanceOf(HttpException.class).hasMessage("HTTP 404 OK");
     }
   }
 

--- a/retrofit/src/main/java/retrofit/Response.java
+++ b/retrofit/src/main/java/retrofit/Response.java
@@ -84,6 +84,11 @@ public final class Response<T> {
     return rawResponse.code();
   }
 
+  /** HTTP status message. */
+  public String message() {
+    return rawResponse.message();
+  }
+
   public Headers headers() {
     return rawResponse.headers();
   }


### PR DESCRIPTION
When you specify a return type of Observable<ResponseType>, we need a way to propagate non-2xx failures through the onError pipeline which accepts any Throwable. A custom exception subclassing IOException allows downstream consumers to filter and extract the code, message, and full response.