### PR TITLE
Switch HttpException to not be an IOException.

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit/HttpException.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/HttpException.java
@@ -1,9 +1,7 @@
 package retrofit;
 
-import java.io.IOException;
-
 /** Exception for an unexpected, non-2xx HTTP response. */
-public final class HttpException extends IOException {
+public final class HttpException extends Exception {
   private final int code;
   private final String message;
   private final transient Response<?> response;


### PR DESCRIPTION
This allows for easier 'instanceof' checks in an onError to differentiate whether the problem was in the transport or the received response.