### PR TITLE
RxJava 1.0.14 with an important Android fix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <animal.sniffer.version>1.14</animal.sniffer.version>
 
     <!-- Adapter Dependencies -->
-    <rxjava.version>1.0.13</rxjava.version>
+    <rxjava.version>1.0.14</rxjava.version>
 
     <!-- Converter Dependencies -->
     <gson.version>2.3.1</gson.version>


### PR DESCRIPTION
Just in case someone is relying on the transitive dependency.