### PR TITLE
Give method or parameter annotations to CallAdapter and Converter factories.

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package retrofit;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import rx.Observable;
@@ -37,7 +38,7 @@ public final class RxJavaCallAdapterFactory implements CallAdapter.Factory {
   private RxJavaCallAdapterFactory() {
   }
 
-  @Override public CallAdapter<?> get(Type returnType) {
+  @Override public CallAdapter<?> get(Type returnType, Annotation[] annotations) {
     Class<?> rawType = Utils.getRawType(returnType);
     boolean isSingle = "rx.Single".equals(rawType.getCanonicalName());
     if (rawType != Observable.class && !isSingle) {

--- a/retrofit-adapters/rxjava/src/test/java/retrofit/RxJavaCallAdapterFactoryTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit/RxJavaCallAdapterFactoryTest.java
@@ -22,6 +22,7 @@ import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
 import org.junit.Before;
@@ -38,6 +39,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 public final class RxJavaCallAdapterFactoryTest {
+  private static final Annotation[] NO_ANNOTATIONS = new Annotation[0];
+
   @Rule public final MockWebServer server = new MockWebServer();
 
   interface Service {
@@ -156,21 +159,21 @@ public final class RxJavaCallAdapterFactoryTest {
   @Test public void responseType() {
     CallAdapter.Factory factory = RxJavaCallAdapterFactory.create();
     Type classType = new TypeToken<Observable<String>>() {}.getType();
-    assertThat(factory.get(classType).responseType()).isEqualTo(String.class);
+    assertThat(factory.get(classType, NO_ANNOTATIONS).responseType()).isEqualTo(String.class);
     Type wilcardType = new TypeToken<Observable<? extends String>>() {}.getType();
-    assertThat(factory.get(wilcardType).responseType()).isEqualTo(String.class);
+    assertThat(factory.get(wilcardType, NO_ANNOTATIONS).responseType()).isEqualTo(String.class);
     Type genericType = new TypeToken<Observable<List<String>>>() {}.getType();
-    assertThat(factory.get(genericType).responseType()) //
+    assertThat(factory.get(genericType, NO_ANNOTATIONS).responseType()) //
         .isEqualTo(new TypeToken<List<String>>() {}.getType());
     Type responseType = new TypeToken<Observable<Response<String>>>() {}.getType();
-    assertThat(factory.get(responseType).responseType()).isEqualTo(String.class);
+    assertThat(factory.get(responseType, NO_ANNOTATIONS).responseType()).isEqualTo(String.class);
     Type resultType = new TypeToken<Observable<Response<String>>>() {}.getType();
-    assertThat(factory.get(resultType).responseType()).isEqualTo(String.class);
+    assertThat(factory.get(resultType, NO_ANNOTATIONS).responseType()).isEqualTo(String.class);
   }
 
   @Test public void nonObservableTypeReturnsNull() {
     CallAdapter.Factory factory = RxJavaCallAdapterFactory.create();
-    CallAdapter<?> adapter = factory.get(String.class);
+    CallAdapter<?> adapter = factory.get(String.class, NO_ANNOTATIONS);
     assertThat(adapter).isNull();
   }
 
@@ -178,14 +181,14 @@ public final class RxJavaCallAdapterFactoryTest {
     CallAdapter.Factory factory = RxJavaCallAdapterFactory.create();
     Type observableType = new TypeToken<Observable>() {}.getType();
     try {
-      factory.get(observableType);
+      factory.get(observableType, NO_ANNOTATIONS);
       fail();
     } catch (IllegalStateException e) {
       assertThat(e).hasMessage("Observable return type must be parameterized as Observable<Foo> or Observable<? extends Foo>");
     }
     Type singleType = new TypeToken<Single>() {}.getType();
     try {
-      factory.get(singleType);
+      factory.get(singleType, NO_ANNOTATIONS);
       fail();
     } catch (IllegalStateException e) {
       assertThat(e).hasMessage("Single return type must be parameterized as Single<Foo> or Single<? extends Foo>");
@@ -196,14 +199,14 @@ public final class RxJavaCallAdapterFactoryTest {
     CallAdapter.Factory factory = RxJavaCallAdapterFactory.create();
     Type observableType = new TypeToken<Observable<Response>>() {}.getType();
     try {
-      factory.get(observableType);
+      factory.get(observableType, NO_ANNOTATIONS);
       fail();
     } catch (IllegalStateException e) {
       assertThat(e).hasMessage("Response must be parameterized as Response<Foo> or Response<? extends Foo>");
     }
     Type singleType = new TypeToken<Single<Response>>() {}.getType();
     try {
-      factory.get(singleType);
+      factory.get(singleType, NO_ANNOTATIONS);
       fail();
     } catch (IllegalStateException e) {
       assertThat(e).hasMessage("Response must be parameterized as Response<Foo> or Response<? extends Foo>");
@@ -214,14 +217,14 @@ public final class RxJavaCallAdapterFactoryTest {
     CallAdapter.Factory factory = RxJavaCallAdapterFactory.create();
     Type observableType = new TypeToken<Observable<Result>>() {}.getType();
     try {
-      factory.get(observableType);
+      factory.get(observableType, NO_ANNOTATIONS);
       fail();
     } catch (IllegalStateException e) {
       assertThat(e).hasMessage("Result must be parameterized as Result<Foo> or Result<? extends Foo>");
     }
     Type singleType = new TypeToken<Single<Result>>() {}.getType();
     try {
-      factory.get(singleType);
+      factory.get(singleType, NO_ANNOTATIONS);
       fail();
     } catch (IllegalStateException e) {
       assertThat(e).hasMessage("Result must be parameterized as Result<Foo> or Result<? extends Foo>");
@@ -236,7 +239,7 @@ public final class RxJavaCallAdapterFactoryTest {
   }
 
   static class StringConverterFactory implements Converter.Factory {
-    @Override public Converter<?> get(Type type) {
+    @Override public Converter<?> get(Type type, Annotation[] annotations) {
       return new Converter<String>() {
         @Override public String fromBody(ResponseBody body) throws IOException {
           return body.string();

--- a/retrofit-converters/gson/src/main/java/retrofit/GsonConverterFactory.java
+++ b/retrofit-converters/gson/src/main/java/retrofit/GsonConverterFactory.java
@@ -18,6 +18,7 @@ package retrofit;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 /** A {@linkplain Converter.Factory converter} which uses Gson for JSON. */
@@ -46,7 +47,7 @@ public final class GsonConverterFactory implements Converter.Factory {
   }
 
   /** Create a converter for {@code type}. */
-  @Override public Converter<?> get(Type type) {
+  @Override public Converter<?> get(Type type, Annotation[] annotations) {
     TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
     return new GsonConverter<>(adapter);
   }

--- a/retrofit-converters/jackson/src/main/java/retrofit/JacksonConverterFactory.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit/JacksonConverterFactory.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 /** A {@linkplain Converter.Factory converter} which uses Jackson. */
@@ -41,7 +42,7 @@ public final class JacksonConverterFactory implements Converter.Factory {
   }
 
   /** Create a converter for {@code type}. */
-  @Override public Converter<?> get(Type type) {
+  @Override public Converter<?> get(Type type, Annotation[] annotations) {
     JavaType javaType = mapper.getTypeFactory().constructType(type);
     ObjectWriter writer = mapper.writerWithType(javaType);
     ObjectReader reader = mapper.reader(javaType);

--- a/retrofit-converters/moshi/src/main/java/retrofit/MoshiConverterFactory.java
+++ b/retrofit-converters/moshi/src/main/java/retrofit/MoshiConverterFactory.java
@@ -17,6 +17,7 @@ package retrofit;
 
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 /** A {@linkplain Converter.Factory converter} which uses Moshi for JSON. */
@@ -39,7 +40,7 @@ public final class MoshiConverterFactory implements Converter.Factory {
   }
 
   /** Create a converter for {@code type}. */
-  @Override public Converter<?> get(Type type) {
+  @Override public Converter<?> get(Type type, Annotation[] annotations) {
     JsonAdapter<Object> adapter = moshi.adapter(type);
     return new MoshiConverter<>(adapter);
   }

--- a/retrofit-converters/protobuf/src/main/java/retrofit/ProtoConverterFactory.java
+++ b/retrofit-converters/protobuf/src/main/java/retrofit/ProtoConverterFactory.java
@@ -17,6 +17,7 @@ package retrofit;
 
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.Parser;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 
@@ -31,7 +32,7 @@ public final class ProtoConverterFactory implements Converter.Factory {
    * Create a converter for {@code type} provided it is a {@link MessageLite} type. Returns null
    * otherwise.
    */
-  @Override public Converter<?> get(Type type) {
+  @Override public Converter<?> get(Type type, Annotation[] annotations) {
     if (!(type instanceof Class<?>)) {
       return null;
     }

--- a/retrofit-converters/simplexml/src/main/java/retrofit/SimpleXmlConverterFactory.java
+++ b/retrofit-converters/simplexml/src/main/java/retrofit/SimpleXmlConverterFactory.java
@@ -15,6 +15,7 @@
  */
 package retrofit;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import org.simpleframework.xml.Serializer;
 import org.simpleframework.xml.core.Persister;
@@ -55,7 +56,7 @@ public final class SimpleXmlConverterFactory implements Converter.Factory {
   }
 
   /** Create a converter for {@code type} provided it is a class. Returns null otherwise. */
-  @Override public Converter<?> get(Type type) {
+  @Override public Converter<?> get(Type type, Annotation[] annotations) {
     if (!(type instanceof Class)) {
       return null;
     }

--- a/retrofit-converters/wire/src/main/java/retrofit/WireConverterFactory.java
+++ b/retrofit-converters/wire/src/main/java/retrofit/WireConverterFactory.java
@@ -17,6 +17,7 @@ package retrofit;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.Wire;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 /** A {@linkplain Converter.Factory converter} that uses Wire for protocol buffers. */
@@ -43,7 +44,7 @@ public final class WireConverterFactory implements Converter.Factory {
    * Create a converter for {@code type} provided it is a {@link Message} type. Returns null
    * otherwise.
    */
-  @Override public Converter<?> get(Type type) {
+  @Override public Converter<?> get(Type type, Annotation[] annotations) {
     if (!(type instanceof Class<?>)) {
       return null;
     }

--- a/retrofit/src/main/java/retrofit/CallAdapter.java
+++ b/retrofit/src/main/java/retrofit/CallAdapter.java
@@ -15,6 +15,7 @@
  */
 package retrofit;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 /** Adapts a {@link Call} into the type of {@code T}. */
@@ -37,6 +38,6 @@ public interface CallAdapter<T> {
      * Returns a call adapter for interface methods that return {@code returnType}, or null if this
      * factory doesn't adapt that type.
      */
-    CallAdapter<?> get(Type returnType);
+    CallAdapter<?> get(Type returnType, Annotation[] annotations);
   }
 }

--- a/retrofit/src/main/java/retrofit/Converter.java
+++ b/retrofit/src/main/java/retrofit/Converter.java
@@ -18,6 +18,7 @@ package retrofit;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.ResponseBody;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 /**
@@ -34,6 +35,6 @@ public interface Converter<T> {
 
   interface Factory {
     /** Create a converter for {@code type}. Returns null if the type cannot be handled. */
-    Converter<?> get(Type type);
+    Converter<?> get(Type type, Annotation[] annotations);
   }
 }

--- a/retrofit/src/main/java/retrofit/DefaultCallAdapter.java
+++ b/retrofit/src/main/java/retrofit/DefaultCallAdapter.java
@@ -15,6 +15,7 @@
  */
 package retrofit;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 /**
@@ -24,7 +25,7 @@ import java.lang.reflect.Type;
  */
 final class DefaultCallAdapter implements CallAdapter<Call<?>> {
   public static final Factory FACTORY = new Factory() {
-    @Override public CallAdapter<?> get(Type returnType) {
+    @Override public CallAdapter<?> get(Type returnType, Annotation[] annotations) {
       if (Utils.getRawType(returnType) != Call.class) {
         return null;
       }

--- a/retrofit/src/main/java/retrofit/ExecutorCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit/ExecutorCallAdapterFactory.java
@@ -16,6 +16,7 @@
 package retrofit;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.concurrent.Executor;
 
@@ -26,7 +27,7 @@ final class ExecutorCallAdapterFactory implements CallAdapter.Factory {
     this.callbackExecutor = callbackExecutor;
   }
 
-  @Override public CallAdapter<Call<?>> get(Type returnType) {
+  @Override public CallAdapter<Call<?>> get(Type returnType, Annotation[] annotations) {
     if (Utils.getRawType(returnType) != Call.class) {
       return null;
     }

--- a/retrofit/src/main/java/retrofit/MethodHandler.java
+++ b/retrofit/src/main/java/retrofit/MethodHandler.java
@@ -16,11 +16,10 @@
 package retrofit;
 
 import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.ResponseBody;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.List;
-import retrofit.http.Streaming;
 
 final class MethodHandler<T> {
   @SuppressWarnings("unchecked")
@@ -45,8 +44,9 @@ final class MethodHandler<T> {
     if (returnType == void.class) {
       throw Utils.methodError(method, "Service methods cannot return void.");
     }
+    Annotation[] annotations = method.getAnnotations();
     try {
-      return Utils.resolveCallAdapter(adapterFactories, returnType);
+      return Utils.resolveCallAdapter(adapterFactories, returnType, annotations);
     } catch (RuntimeException e) { // Wide exception range because factories are user code.
       throw Utils.methodError(e, method, "Unable to create call adapter for %s", returnType);
     }
@@ -55,14 +55,9 @@ final class MethodHandler<T> {
 
   private static Converter<?> createResponseConverter(Method method, Type responseType,
       List<Converter.Factory> converterFactories) {
-    // TODO how can we not special case this? See TODO below, maybe...
-    if (responseType == ResponseBody.class) {
-      boolean isStreaming = method.isAnnotationPresent(Streaming.class);
-      return new OkHttpResponseBodyConverter(isStreaming);
-    }
-
+    Annotation[] annotations = method.getAnnotations();
     try {
-      return Utils.resolveConverter(converterFactories, responseType);
+      return Utils.resolveConverter(converterFactories, responseType, annotations);
     } catch (RuntimeException e) { // Wide exception range because factories are user code.
       throw Utils.methodError(e, method, "Unable to create converter for %s", responseType);
     }

--- a/retrofit/src/main/java/retrofit/OkHttpBodyConverterFactory.java
+++ b/retrofit/src/main/java/retrofit/OkHttpBodyConverterFactory.java
@@ -17,10 +17,12 @@ package retrofit;
 
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.ResponseBody;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import retrofit.http.Streaming;
 
 final class OkHttpBodyConverterFactory implements Converter.Factory {
-  @Override public Converter<?> get(Type type) {
+  @Override public Converter<?> get(Type type, Annotation[] annotations) {
     if (!(type instanceof Class)) {
       return null;
     }
@@ -28,8 +30,9 @@ final class OkHttpBodyConverterFactory implements Converter.Factory {
     if (RequestBody.class.isAssignableFrom(cls)) {
       return new OkHttpRequestBodyConverter();
     }
-    if (ResponseBody.class.isAssignableFrom(cls)) {
-      return new OkHttpResponseBodyConverter(false);
+    if (cls == ResponseBody.class) {
+      boolean streaming = Utils.isAnnotationPresent(annotations, Streaming.class);
+      return new OkHttpResponseBodyConverter(streaming);
     }
     return null;
   }

--- a/retrofit/src/main/java/retrofit/RequestBuilderAction.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilderAction.java
@@ -16,6 +16,7 @@
 package retrofit;
 
 import com.squareup.okhttp.Headers;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.util.List;
 import java.util.Map;
@@ -208,10 +209,13 @@ abstract class RequestBuilderAction {
   static final class PartMap extends RequestBuilderAction {
     private final List<Converter.Factory> converterFactories;
     private final String transferEncoding;
+    private final Annotation[] annotations;
 
-    PartMap(List<Converter.Factory> converterFactories, String transferEncoding) {
+    PartMap(List<Converter.Factory> converterFactories, String transferEncoding,
+        Annotation[] annotations) {
       this.converterFactories = converterFactories;
       this.transferEncoding = transferEncoding;
+      this.annotations = annotations;
     }
 
     @Override void perform(RequestBuilder builder, Object value) {
@@ -235,7 +239,7 @@ abstract class RequestBuilderAction {
         Class<?> entryClass = entryValue.getClass();
         //noinspection unchecked
         Converter<Object> converter =
-            (Converter<Object>) Utils.resolveConverter(converterFactories, entryClass);
+            (Converter<Object>) Utils.resolveConverter(converterFactories, entryClass, annotations);
         builder.addPart(headers, converter.toBody(entryValue));
       }
     }

--- a/retrofit/src/main/java/retrofit/RequestFactoryParser.java
+++ b/retrofit/src/main/java/retrofit/RequestFactoryParser.java
@@ -293,7 +293,8 @@ final class RequestFactoryParser {
                 "Content-Transfer-Encoding", part.encoding());
             Converter<?> converter;
             try {
-              converter = Utils.resolveConverter(converterFactories, methodParameterType);
+              converter = Utils.resolveConverter(converterFactories, methodParameterType,
+                  methodParameterAnnotations);
             } catch (RuntimeException e) { // Wide exception range because factories are user code.
               throw parameterError(e, i, "Unable to create @Part converter for %s",
                   methodParameterType);
@@ -310,7 +311,8 @@ final class RequestFactoryParser {
               throw parameterError(i, "@PartMap parameter type must be Map.");
             }
             PartMap partMap = (PartMap) methodParameterAnnotation;
-            action = new RequestBuilderAction.PartMap(converterFactories, partMap.encoding());
+            action = new RequestBuilderAction.PartMap(converterFactories, partMap.encoding(),
+                methodParameterAnnotations);
             gotPart = true;
 
           } else if (methodParameterAnnotation instanceof Body) {
@@ -324,7 +326,8 @@ final class RequestFactoryParser {
 
             Converter<?> converter;
             try {
-              converter = Utils.resolveConverter(converterFactories, methodParameterType);
+              converter = Utils.resolveConverter(converterFactories, methodParameterType,
+                  methodParameterAnnotations);
             } catch (RuntimeException e) { // Wide exception range because factories are user code.
               throw parameterError(e, i, "Unable to create @Body converter for %s",
                   methodParameterType);

--- a/retrofit/src/main/java/retrofit/Retrofit.java
+++ b/retrofit/src/main/java/retrofit/Retrofit.java
@@ -19,6 +19,7 @@ import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.ResponseBody;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -215,7 +216,7 @@ public final class Retrofit {
       checkNotNull(type, "type == null");
       checkNotNull(converter, "converter == null");
       converterFactories.add(new Converter.Factory() {
-        @Override public Converter<?> get(Type candidate) {
+        @Override public Converter<?> get(Type candidate, Annotation[] annotations) {
           return candidate.equals(type) ? converter : null;
         }
         @Override public String toString() {

--- a/retrofit/src/main/java/retrofit/Utils.java
+++ b/retrofit/src/main/java/retrofit/Utils.java
@@ -20,6 +20,7 @@ import com.squareup.okhttp.Response;
 import com.squareup.okhttp.ResponseBody;
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
@@ -49,10 +50,21 @@ final class Utils {
     }
   }
 
+  /** Returns true if {@code annotations} contains an instance of {@code cls}. */
+  static boolean isAnnotationPresent(Annotation[] annotations,
+      Class<? extends Annotation> cls) {
+    for (Annotation annotation : annotations) {
+      if (cls.isInstance(annotation)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
-  static CallAdapter<?> resolveCallAdapter(List<CallAdapter.Factory> adapterFactories, Type type) {
+  static CallAdapter<?> resolveCallAdapter(List<CallAdapter.Factory> adapterFactories, Type type,
+      Annotation[] annotations) {
     for (int i = 0, count = adapterFactories.size(); i < count; i++) {
-      CallAdapter<?> adapter = adapterFactories.get(i).get(type);
+      CallAdapter<?> adapter = adapterFactories.get(i).get(type, annotations);
       if (adapter != null) {
         return adapter;
       }
@@ -67,9 +79,10 @@ final class Utils {
     throw new IllegalArgumentException(builder.toString());
   }
 
-  static Converter<?> resolveConverter(List<Converter.Factory> converterFactories, Type type) {
+  static Converter<?> resolveConverter(List<Converter.Factory> converterFactories, Type type,
+      Annotation[] annotations) {
     for (int i = 0, count = converterFactories.size(); i < count; i++) {
-      Converter<?> converter = converterFactories.get(i).get(type);
+      Converter<?> converter = converterFactories.get(i).get(type, annotations);
       if (converter != null) {
         return converter;
       }

--- a/retrofit/src/test/java/retrofit/CallTest.java
+++ b/retrofit/src/test/java/retrofit/CallTest.java
@@ -23,6 +23,7 @@ import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.SocketPolicy;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
@@ -189,7 +190,7 @@ public final class CallTest {
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
-          @Override public Converter<?> get(Type type) {
+          @Override public Converter<?> get(Type type, Annotation[] annotations) {
             return new StringConverter() {
               @Override public RequestBody toBody(Object value) {
                 throw new UnsupportedOperationException("I am broken!");
@@ -213,7 +214,7 @@ public final class CallTest {
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
-          @Override public Converter<?> get(Type type) {
+          @Override public Converter<?> get(Type type, Annotation[] annotations) {
             return new StringConverter() {
               @Override public RequestBody toBody(Object value) {
                 throw new UnsupportedOperationException("I am broken!");
@@ -246,7 +247,7 @@ public final class CallTest {
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
-          @Override public Converter<?> get(Type type) {
+          @Override public Converter<?> get(Type type, Annotation[] annotations) {
             return new StringConverter() {
               @Override public String fromBody(ResponseBody body) throws IOException {
                 throw new UnsupportedOperationException("I am broken!");
@@ -289,7 +290,7 @@ public final class CallTest {
         .baseUrl(server.url("/"))
         .client(client)
         .addConverterFactory(new ToStringConverterFactory() {
-          @Override public Converter<?> get(Type type) {
+          @Override public Converter<?> get(Type type, Annotation[] annotations) {
             return new StringConverter() {
               @Override public String fromBody(ResponseBody body) throws IOException {
                 try {
@@ -320,7 +321,7 @@ public final class CallTest {
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
-          @Override public Converter<?> get(Type type) {
+          @Override public Converter<?> get(Type type, Annotation[] annotations) {
             return new StringConverter() {
               @Override public String fromBody(ResponseBody body) throws IOException {
                 throw new UnsupportedOperationException("I am broken!");
@@ -356,7 +357,7 @@ public final class CallTest {
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
-          @Override public Converter get(Type type) {
+          @Override public Converter get(Type type, Annotation[] annotations) {
             return converter;
           }
         })
@@ -376,7 +377,7 @@ public final class CallTest {
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
-          @Override public Converter get(Type type) {
+          @Override public Converter get(Type type, Annotation[] annotations) {
             return converter;
           }
         })

--- a/retrofit/src/test/java/retrofit/ExecutorCallAdapterFactoryTest.java
+++ b/retrofit/src/test/java/retrofit/ExecutorCallAdapterFactoryTest.java
@@ -17,6 +17,7 @@ package retrofit;
 
 import com.google.common.reflect.TypeToken;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -32,6 +33,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @SuppressWarnings("unchecked")
 public final class ExecutorCallAdapterFactoryTest {
+  private static final Annotation[] NO_ANNOTATIONS = new Annotation[0];
+
   private final Callback<String> callback = mock(Callback.class);
   private final Executor callbackExecutor = spy(new Executor() {
     @Override public void execute(Runnable runnable) {
@@ -42,7 +45,7 @@ public final class ExecutorCallAdapterFactoryTest {
 
   @Test public void rawTypeThrows() {
     try {
-      factory.get(Call.class);
+      factory.get(Call.class, NO_ANNOTATIONS);
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage("Call return type must be parameterized as Call<Foo> or Call<? extends Foo>");
@@ -52,7 +55,7 @@ public final class ExecutorCallAdapterFactoryTest {
   @Test public void responseThrows() {
     Type returnType = new TypeToken<Call<Response<String>>>() {}.getType();
     try {
-      factory.get(returnType);
+      factory.get(returnType, NO_ANNOTATIONS);
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage("Call<T> cannot use Response as its generic parameter. "
@@ -62,17 +65,17 @@ public final class ExecutorCallAdapterFactoryTest {
 
   @Test public void responseType() {
     Type classType = new TypeToken<Call<String>>() {}.getType();
-    assertThat(factory.get(classType).responseType()).isEqualTo(String.class);
+    assertThat(factory.get(classType, NO_ANNOTATIONS).responseType()).isEqualTo(String.class);
     Type wilcardType = new TypeToken<Call<? extends String>>() {}.getType();
-    assertThat(factory.get(wilcardType).responseType()).isEqualTo(String.class);
+    assertThat(factory.get(wilcardType, NO_ANNOTATIONS).responseType()).isEqualTo(String.class);
     Type genericType = new TypeToken<Call<List<String>>>() {}.getType();
-    assertThat(factory.get(genericType).responseType()) //
+    assertThat(factory.get(genericType, NO_ANNOTATIONS).responseType()) //
         .isEqualTo(new TypeToken<List<String>>() {}.getType());
   }
 
   @Test public void adaptedCallExecute() throws IOException {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
-    CallAdapter<Call<?>> adapter = (CallAdapter<Call<?>>) factory.get(returnType);
+    CallAdapter<Call<?>> adapter = (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS);
     final Response<String> response = Response.success("Hi");
     Call<String> call = (Call<String>) adapter.adapt(new EmptyCall() {
       @Override public Response<String> execute() throws IOException {
@@ -84,7 +87,7 @@ public final class ExecutorCallAdapterFactoryTest {
 
   @Test public void adaptedCallEnqueueUsesExecutorForSuccessCallback() {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
-    CallAdapter<Call<?>> adapter = (CallAdapter<Call<?>>) factory.get(returnType);
+    CallAdapter<Call<?>> adapter = (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS);
     final Response<String> response = Response.success("Hi");
     Call<String> call = (Call<String>) adapter.adapt(new EmptyCall() {
       @Override public void enqueue(Callback<String> callback) {
@@ -98,7 +101,7 @@ public final class ExecutorCallAdapterFactoryTest {
 
   @Test public void adaptedCallEnqueueUsesExecutorForFailureCallback() {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
-    CallAdapter<Call<?>> adapter = (CallAdapter<Call<?>>) factory.get(returnType);
+    CallAdapter<Call<?>> adapter = (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS);
     final Throwable throwable = new IOException();
     Call<String> call = (Call<String>) adapter.adapt(new EmptyCall() {
       @Override public void enqueue(Callback<String> callback) {
@@ -114,7 +117,7 @@ public final class ExecutorCallAdapterFactoryTest {
 
   @Test public void adaptedCallCloneDeepCopy() {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
-    CallAdapter<Call<?>> adapter = (CallAdapter<Call<?>>) factory.get(returnType);
+    CallAdapter<Call<?>> adapter = (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS);
     Call<String> delegate = mock(Call.class);
     Call<String> call = (Call<String>) adapter.adapt(delegate);
     Call<String> cloned = call.clone();
@@ -125,7 +128,7 @@ public final class ExecutorCallAdapterFactoryTest {
 
   @Test public void adaptedCallCancel() {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
-    CallAdapter<Call<?>> adapter = (CallAdapter<Call<?>>) factory.get(returnType);
+    CallAdapter<Call<?>> adapter = (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS);
     Call<String> delegate = mock(Call.class);
     Call<String> call = (Call<String>) adapter.adapt(delegate);
     call.cancel();

--- a/retrofit/src/test/java/retrofit/ToStringConverterFactory.java
+++ b/retrofit/src/test/java/retrofit/ToStringConverterFactory.java
@@ -19,12 +19,13 @@ import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.ResponseBody;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 class ToStringConverterFactory implements Converter.Factory {
   private static final MediaType MEDIA_TYPE = MediaType.parse("text/plain");
 
-  @Override public Converter get(Type type) {
+  @Override public Converter get(Type type, Annotation[] annotations) {
     if (type != String.class) {
       return null;
     }

--- a/samples/src/main/java/com/example/retrofit/CustomCallAdapter.java
+++ b/samples/src/main/java/com/example/retrofit/CustomCallAdapter.java
@@ -19,6 +19,7 @@ import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -35,7 +36,8 @@ import retrofit.http.GET;
  */
 public final class CustomCallAdapter {
   public static class ListenableFutureCallAdapterFactory implements CallAdapter.Factory {
-    @Override public CallAdapter<ListenableFuture<?>> get(Type returnType) {
+    @Override
+    public CallAdapter<ListenableFuture<?>> get(Type returnType, Annotation[] annotations) {
       TypeToken<?> token = TypeToken.of(returnType);
       if (token.getRawType() != ListenableFuture.class) {
         return null;


### PR DESCRIPTION
Giant win: we no longer have to special-case the streaming ResponseBody behavior.