### PR TITLE
Use form-data subtype for multipart requests.

### DIFF
--- a/retrofit/src/main/java/retrofit/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilder.java
@@ -61,6 +61,7 @@ final class RequestBuilder {
     } else if (isMultipart) {
       // Will be set to 'body' in 'build'.
       multipartBuilder = new MultipartBuilder();
+      multipartBuilder.type(MultipartBuilder.FORM);
     }
   }
 

--- a/retrofit/src/main/java/retrofit/RequestBuilderAction.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilderAction.java
@@ -241,7 +241,7 @@ abstract class RequestBuilderAction {
         }
 
         Headers headers = Headers.of(
-            "Content-Disposition", "name=\"" + entryKey + "\"",
+            "Content-Disposition", "form-data; name=\"" + entryKey + "\"",
             "Content-Transfer-Encoding", transferEncoding);
 
         Class<?> entryClass = entryValue.getClass();

--- a/retrofit/src/main/java/retrofit/RequestFactoryParser.java
+++ b/retrofit/src/main/java/retrofit/RequestFactoryParser.java
@@ -290,7 +290,7 @@ final class RequestFactoryParser {
             }
             Part part = (Part) methodParameterAnnotation;
             com.squareup.okhttp.Headers headers = com.squareup.okhttp.Headers.of(
-                "Content-Disposition", "name=\"" + part.value() + "\"",
+                "Content-Disposition", "form-data; name=\"" + part.value() + "\"",
                 "Content-Transfer-Encoding", part.encoding());
             Converter<?, RequestBody> converter;
             try {

--- a/retrofit/src/main/java/retrofit/http/PartMap.java
+++ b/retrofit/src/main/java/retrofit/http/PartMap.java
@@ -47,6 +47,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(PARAMETER)
 @Retention(RUNTIME)
 public @interface PartMap {
-  /** The {@code Content-Transfer-Encoding} of this part. */
+  /** The {@code Content-Transfer-Encoding} of the parts. */
   String encoding() default "binary";
 }

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -1179,10 +1179,12 @@ public final class RequestBuilderTest {
     String bodyString = buffer.readUtf8();
 
     assertThat(bodyString)
+        .contains("Content-Disposition: form-data;")
         .contains("name=\"ping\"\r\n")
         .contains("\r\npong\r\n--");
 
     assertThat(bodyString)
+        .contains("Content-Disposition: form-data;")
         .contains("name=\"kit\"")
         .contains("\r\nkat\r\n--");
   }
@@ -1208,11 +1210,15 @@ public final class RequestBuilderTest {
     body.writeTo(buffer);
     String bodyString = buffer.readUtf8();
 
-    assertThat(bodyString).contains("name=\"ping\"\r\n")
+    assertThat(bodyString)
+        .contains("Content-Disposition: form-data;")
+        .contains("name=\"ping\"\r\n")
         .contains("Content-Transfer-Encoding: 8-bit")
         .contains("\r\npong\r\n--");
 
-    assertThat(bodyString).contains("name=\"kit\"")
+    assertThat(bodyString)
+        .contains("Content-Disposition: form-data;")
+        .contains("name=\"kit\"")
         .contains("Content-Transfer-Encoding: 7-bit")
         .contains("\r\nkat\r\n--");
   }
@@ -1242,10 +1248,12 @@ public final class RequestBuilderTest {
     String bodyString = buffer.readUtf8();
 
     assertThat(bodyString)
+        .contains("Content-Disposition: form-data;")
         .contains("name=\"ping\"\r\n")
         .contains("\r\npong\r\n--");
 
     assertThat(bodyString)
+        .contains("Content-Disposition: form-data;")
         .contains("name=\"kit\"")
         .contains("\r\nkat\r\n--");
 
@@ -1276,11 +1284,15 @@ public final class RequestBuilderTest {
     body.writeTo(buffer);
     String bodyString = buffer.readUtf8();
 
-    assertThat(bodyString).contains("name=\"ping\"\r\n")
+    assertThat(bodyString)
+        .contains("Content-Disposition: form-data;")
+        .contains("name=\"ping\"\r\n")
         .contains("Content-Transfer-Encoding: 8-bit")
         .contains("\r\npong\r\n--");
 
-    assertThat(bodyString).contains("name=\"kit\"")
+    assertThat(bodyString)
+        .contains("Content-Disposition: form-data;")
+        .contains("name=\"kit\"")
         .contains("Content-Transfer-Encoding: 8-bit")
         .contains("\r\nkat\r\n--");
 
@@ -1345,6 +1357,7 @@ public final class RequestBuilderTest {
     String bodyString = buffer.readUtf8();
 
     assertThat(bodyString)
+        .contains("Content-Disposition: form-data;")
         .contains("name=\"ping\"")
         .contains("\r\npong\r\n--");
   }


### PR DESCRIPTION
Use [form-data](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2) content type for multipart requests. Closes #1092.

I don't especially like how this stretches over multiple classes. Perhaps RequestBuilder should be responsible for creating the right part headers.