### PR TITLE
Added OPTIONS to the built-in methods

### DIFF
--- a/retrofit/src/main/java/retrofit/RequestFactoryParser.java
+++ b/retrofit/src/main/java/retrofit/RequestFactoryParser.java
@@ -37,6 +37,7 @@ import retrofit.http.HTTP;
 import retrofit.http.Header;
 import retrofit.http.Headers;
 import retrofit.http.Multipart;
+import retrofit.http.OPTIONS;
 import retrofit.http.PATCH;
 import retrofit.http.POST;
 import retrofit.http.PUT;
@@ -107,7 +108,9 @@ final class RequestFactoryParser {
       } else if (annotation instanceof POST) {
         parseHttpMethodAndPath("POST", ((POST) annotation).value(), true);
       } else if (annotation instanceof PUT) {
-        parseHttpMethodAndPath("PUT", ((PUT) annotation).value(), true);
+          parseHttpMethodAndPath("PUT", ((PUT) annotation).value(), true);
+      } else if (annotation instanceof OPTIONS) {
+        parseHttpMethodAndPath("OPTIONS", ((OPTIONS) annotation).value(), false);
       } else if (annotation instanceof HTTP) {
         HTTP http = (HTTP) annotation;
         parseHttpMethodAndPath(http.method(), http.path(), http.hasBody());

--- a/retrofit/src/main/java/retrofit/Retrofit.java
+++ b/retrofit/src/main/java/retrofit/Retrofit.java
@@ -42,8 +42,8 @@ import static retrofit.Utils.checkNotNull;
  * The relative path for a given method is obtained from an annotation on the method describing
  * the request type. The built-in methods are {@link retrofit.http.GET GET},
  * {@link retrofit.http.PUT PUT}, {@link retrofit.http.POST POST}, {@link retrofit.http.PATCH
- * PATCH}, {@link retrofit.http.HEAD HEAD}, and {@link retrofit.http.DELETE DELETE}. You can use a
- * custom HTTP method with {@link HTTP @HTTP}.
+ * PATCH}, {@link retrofit.http.HEAD HEAD}, {@link retrofit.http.DELETE DELETE} and
+ * {@link retrofit.http.OPTIONS OPTIONS}. You can use a custom HTTP method with {@link HTTP @HTTP}.
  * <p>
  * Method parameters can be used to replace parts of the URL by annotating them with
  * {@link retrofit.http.Path @Path}. Replacement sections are denoted by an identifier surrounded

--- a/retrofit/src/main/java/retrofit/http/OPTIONS.java
+++ b/retrofit/src/main/java/retrofit/http/OPTIONS.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit.http;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/** Make a OPTIONS request to a REST path relative to base URL. */
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface OPTIONS {
+  String value() default "";
+}

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -27,6 +27,7 @@ import retrofit.http.HTTP;
 import retrofit.http.Header;
 import retrofit.http.Headers;
 import retrofit.http.Multipart;
+import retrofit.http.OPTIONS;
 import retrofit.http.PATCH;
 import retrofit.http.POST;
 import retrofit.http.PUT;
@@ -44,6 +45,20 @@ import static org.junit.Assert.fail;
 @SuppressWarnings({"UnusedParameters", "unused"}) // Parameters inspected reflectively.
 public final class RequestBuilderTest {
   private static final MediaType TEXT_PLAIN = MediaType.parse("text/plain");
+
+    @Test public void optionsMethodNoBody() {
+        class Example {
+            @OPTIONS("/foobar")
+            Call<Object> method() {
+                return null;
+            }
+        }
+
+        Request request = buildRequest(Example.class);
+        assertThat(request.method()).isEqualTo("OPTIONS");
+        assertThat(request.urlString()).isEqualTo("http://example.com/foobar");
+        assertThat(request.body()).isNull();
+    }
 
   @Test public void customMethodNoBody() {
     class Example {


### PR DESCRIPTION
Hey guys,

first of all, thanks for the great work. 
We are currently working on a project, which heavily uses the OPTIONS method. I did not read about the @HTTP annotation (just saw it when adding the docs and the test; darn). So I forked the project and added the @OPTIONS annotation. 
Since there is the @HTTP annotation, this might not be that useful, but maybe you still like to add it to your codebase.

Best regards
Alex