### PR TITLE
Added extra caution before calling onError/onCompleted

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
@@ -109,10 +109,14 @@ public final class RxJavaCallAdapterFactory implements CallAdapter.Factory {
           try {
             subscriber.onNext(response);
           } catch (Throwable t) {
-            subscriber.onError(t);
+            if (!subscriber.isUnsubscribed()) {
+              subscriber.onError(t);
+            }
             return;
           }
-          subscriber.onCompleted();
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onCompleted();
+          }
         }
 
         @Override public void onFailure(Throwable t) {


### PR DESCRIPTION
The chances are low (but not zero) of an unsubscription between onNext() and
the terminal event.