### PR TITLE
Use execute() instead of enqueue() in Rx adapter

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
@@ -102,31 +102,25 @@ public final class RxJavaCallAdapterFactory implements CallAdapter.Factory {
         }
       }));
 
-      call.enqueue(new Callback<T>() {
-        @Override public void onResponse(Response<T> response, Retrofit retrofit) {
-          if (subscriber.isUnsubscribed()) {
-            return;
-          }
-          try {
-            subscriber.onNext(response);
-          } catch (Throwable t) {
-            if (!subscriber.isUnsubscribed()) {
-              subscriber.onError(t);
-            }
-            return;
-          }
-          if (!subscriber.isUnsubscribed()) {
-            subscriber.onCompleted();
-          }
-        }
+      if (subscriber.isUnsubscribed()) {
+        return;
+      }
 
-        @Override public void onFailure(Throwable t) {
-          if (subscriber.isUnsubscribed()) {
-            return;
-          }
+      try {
+        Response<T> response = call.execute();
+        if (!subscriber.isUnsubscribed()) {
+          subscriber.onNext(response);
+        }
+      } catch (Throwable t) {
+        if (!subscriber.isUnsubscribed()) {
           subscriber.onError(t);
         }
-      });
+        return;
+      }
+
+      if (!subscriber.isUnsubscribed()) {
+        subscriber.onCompleted();
+      }
     }
   }
 


### PR DESCRIPTION
Retrofit should leave threading up to the Scheduler used to invoke call().

Otherwise, there can be two types of unwanted behavior:

1. It can execute on another Thread when sync behavior is desired.

2. It uses unnecessary extra Threads even when already called on a Scheduler.