### PR TITLE
Temporarily revert to using Gson instance directly.

### DIFF
--- a/retrofit-converters/gson/src/main/java/retrofit/GsonConverterFactory.java
+++ b/retrofit-converters/gson/src/main/java/retrofit/GsonConverterFactory.java
@@ -16,8 +16,6 @@
 package retrofit;
 
 import com.google.gson.Gson;
-import com.google.gson.TypeAdapter;
-import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.ResponseBody;
 import java.lang.annotation.Annotation;
@@ -57,12 +55,10 @@ public final class GsonConverterFactory extends Converter.Factory {
 
   @Override
   public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
-    TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
-    return new GsonResponseBodyConverter<>(adapter);
+    return new GsonResponseBodyConverter<>(gson, type);
   }
 
   @Override public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
-    TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
-    return new GsonRequestBodyConverter<>(adapter);
+    return new GsonRequestBodyConverter<>(gson, type);
   }
 }

--- a/retrofit-converters/gson/src/main/java/retrofit/GsonRequestBodyConverter.java
+++ b/retrofit-converters/gson/src/main/java/retrofit/GsonRequestBodyConverter.java
@@ -15,12 +15,13 @@
  */
 package retrofit;
 
-import com.google.gson.TypeAdapter;
+import com.google.gson.Gson;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.RequestBody;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.lang.reflect.Type;
 import java.nio.charset.Charset;
 import okio.Buffer;
 
@@ -28,17 +29,19 @@ final class GsonRequestBodyConverter<T> implements Converter<T, RequestBody> {
   private static final MediaType MEDIA_TYPE = MediaType.parse("application/json; charset=UTF-8");
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
-  private final TypeAdapter<T> adapter;
+  private final Gson gson;
+  private final Type type;
 
-  GsonRequestBodyConverter(TypeAdapter<T> adapter) {
-    this.adapter = adapter;
+  GsonRequestBodyConverter(Gson gson, Type type) {
+    this.gson = gson;
+    this.type = type;
   }
 
   @Override public RequestBody convert(T value) throws IOException {
     Buffer buffer = new Buffer();
     Writer writer = new OutputStreamWriter(buffer.outputStream(), UTF_8);
     try {
-      adapter.toJson(writer, value);
+      gson.toJson(value, type, writer);
       writer.flush();
     } catch (IOException e) {
       throw new AssertionError(e); // Writing to Buffer does no I/O.

--- a/retrofit-converters/gson/src/main/java/retrofit/GsonResponseBodyConverter.java
+++ b/retrofit-converters/gson/src/main/java/retrofit/GsonResponseBodyConverter.java
@@ -15,22 +15,25 @@
  */
 package retrofit;
 
-import com.google.gson.TypeAdapter;
+import com.google.gson.Gson;
 import com.squareup.okhttp.ResponseBody;
 import java.io.IOException;
 import java.io.Reader;
+import java.lang.reflect.Type;
 
 final class GsonResponseBodyConverter<T> implements Converter<ResponseBody, T> {
-  private final TypeAdapter<T> adapter;
+  private final Gson gson;
+  private final Type type;
 
-  GsonResponseBodyConverter(TypeAdapter<T> adapter) {
-    this.adapter = adapter;
+  GsonResponseBodyConverter(Gson gson, Type type) {
+    this.gson = gson;
+    this.type = type;
   }
 
   @Override public T convert(ResponseBody value) throws IOException {
     Reader reader = value.charStream();
     try {
-      return adapter.fromJson(reader);
+      return gson.fromJson(reader, type);
     } finally {
       Utils.closeQuietly(reader);
     }

--- a/retrofit-converters/gson/src/test/java/retrofit/GsonConverterFactoryTest.java
+++ b/retrofit-converters/gson/src/test/java/retrofit/GsonConverterFactoryTest.java
@@ -118,6 +118,15 @@ public final class GsonConverterFactoryTest {
     RecordedRequest request = server.takeRequest();
     assertThat(request.getBody().readUtf8()).isEqualTo("{\"theName\":\"value\"}");
     assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
+  }
 
+  @Test public void serializeUsesConfiguration() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse());
+
+    service.anImplementation(new AnImplementation(null)).execute();
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getBody().readUtf8()).isEqualTo("{}"); // Null value was not serialized.
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
   }
 }


### PR DESCRIPTION
Until Gson 2.4 is released, this is the only way to ensure that the configuration of the Gson instance (e.g., not serializing nulls) is honored when writing values.

Refs #1062.