### PR TITLE
Remove useless unsubscribed check.

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
@@ -103,10 +103,6 @@ public final class RxJavaCallAdapterFactory implements CallAdapter.Factory {
         }
       }));
 
-      if (subscriber.isUnsubscribed()) {
-        return;
-      }
-
       try {
         Response<T> response = call.execute();
         if (!subscriber.isUnsubscribed()) {


### PR DESCRIPTION
This is called synchronously in the subscribe method so it's (effectively) impossible to be subscribed here.