### PR TITLE
Common prefix for all methods in an interface

### DIFF
--- a/retrofit/src/main/java/retrofit/http/PathPrefix.java
+++ b/retrofit/src/main/java/retrofit/http/PathPrefix.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit.http;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Path prefix for all methods declared in an interface
+ * <p>
+ * Simple example:
+ * <pre>
+ * &#64;PathPrefix("/image")
+ * public interface ImageService {
+ *     &#64;GET("/{id}")
+ *     void example(@Path("id") int id);
+ * }
+ * </pre>
+ * Calling with {@code foo.example(1)} yields {@code /image/1}.
+ * <p>
+ * Path parameters may not be {@code null}.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface PathPrefix {
+  String value();
+}

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -38,6 +38,7 @@ import retrofit.http.PUT;
 import retrofit.http.Part;
 import retrofit.http.PartMap;
 import retrofit.http.Path;
+import retrofit.http.PathPrefix;
 import retrofit.http.Query;
 import retrofit.http.QueryMap;
 import retrofit.http.Url;
@@ -1687,6 +1688,21 @@ public final class RequestBuilderTest {
     RequestBody body = RequestBody.create(MediaType.parse("text/plain"), "Plain");
     Request request = buildRequest(Example.class, "text/not-plain", body);
     assertThat(request.body().contentType().toString()).isEqualTo("text/not-plain");
+  }
+
+  @Test public void testPathPrefix() {
+    @PathPrefix("/foo")
+    class Example {
+      @GET("/bar/") //
+      Call<ResponseBody> method() {
+        return null;
+      }
+    }
+    Request request = buildRequest(Example.class);
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo("http://example.com/foo/bar/");
+    assertThat(request.body()).isNull();
   }
 
   private static void assertBody(RequestBody body, String expected) {

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -1693,7 +1693,7 @@ public final class RequestBuilderTest {
   @Test public void testPathPrefix() {
     @PathPrefix("/foo")
     class Example {
-      @GET("/bar/") //
+      @GET("/bar") //
       Call<ResponseBody> method() {
         return null;
       }
@@ -1701,7 +1701,22 @@ public final class RequestBuilderTest {
     Request request = buildRequest(Example.class);
     assertThat(request.method()).isEqualTo("GET");
     assertThat(request.headers().size()).isZero();
-    assertThat(request.urlString()).isEqualTo("http://example.com/foo/bar/");
+    assertThat(request.urlString()).isEqualTo("http://example.com/foo/bar");
+    assertThat(request.body()).isNull();
+  }
+
+  @Test public void testPathPrefix2() {
+    @PathPrefix("/foo")
+    class Example {
+      @GET("Bar") //
+      Call<ResponseBody> method() {
+        return null;
+      }
+    }
+    Request request = buildRequest(Example.class);
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.urlString()).isEqualTo("http://example.com/fooBar");
     assertThat(request.body()).isNull();
   }
 

--- a/website/index.html
+++ b/website/index.html
@@ -88,6 +88,21 @@ List&lt;User> groupList(@Path("id") int groupId, @Query("sort") String sort);</p
               <pre class="prettyprint">@GET("/group/{id}/users")
 List&lt;User> groupList(@Path("id") int groupId, @QueryMap Map&lt;String, String&gt; options);</pre>
 
+              <h4>Path Prefix</h4>
+              <p>An interface can be annotated with <code>@PathPrefix</code> in order to set a prefix for all URLs in this interface:</p>
+              <pre class="prettyprint">@PathPrefix("/cats")
+public interface CatService {
+  @GET              // -> /cats
+  Call&lt;List&lt;Cat>> getCats();
+
+  @GET("/{catId}")  // -> /cats/{catId}
+  Call&lt;Cat> getCat(@Path("catId") int catId);
+
+  @POST("AndDogs")  // -> /catsAndDogs
+  Call&lt;ResponseBody> postCatsAndDogs();
+}</pre>
+              <p>If the prefix contains an replacement block for path parameters, every method in the interface must have an corresponding parameter annotated with <code>@Path</code></p>
+
               <h4>Request Body</h4>
               <p>An object can be specified for use as an HTTP request body with the <code>@Body</code> annotation.</p>
               <pre class="prettyprint">@POST("/users/new")


### PR DESCRIPTION
Allow a common prefix for all methods in an interface by annotating the interface:
```java
@PathPrefix("/foo")
public interface FooService {
    @GET("/bar)
    Call<Object> bar(...);
}
```
The bar() method would produce the relative url ```/foo/bar```