### PR TITLE
Added Retrofit to CallAdapter and Result

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit/Result.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/Result.java
@@ -22,18 +22,21 @@ import static retrofit.Utils.checkNotNull;
 /** The result of executing an HTTP request. */
 public final class Result<T> {
   public static <T> Result<T> error(Throwable error) {
-    return new Result<>(null, checkNotNull(error, "error == null"));
+    return new Result<>(null, null, checkNotNull(error, "error == null"));
   }
 
-  public static <T> Result<T> response(Response<T> response) {
-    return new Result<>(checkNotNull(response, "response == null"), null);
+  public static <T> Result<T> response(Response<T> response, Retrofit retrofit) {
+    return new Result<>(checkNotNull(response, "response == null"),
+      checkNotNull(retrofit, "retrofit == null"), null);
   }
 
   private final Response<T> response;
+  private final Retrofit retrofit;
   private final Throwable error;
 
-  Result(Response<T> response, Throwable error) {
+  Result(Response<T> response, Retrofit retrofit, Throwable error) {
     this.response = response;
+    this.retrofit = retrofit;
     this.error = error;
   }
 
@@ -43,6 +46,14 @@ public final class Result<T> {
    */
   public Response<T> response() {
     return response;
+  }
+
+  /**
+   * The Retrofit used to make this request. Only present when {@link #isError()} is
+   * false, null otherwise.
+   */
+  public Retrofit retrofit() {
+    return retrofit;
   }
 
   /**

--- a/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
@@ -133,7 +133,7 @@ public final class RxJavaCallAdapterFactory implements CallAdapter.Factory {
       return responseType;
     }
 
-    @Override public <R> Observable<Response<R>> adapt(Call<R> call) {
+    @Override public <R> Observable<Response<R>> adapt(Call<R> call, Retrofit retrofit) {
       return Observable.create(new CallOnSubscribe<>(call));
     }
   }
@@ -149,7 +149,7 @@ public final class RxJavaCallAdapterFactory implements CallAdapter.Factory {
       return responseType;
     }
 
-    @Override public <R> Observable<R> adapt(Call<R> call) {
+    @Override public <R> Observable<R> adapt(Call<R> call, Retrofit retrofit) {
       return Observable.create(new CallOnSubscribe<>(call)) //
           .flatMap(new Func1<Response<R>, Observable<R>>() {
             @Override public Observable<R> call(Response<R> response) {
@@ -173,7 +173,7 @@ public final class RxJavaCallAdapterFactory implements CallAdapter.Factory {
       return responseType;
     }
 
-    @Override public <R> Observable<Result<R>> adapt(Call<R> call) {
+    @Override public <R> Observable<Result<R>> adapt(Call<R> call, Retrofit retrofit) {
       return Observable.create(new CallOnSubscribe<>(call)) //
           .map(new Func1<Response<R>, Result<R>>() {
             @Override public Result<R> call(Response<R> response) {

--- a/retrofit-adapters/rxjava/src/main/java/retrofit/SingleHelper.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/SingleHelper.java
@@ -26,8 +26,8 @@ final class SingleHelper {
         return callAdapter.responseType();
       }
 
-      @Override public <R> Single<?> adapt(Call<R> call) {
-        Observable<?> observable = callAdapter.adapt(call);
+      @Override public <R> Single<?> adapt(Call<R> call, Retrofit retrofit) {
+        Observable<?> observable = callAdapter.adapt(call, retrofit);
         return observable.toSingle();
       }
     };

--- a/retrofit-adapters/rxjava/src/test/java/retrofit/ResultTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit/ResultTest.java
@@ -16,15 +16,27 @@
 package retrofit;
 
 import java.io.IOException;
+
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 public final class ResultTest {
+
+  private Retrofit retrofit;
+
+  @Before
+  public void setUp() {
+    retrofit = new Retrofit.Builder()
+        .baseUrl("http://madeup.com")
+        .build();
+  }
+
   @Test public void response() {
     Response<String> response = Response.success("Hi");
-    Result<String> result = Result.response(response);
+    Result<String> result = Result.response(response, retrofit);
     assertThat(result.isError()).isFalse();
     assertThat(result.error()).isNull();
     assertThat(result.response()).isSameAs(response);
@@ -32,10 +44,20 @@ public final class ResultTest {
 
   @Test public void nullResponseThrows() {
     try {
-      Result.response(null);
+      Result.response(null, retrofit);
       fail();
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("response == null");
+    }
+  }
+
+  @Test public void nullRetrofitThrows() {
+    try {
+      Response<String> response = Response.success("Hi");
+      Result.response(response, null);
+      fail();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("retrofit == null");
     }
   }
 

--- a/retrofit/src/main/java/retrofit/CallAdapter.java
+++ b/retrofit/src/main/java/retrofit/CallAdapter.java
@@ -31,7 +31,7 @@ public interface CallAdapter<T> {
   Type responseType();
 
   /** Returns an instance of the {@code T} which adapts the execution of {@code call}. */
-  <R> T adapt(Call<R> call);
+  <R> T adapt(Call<R> call, Retrofit retrofit);
 
   interface Factory {
     /**

--- a/retrofit/src/main/java/retrofit/DefaultCallAdapter.java
+++ b/retrofit/src/main/java/retrofit/DefaultCallAdapter.java
@@ -45,7 +45,7 @@ final class DefaultCallAdapter implements CallAdapter<Call<?>> {
     return responseType;
   }
 
-  @Override public <R> Call<R> adapt(Call<R> call) {
+  @Override public <R> Call<R> adapt(Call<R> call, Retrofit retrofit) {
     return call;
   }
 }

--- a/retrofit/src/main/java/retrofit/ExecutorCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit/ExecutorCallAdapterFactory.java
@@ -38,7 +38,7 @@ final class ExecutorCallAdapterFactory implements CallAdapter.Factory {
         return responseType;
       }
 
-      @Override public <R> Call<R> adapt(Call<R> call) {
+      @Override public <R> Call<R> adapt(Call<R> call, Retrofit retrofit) {
         return new ExecutorCallbackCall<>(callbackExecutor, call);
       }
     };

--- a/retrofit/src/main/java/retrofit/MethodHandler.java
+++ b/retrofit/src/main/java/retrofit/MethodHandler.java
@@ -72,6 +72,7 @@ final class MethodHandler<T> {
   }
 
   Object invoke(Object... args) {
-    return callAdapter.adapt(new OkHttpCall<>(retrofit, requestFactory, responseConverter, args));
+    return callAdapter.adapt(new OkHttpCall<>(retrofit, requestFactory, responseConverter, args),
+      retrofit);
   }
 }

--- a/retrofit/src/test/java/retrofit/ExecutorCallAdapterFactoryTest.java
+++ b/retrofit/src/test/java/retrofit/ExecutorCallAdapterFactoryTest.java
@@ -87,7 +87,7 @@ public final class ExecutorCallAdapterFactoryTest {
       @Override public Response<String> execute() throws IOException {
         return response;
       }
-    });
+    }, retrofit);
     assertThat(call.execute()).isSameAs(response);
   }
 
@@ -100,7 +100,7 @@ public final class ExecutorCallAdapterFactoryTest {
       @Override public void enqueue(Callback<String> callback) {
         callback.onResponse(response, retrofit);
       }
-    });
+    }, retrofit);
     call.enqueue(callback);
     verify(callbackExecutor).execute(any(Runnable.class));
     verify(callback).onResponse(response, retrofit);
@@ -115,7 +115,7 @@ public final class ExecutorCallAdapterFactoryTest {
       @Override public void enqueue(Callback<String> callback) {
         callback.onFailure(throwable);
       }
-    });
+    }, retrofit);
     call.enqueue(callback);
     verify(callbackExecutor).execute(any(Runnable.class));
     verifyNoMoreInteractions(callbackExecutor);
@@ -128,7 +128,7 @@ public final class ExecutorCallAdapterFactoryTest {
     CallAdapter<Call<?>> adapter =
         (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
     Call<String> delegate = mock(Call.class);
-    Call<String> call = (Call<String>) adapter.adapt(delegate);
+    Call<String> call = (Call<String>) adapter.adapt(delegate, retrofit);
     Call<String> cloned = call.clone();
     assertThat(cloned).isNotSameAs(call);
     verify(delegate).clone();
@@ -140,7 +140,7 @@ public final class ExecutorCallAdapterFactoryTest {
     CallAdapter<Call<?>> adapter =
         (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
     Call<String> delegate = mock(Call.class);
-    Call<String> call = (Call<String>) adapter.adapt(delegate);
+    Call<String> call = (Call<String>) adapter.adapt(delegate, retrofit);
     call.cancel();
     verify(delegate).cancel();
     verifyNoMoreInteractions(delegate);

--- a/retrofit/src/test/java/retrofit/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit/RetrofitTest.java
@@ -153,7 +153,7 @@ public final class RetrofitTest {
             return Utils.getSingleParameterUpperBound((ParameterizedType) returnType);
           }
 
-          @Override public <R> Call<R> adapt(Call<R> call) {
+          @Override public <R> Call<R> adapt(Call<R> call, Retrofit retrofit) {
             adapterCalled.set(true);
             return call;
           }
@@ -183,7 +183,7 @@ public final class RetrofitTest {
             return String.class;
           }
 
-          @Override public <R> String adapt(Call<R> call) {
+          @Override public <R> String adapt(Call<R> call, Retrofit retrofit) {
             return "Hi!";
           }
         };

--- a/samples/src/main/java/com/example/retrofit/CustomCallAdapter.java
+++ b/samples/src/main/java/com/example/retrofit/CustomCallAdapter.java
@@ -54,7 +54,7 @@ public final class CustomCallAdapter {
           return responseType;
         }
 
-        @Override public <R> ListenableFuture<R> adapt(Call<R> call) {
+        @Override public <R> ListenableFuture<R> adapt(Call<R> call, Retrofit retrofit) {
           CallFuture<R> future = new CallFuture<>(call);
           call.enqueue(future);
           return future;


### PR DESCRIPTION
`Callback.onResponse()` provides `Retrofit` now, so it makes sense that the call adapters would also need to provide it as well.

Two changes:

- Added `Retrofit` to `CallAdapter.adapt()` as a convenience (otherwise you have to pass `Retrofit` around quite a bit).
- Added `Retrofit` to `Result` so that the RxJava adapter can parse errors using `Retrofit`.