### PR TITLE
Fixes - Path encoding #1156

### DIFF
--- a/retrofit/src/main/java/retrofit/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilder.java
@@ -29,7 +29,7 @@ import okio.BufferedSink;
 final class RequestBuilder {
   private static final char[] HEX_DIGITS =
       { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
-  private static final String PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|/\\?#";
+  private static final String PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|\\?#";
 
   private final String method;
 
@@ -94,7 +94,7 @@ final class RequestBuilder {
       codePoint = input.codePointAt(i);
       if (codePoint < 0x20 || codePoint >= 0x7f
           || PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1
-          || (codePoint == '%' && !alreadyEncoded)) {
+          || ((codePoint == '%' || codePoint == '/') && !alreadyEncoded)) {
         // Slow path: the character at i requires encoding!
         Buffer out = new Buffer();
         out.writeUtf8(input, 0, i);
@@ -118,7 +118,7 @@ final class RequestBuilder {
       } else if (codePoint < 0x20
           || codePoint >= 0x7f
           || PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1
-          || (codePoint == '%' && !alreadyEncoded)) {
+          || ((codePoint == '%' || codePoint == '/') && !alreadyEncoded)) {
         // Percent encode this character.
         if (utf8Buffer == null) {
           utf8Buffer = new Buffer();

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -926,6 +926,17 @@ public final class RequestBuilderTest {
     assertThat(request.urlString()).isEqualTo("http://example2.com/foo/bar/");
     assertThat(request.body()).isNull();
   }
+  
+  @Test public void getWithEncodedRelativeUrl() {
+    class Example {
+	  @GET("{url}")
+	  Call<ResponseBody> method(@Path(value = "url", encoded = true) String url) {
+	    return null;
+	  }
+	}
+	Request request = buildRequest(Example.class, "2015-10-01/560d3447c28eb5853953101b/560d3448fca6b4191105633a.jpg");
+	assertThat(request.urlString()).isEqualTo("http://example.com/2015-10-01/560d3447c28eb5853953101b/560d3448fca6b4191105633a.jpg");
+  }
 
   @Test public void getWithUrlAbsolute() {
     class Example {

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -929,13 +929,13 @@ public final class RequestBuilderTest {
   
   @Test public void getWithEncodedRelativeUrl() {
     class Example {
-	  @GET("{url}")
-	  Call<ResponseBody> method(@Path(value = "url", encoded = true) String url) {
-	    return null;
-	  }
-	}
-	Request request = buildRequest(Example.class, "2015-10-01/560d3447c28eb5853953101b/560d3448fca6b4191105633a.jpg");
-	assertThat(request.urlString()).isEqualTo("http://example.com/2015-10-01/560d3447c28eb5853953101b/560d3448fca6b4191105633a.jpg");
+      @GET("{url}")
+      Call<ResponseBody> method(@Path(value = "url", encoded = true) String url) {
+        return null;
+      }
+    }
+    Request request = buildRequest(Example.class, "2015-10-01/560d3447c28eb5853953101b/560d3448fca6b4191105633a.jpg");
+    assertThat(request.urlString()).isEqualTo("http://example.com/2015-10-01/560d3447c28eb5853953101b/560d3448fca6b4191105633a.jpg");
   }
 
   @Test public void getWithUrlAbsolute() {


### PR DESCRIPTION
Hi all,

This commit should fix the issue #1156 - Path encoding.

Earlier, the alreadyEncoded flag was ignored while encoding the / character in the canonicalize method of RequestBuilder.java. I've now explicitly handled encoding for this particular character to resolve the issue.

I've also created a JUnit test to verify the fix. You can find the test under RequestBuilderTest.java with the name getWithEncodedRelativeUrl.

Please review and pull.

Thank you.