### PR TITLE
Introduce @PartFile for including TypedFile parts in a multi-part request

### DIFF
--- a/retrofit/src/main/java/retrofit2/RequestAction.java
+++ b/retrofit/src/main/java/retrofit2/RequestAction.java
@@ -229,6 +229,26 @@ abstract class RequestAction<T> {
     }
   }
 
+  static final class PartFile extends RequestAction {
+    private final String partName;
+
+    PartFile(String partName) {
+      this.partName = partName;
+    }
+
+    @Override void perform(RequestBuilder builder, Object value) {
+      if (value == null) return; // Skip null values.
+
+      TypedFile typedFile = (TypedFile) value;
+      Headers headers = Headers.of(
+              "Content-Disposition", "form-data; name=\"" + partName + "\"; filename=\""
+                      + typedFile.fileName() + "\"",
+              "Content-Transfer-Encoding", "binary");
+      RequestBody body = RequestBody.create(typedFile.mediaType(), typedFile.file());
+      builder.addPart(headers, body);
+    }
+  }
+
   static final class Body<T> extends RequestAction<T> {
     private final Converter<T, RequestBody> converter;
 

--- a/retrofit/src/main/java/retrofit2/RequestFactoryParser.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactoryParser.java
@@ -42,6 +42,7 @@ import retrofit2.http.PATCH;
 import retrofit2.http.POST;
 import retrofit2.http.PUT;
 import retrofit2.http.Part;
+import retrofit2.http.PartFile;
 import retrofit2.http.PartMap;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
@@ -454,6 +455,18 @@ final class RequestFactoryParser {
 
             PartMap partMap = (PartMap) methodParameterAnnotation;
             action = new RequestAction.PartMap<>(valueConverter, partMap.encoding());
+            gotPart = true;
+
+          } else if (methodParameterAnnotation instanceof PartFile) {
+            if (!isMultipart) {
+              throw parameterError(i,
+                  "@PartFile parameters can only be used with multipart encoding.");
+            }
+            if (methodParameterType != TypedFile.class) {
+              throw parameterError(i, "@PartFile parameter type must be TypedFile.");
+            }
+            PartFile partFile = (PartFile) methodParameterAnnotation;
+            action = new RequestAction.PartFile(partFile.value());
             gotPart = true;
 
           } else if (methodParameterAnnotation instanceof Body) {

--- a/retrofit/src/main/java/retrofit2/TypedFile.java
+++ b/retrofit/src/main/java/retrofit2/TypedFile.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2;
+
+import com.squareup.okhttp.MediaType;
+import java.io.File;
+
+import static retrofit2.Utils.checkNotNull;
+
+/**
+ * Wrapper for a File, its MediaType, and optionally alternative filename.
+ */
+public final class TypedFile {
+  private final MediaType mediaType;
+  private final File file;
+  private final String fileName;
+
+  public TypedFile(MediaType mediaType, File file) {
+    this(mediaType, file, file != null ? file.getName() : null);
+  }
+
+  public TypedFile(MediaType mediaType, File file, String fileName) {
+    this.mediaType = checkNotNull(mediaType, "MediaType cannot be null.");
+    this.file = checkNotNull(file, "File cannot be null.");
+    this.fileName = checkNotNull(fileName, "Filename cannot be null.");
+  }
+
+  public MediaType mediaType() {
+    return mediaType;
+  }
+
+  public File file() {
+    return file;
+  }
+
+  public String fileName() {
+    return fileName;
+  }
+
+  @Override public String toString() {
+    return file.getAbsolutePath() + " (" + mediaType() + ")";
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o instanceof TypedFile) {
+      TypedFile rhs = (TypedFile) o;
+      return file.equals(rhs.file);
+    }
+    return false;
+  }
+
+  @Override public int hashCode() {
+    return file.hashCode();
+  }
+}

--- a/retrofit/src/main/java/retrofit2/http/PartFile.java
+++ b/retrofit/src/main/java/retrofit2/http/PartFile.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.http;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Denotes a single {@link retrofit.TypedFile} part of a multi-part request.
+ * <p>
+ * Values may be {@code null} which will omit them from the request body.
+ * <p>
+ * The {@code Content-Transfer-Encoding} will be {@code binary} and the {@code filename} parameter
+ * value will be read from the {@code File} field by default. If you need finer control, consider
+ * using {@link PartMap} instead.
+ * <p>
+ * <pre>
+ * &#64;Multipart
+ * &#64;POST("/")
+ * Call&lt;ResponseBody&gt; upload(
+ *     &#64;PartFile("image") TypedFile imageFile);
+ * </pre>
+ * <p>
+ * PartFile parameters may not be {@code null}.
+ *
+ * @see Multipart
+ * @see PartMap
+ */
+@Documented
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface PartFile {
+  String value();
+}


### PR DESCRIPTION
Since the removal of `TypedFile` in Retrofit 2.x, it has been somewhat of a challenge trying to figure out how to include a `File` part in a multi-part request. @JakeWharton has recommended using `RequestBody` but it doesn't include the `filename` property when created using a `File`, which some backends require. See #1140 for more information and discussion.

I've personally been using `@PartMap`, similar to @ayon115's [comment](https://github.com/square/retrofit/issues/1063#issuecomment-145920568) in #1063, but @BugsBunnyBR suggested a `@PartFile` annotation which sounded like a nice convenience. I took a stab at it here.

It [may need some help](http://www.quickmeme.com/img/d6/d6a1143f571184db25f94613edd43b40af6d3a629221aba00d9efdcfef5efd84.jpg).

Example usage (added 2015-12-01):

```java
public interface SomeService {
    @Multipart
    @POST("images/new")
    Call<UploadResponse> upload(@PartFile("image") TypedFile myImage);
}

// ... (build your service, etc.)

File file = getSomeFile("picture.png");
TypedFile image = new TypedFile("image/png", file);
Call<UploadResponse> response = someService.upload(image);
```

Resulting request headers:

```
Content-Disposition: form-data; name="image"; filename="picture.png"
Content-Type: image/png
Content-Transfer-Encoding: binary
```

Note: the `filename` value defaults to the result of `File#getName()` but you can override it when creating the `TypedFile` if desired:

```java
TypedFile foo = new TypedFile("image/png", file, "customFilename.png")
```