### PR TITLE
Moar useful info for exceptions!

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit/HttpException.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/HttpException.java
@@ -6,8 +6,8 @@ public final class HttpException extends Exception {
   private final String message;
   private final transient Response<?> response;
 
-  public HttpException(Response<?> response) {
-    super("HTTP " + response.code() + " " + response.message());
+  public HttpException(Response<?> response, String callDescription) {
+    super("HTTP " + response.code() + " " + response.message() + ", " + callDescription);
     this.code = response.code();
     this.message = response.message();
     this.response = response;

--- a/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
@@ -149,14 +149,14 @@ public final class RxJavaCallAdapterFactory implements CallAdapter.Factory {
       return responseType;
     }
 
-    @Override public <R> Observable<R> adapt(Call<R> call) {
+    @Override public <R> Observable<R> adapt(final Call<R> call) {
       return Observable.create(new CallOnSubscribe<>(call)) //
           .flatMap(new Func1<Response<R>, Observable<R>>() {
             @Override public Observable<R> call(Response<R> response) {
               if (response.isSuccess()) {
                 return Observable.just(response.body());
               }
-              return Observable.error(new HttpException(response));
+              return Observable.error(new HttpException(response, call.toString()));
             }
           });
     }

--- a/retrofit-adapters/rxjava/src/test/java/retrofit/RxJavaCallAdapterFactoryTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit/RxJavaCallAdapterFactoryTest.java
@@ -80,7 +80,7 @@ public final class RxJavaCallAdapterFactoryTest {
       fail();
     } catch (RuntimeException e) {
       Throwable cause = e.getCause();
-      assertThat(cause).isInstanceOf(HttpException.class).hasMessage("HTTP 404 OK");
+      assertThat(cause).isInstanceOf(HttpException.class).hasMessage("HTTP 404 OK, Service.observableBody(), HTTP method = GET, relative path template = /");
     }
   }
 

--- a/retrofit-converters/protobuf/src/test/java/retrofit/ProtoConverterFactoryTest.java
+++ b/retrofit-converters/protobuf/src/test/java/retrofit/ProtoConverterFactoryTest.java
@@ -120,7 +120,9 @@ public final class ProtoConverterFactoryTest {
       call.execute();
       fail();
     } catch (RuntimeException e) {
-      assertThat(e.getCause()).isInstanceOf(InvalidProtocolBufferException.class)
+      assertThat(e).isExactlyInstanceOf(RuntimeException.class)
+          .hasMessage("Problem has occurred during conversion of response for Service.get(), HTTP method = GET, relative path template = /");
+      assertThat(e.getCause().getCause()).isInstanceOf(InvalidProtocolBufferException.class)
           .hasMessageContaining("input ended unexpectedly");
     }
   }

--- a/retrofit-converters/simplexml/src/test/java/retrofit/SimpleXmlConverterFactoryTest.java
+++ b/retrofit-converters/simplexml/src/test/java/retrofit/SimpleXmlConverterFactoryTest.java
@@ -79,7 +79,9 @@ public class SimpleXmlConverterFactoryTest {
       call.execute();
       fail();
     } catch (RuntimeException e) {
-      assertThat(e.getCause()).isInstanceOf(ElementException.class)
+      assertThat(e).isExactlyInstanceOf(RuntimeException.class)
+          .hasMessage("Problem has occurred during conversion of response for Service.get(), HTTP method = GET, relative path template = /");
+      assertThat(e.getCause().getCause()).isInstanceOf(ElementException.class)
           .hasMessageStartingWith("Element 'foo' does not have a match in class retrofit.MyObject");
     }
   }
@@ -93,7 +95,9 @@ public class SimpleXmlConverterFactoryTest {
       call.execute();
       fail();
     } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Could not deserialize body as class java.lang.String");
+      assertThat(e).isExactlyInstanceOf(RuntimeException.class)
+          .hasMessage("Problem has occurred during conversion of response for Service.wrongClass(), HTTP method = GET, relative path template = /");
+      assertThat(e.getCause()).hasMessage("Could not deserialize body as class java.lang.String");
     }
   }
 }

--- a/retrofit/src/main/java/retrofit/Call.java
+++ b/retrofit/src/main/java/retrofit/Call.java
@@ -27,6 +27,9 @@ import java.io.IOException;
  * #enqueue}. In either case the call can be canceled at any time with {@link #cancel}. A call that
  * is busy writing its request or reading its response may receive a {@link IOException}; this is
  * working as designed.
+ *
+ * <p>Implementation of {@code toString()} for this interface should never include sensitive data
+ * such as query params, headers and so on.
  */
 public interface Call<T> extends Cloneable {
   Response<T> execute() throws IOException;

--- a/retrofit/src/main/java/retrofit/ExecutorCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit/ExecutorCallAdapterFactory.java
@@ -69,6 +69,11 @@ final class ExecutorCallAdapterFactory implements CallAdapter.Factory {
     @Override public Call<T> clone() {
       return new ExecutorCallbackCall<>(callbackExecutor, delegate.clone());
     }
+
+    @Override
+    public String toString() {
+      return delegate.toString();
+    }
   }
 
   static final class ExecutorCallback<T> implements Callback<T> {

--- a/retrofit/src/main/java/retrofit/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit/OkHttpCall.java
@@ -51,7 +51,7 @@ final class OkHttpCall<T> implements Call<T> {
 
   @Override public void enqueue(final Callback<T> callback) {
     synchronized (this) {
-      if (executed) throw new IllegalStateException("Already executed");
+      if (executed) throw new IllegalStateException("Already executed, " + toString());
       executed = true;
     }
 
@@ -59,7 +59,7 @@ final class OkHttpCall<T> implements Call<T> {
     try {
       rawCall = createRawCall();
     } catch (Throwable t) {
-      callback.onFailure(t);
+      callback.onFailure(new RuntimeException("Can not create call for " + toString(), t));
       return;
     }
     if (canceled) {
@@ -103,7 +103,7 @@ final class OkHttpCall<T> implements Call<T> {
 
   public Response<T> execute() throws IOException {
     synchronized (this) {
-      if (executed) throw new IllegalStateException("Already executed");
+      if (executed) throw new IllegalStateException("Already executed, " + toString());
       executed = true;
     }
 
@@ -151,7 +151,8 @@ final class OkHttpCall<T> implements Call<T> {
       // If the underlying source threw an exception, propagate that rather than indicating it was
       // a runtime exception.
       catchingBody.throwIfCaught();
-      throw e;
+      throw new RuntimeException("Problem has occurred during conversion of response for "
+          + toString(), e);
     }
   }
 
@@ -161,6 +162,12 @@ final class OkHttpCall<T> implements Call<T> {
     if (rawCall != null) {
       rawCall.cancel();
     }
+  }
+
+  @Override
+  public String toString() {
+    // Should never include sensitive data such as query params, headers and so on.
+    return requestFactory.toString();
   }
 
   static final class NoContentResponseBody extends ResponseBody {

--- a/retrofit/src/main/java/retrofit/RequestFactoryParser.java
+++ b/retrofit/src/main/java/retrofit/RequestFactoryParser.java
@@ -79,8 +79,8 @@ final class RequestFactoryParser {
   }
 
   private RequestFactory toRequestFactory(BaseUrl baseUrl) {
-    return new RequestFactory(httpMethod, baseUrl, relativeUrl, headers, contentType, hasBody,
-        isFormEncoded, isMultipart, requestBuilderActions);
+    return new RequestFactory(method, httpMethod, baseUrl, relativeUrl, headers, contentType,
+        hasBody, isFormEncoded, isMultipart, requestBuilderActions);
   }
 
   private RuntimeException parameterError(Throwable cause, int index, String message,

--- a/retrofit/src/test/java/retrofit/CallTest.java
+++ b/retrofit/src/test/java/retrofit/CallTest.java
@@ -245,8 +245,11 @@ public final class CallTest {
     });
     assertTrue(latch.await(2, SECONDS));
 
-    assertThat(failureRef.get()).isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("I am broken!");
+    Throwable failure = failureRef.get();
+
+    assertThat(failure).hasMessage("Can not create call for Service.postString(String), HTTP method = POST, relative path template = /");
+    assertThat(failure.getCause()).hasMessage("I am broken!")
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test public void conversionProblemIncomingSync() throws IOException {
@@ -271,8 +274,10 @@ public final class CallTest {
     try {
       call.execute();
       fail();
-    } catch (UnsupportedOperationException e) {
-      assertThat(e).hasMessage("I am broken!");
+    } catch (RuntimeException e) {
+      assertThat(e).hasMessage("Problem has occurred during conversion of response for Service.postString(String), HTTP method = POST, relative path template = /");
+      assertThat(e.getCause()).hasMessage("I am broken!")
+          .isInstanceOf(UnsupportedOperationException.class);
     }
   }
 
@@ -357,8 +362,11 @@ public final class CallTest {
     });
     assertTrue(latch.await(2, SECONDS));
 
-    assertThat(failureRef.get()).isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("I am broken!");
+    Throwable failure = failureRef.get();
+
+    assertThat(failure).hasMessage("Problem has occurred during conversion of response for Service.postString(String), HTTP method = POST, relative path template = /");
+    assertThat(failure.getCause()).hasMessage("I am broken!")
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test public void http204SkipsConverter() throws IOException {

--- a/retrofit/src/test/java/retrofit/RequestFactoryTest.java
+++ b/retrofit/src/test/java/retrofit/RequestFactoryTest.java
@@ -1,0 +1,41 @@
+package retrofit;
+
+import org.junit.Test;
+import retrofit.http.DELETE;
+import retrofit.http.GET;
+import retrofit.http.POST;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class RequestFactoryTest {
+
+  private interface Service {
+    void callWithoutParams();
+    void callWithOneParam(Integer number);
+    void callWithTwoParams(String param1, Object param2);
+  }
+
+  @Test public void toStringForMethodWithoutParams() throws NoSuchMethodException {
+    RequestFactory requestFactory = new RequestFactory(Service.class.getMethod("callWithoutParams"),
+        "GET", null, "/whereever1/", null, null, false, false, false, null);
+    assertThat(requestFactory.toString())
+    .isEqualTo("Service.callWithoutParams(), HTTP method = GET, relative path template = /whereever1/");
+  }
+
+  @Test public void toStringForMethodWithOneParam() throws NoSuchMethodException {
+    RequestFactory requestFactory = new RequestFactory(
+        Service.class.getMethod("callWithOneParam", Integer.class),
+        "POST", null, "/whereever2/", null, null, false, false, false, null);
+    assertThat(requestFactory.toString())
+        .isEqualTo("Service.callWithOneParam(Integer), HTTP method = POST, relative path template = /whereever2/");
+  }
+
+  @Test public void toStringForMethodWithTwoParams() throws NoSuchMethodException {
+    RequestFactory requestFactory = new RequestFactory(
+        Service.class.getMethod("callWithTwoParams", String.class, Object.class),
+        "DELETE", null, "/whereever3/", null, null, false, false, false, null);
+    assertThat(requestFactory.toString())
+        .isEqualTo("Service.callWithTwoParams(String,Object), HTTP method = DELETE, relative path template = /whereever3/");
+  }
+}


### PR DESCRIPTION
Closes #1162.

Now stacktraces make sense!

**Before:**
![screen shot 2015-10-03 at 23 22 48](https://cloud.githubusercontent.com/assets/967132/10264954/cf9ae624-6a25-11e5-95f2-566c2c662940.png)

**Now:**
<img width="1270" alt="screen shot 2015-10-12 at 06 07 22" src="https://cloud.githubusercontent.com/assets/967132/10420970/9e443ebc-70a7-11e5-8cfd-1f5302bf4380.png">

Though I don't like at least two things:
1. Name of the  `infoForException`
2. Need in wrapping exceptions into `RuntimeException` just to set message.
