### PR TITLE
add converter for fastjson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <wire.version>1.7.0</wire.version>
     <simplexml.version>2.7.1</simplexml.version>
     <moshi.version>1.0.0</moshi.version>
+    <fastjson.version>1.1.45.android</fastjson.version>
 
     <!-- Test Dependencies -->
     <junit.version>4.12</junit.version>
@@ -147,6 +148,11 @@
         <groupId>com.squareup.moshi</groupId>
         <artifactId>moshi</artifactId>
         <version>${moshi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.alibaba</groupId>
+        <artifactId>fastjson</artifactId>
+        <version>${fastjson.version}</version>
       </dependency>
 
       <dependency>

--- a/retrofit-converters/fastjson/pom.xml
+++ b/retrofit-converters/fastjson/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>retrofit-converters</artifactId>
+    <groupId>com.squareup.retrofit</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>converters-fastjson</artifactId>
+  <name>Converter: Fastjson</name>
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup.retrofit</groupId>
+      <artifactId>retrofit</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba</groupId>
+      <artifactId>fastjson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/retrofit-converters/fastjson/src/main/java/retrofit/FastjsonConverterFactory.java
+++ b/retrofit-converters/fastjson/src/main/java/retrofit/FastjsonConverterFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.ResponseBody;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * A {@linkplain Converter.Factory converter} which uses fastjson for JSON
+ */
+public class FastjsonConverterFactory extends Converter.Factory {
+
+  public static FastjsonConverterFactory create() {
+    return new FastjsonConverterFactory();
+  }
+
+  @Override
+  public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+    if (!(type instanceof Class)) {
+      return null;
+    }
+    return new FastjsonResponseConverter<>((Class<?>) type);
+  }
+
+  @Override
+  public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+    return new FastjsonRequestBodyConverter<>();
+  }
+}

--- a/retrofit-converters/fastjson/src/main/java/retrofit/FastjsonRequestBodyConverter.java
+++ b/retrofit-converters/fastjson/src/main/java/retrofit/FastjsonRequestBodyConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.alibaba.fastjson.JSON;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.RequestBody;
+
+import java.io.IOException;
+
+public class FastjsonRequestBodyConverter<T> implements Converter<T, RequestBody> {
+  private static final MediaType MEDIA_TYPE = MediaType.parse("application/json; charset=UTF-8");
+
+  @Override public RequestBody convert(T value) throws IOException {
+    byte[] bytes = JSON.toJSONBytes(value);
+    return RequestBody.create(MEDIA_TYPE, bytes);
+  }
+}

--- a/retrofit-converters/fastjson/src/main/java/retrofit/FastjsonResponseConverter.java
+++ b/retrofit-converters/fastjson/src/main/java/retrofit/FastjsonResponseConverter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.alibaba.fastjson.JSON;
+import com.squareup.okhttp.ResponseBody;
+
+import java.io.IOException;
+
+public class FastjsonResponseConverter<T> implements Converter<ResponseBody, T> {
+  Class<T> mClass;
+
+  FastjsonResponseConverter(Class<T> clz) {
+    mClass = clz;
+  }
+
+
+  @Override public T convert(ResponseBody value) throws IOException {
+    return JSON.parseObject(value.bytes(), mClass);
+  }
+}

--- a/retrofit-converters/fastjson/src/test/java/retrofit/FastjsonConverterFactoryTest.java
+++ b/retrofit-converters/fastjson/src/test/java/retrofit/FastjsonConverterFactoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import retrofit.http.Body;
+import retrofit.http.POST;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FastjsonConverterFactoryTest {
+
+  static class AnObject {
+    private String theName;
+
+    public String getTheName() {
+      return theName;
+    }
+
+    public void setTheName(String theName) {
+      this.theName = theName;
+    }
+  }
+
+  interface Service {
+    @POST("/") Call<AnObject> anObject(@Body AnObject impl);
+  }
+
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  private Service service;
+
+  @Before public void setUp() {
+    Retrofit retrofit = new Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .addConverterFactory(FastjsonConverterFactory.create())
+            .build();
+    service = retrofit.create(Service.class);
+  }
+
+  @Test public void anObject() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setBody("{\"theName\":\"value\"}"));
+    AnObject requestBodyObject = new AnObject();
+    requestBodyObject.setTheName("value");
+    Call<AnObject> call = service.anObject(requestBodyObject);
+    Response<AnObject> response = call.execute();
+    AnObject body = response.body();
+    assertThat(body.theName).isEqualTo("value");
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getBody().readUtf8()).isEqualTo("{\"theName\":\"value\"}");
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
+  }
+}

--- a/retrofit-converters/pom.xml
+++ b/retrofit-converters/pom.xml
@@ -21,5 +21,6 @@
     <module>wire</module>
     <module>simplexml</module>
     <module>moshi</module>
+    <module>fastjson</module>
   </modules>
 </project>


### PR DESCRIPTION
Retrofit has implemented some useful converters as listed on:
https://github.com/square/retrofit/tree/master/retrofit-converters

However the converter for [fastjson](https://github.com/alibaba/fastjson) is not implemented by default, personally I'v used [fastjson](https://github.com/alibaba/fastjson) to deal with json data somtimes. 

I'd like to contribute  the converter-fastjson implemention according to the [guidelines for contributing](https://github.com/square/retrofit/blob/master/CONTRIBUTING.md).

**Reference**
* [https://github.com/alibaba/fastjson](https://github.com/alibaba/fastjson)