### PR TITLE
RequestBuilderAction: pass exception from converter as cause of thrown n exception

### DIFF
--- a/retrofit/src/main/java/retrofit/RequestBuilderAction.java
+++ b/retrofit/src/main/java/retrofit/RequestBuilderAction.java
@@ -207,7 +207,7 @@ abstract class RequestBuilderAction {
         //noinspection unchecked
         body = converter.convert((T) value);
       } catch (IOException e) {
-        throw new RuntimeException("Unable to convert " + value + " to RequestBody");
+        throw new RuntimeException("Unable to convert " + value + " to RequestBody", e);
       }
       builder.addPart(headers, body);
     }
@@ -250,7 +250,7 @@ abstract class RequestBuilderAction {
         try {
           body = converter.convert(entryValue);
         } catch (IOException e) {
-          throw new RuntimeException("Unable to convert " + entryValue + " to RequestBody");
+          throw new RuntimeException("Unable to convert " + entryValue + " to RequestBody", e);
         }
         builder.addPart(headers, body);
       }
@@ -273,7 +273,7 @@ abstract class RequestBuilderAction {
         //noinspection unchecked
         body = converter.convert((T) value);
       } catch (IOException e) {
-        throw new RuntimeException("Unable to convert " + value + " to RequestBody");
+        throw new RuntimeException("Unable to convert " + value + " to RequestBody", e);
       }
       builder.setBody(body);
     }


### PR DESCRIPTION
Closes #1251.

I've checked all `catch`es in the Retrofit for the same pattern of not passing real cause to the thrown exception — found only `RequestBuilderAction`. 

@JakeWharton, I also wanted to add tests for  `RequestBuilderAction` but when I started I've found that `RequestBuilder` is not mockable and it requires a lot of parameters for the constructor, and since it's final it's not possible (easily) to verify invocations on it. So, no tests from me today :(