### PR TITLE
Make Retrofit ready for usage in OSGi

### DIFF
--- a/retrofit-converters/gson/src/main/java/retrofit/GsonResponseBodyConverter.java
+++ b/retrofit-converters/gson/src/main/java/retrofit/GsonResponseBodyConverter.java
@@ -32,7 +32,12 @@ final class GsonResponseBodyConverter<T> implements Converter<ResponseBody, T> {
     try {
       return adapter.fromJson(reader);
     } finally {
-      Utils.closeQuietly(reader);
+      if (reader != null) {
+        try {
+          reader.close();
+        } catch (IOException ignored) {
+        }
+      }
     }
   }
 }

--- a/retrofit-converters/jackson/src/main/java/retrofit/JacksonResponseBodyConverter.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit/JacksonResponseBodyConverter.java
@@ -32,7 +32,12 @@ final class JacksonResponseBodyConverter<T> implements Converter<ResponseBody, T
     try {
       return adapter.readValue(reader);
     } finally {
-      Utils.closeQuietly(reader);
+      if (reader != null) {
+        try {
+          reader.close();
+        } catch (IOException ignored) {
+        }
+      }
     }
   }
 }

--- a/retrofit-converters/moshi/src/main/java/retrofit/MoshiResponseBodyConverter.java
+++ b/retrofit-converters/moshi/src/main/java/retrofit/MoshiResponseBodyConverter.java
@@ -32,7 +32,12 @@ final class MoshiResponseBodyConverter<T> implements Converter<ResponseBody, T> 
     try {
       return adapter.fromJson(source);
     } finally {
-      Utils.closeQuietly(source);
+      if (source != null) {
+        try {
+          source.close();
+        } catch (IOException ignored) {
+        }
+      }
     }
   }
 }

--- a/retrofit-converters/protobuf/src/main/java/retrofit/ProtoResponseBodyConverter.java
+++ b/retrofit-converters/protobuf/src/main/java/retrofit/ProtoResponseBodyConverter.java
@@ -37,7 +37,12 @@ final class ProtoResponseBodyConverter<T extends MessageLite>
     } catch (InvalidProtocolBufferException e) {
       throw new RuntimeException(e); // Despite extending IOException, this is data mismatch.
     } finally {
-      Utils.closeQuietly(is);
+      if (is != null) {
+        try {
+          is.close();
+        } catch (IOException ignored) {
+        }
+      }
     }
   }
 }

--- a/retrofit-converters/wire/src/main/java/retrofit/WireResponseBodyConverter.java
+++ b/retrofit-converters/wire/src/main/java/retrofit/WireResponseBodyConverter.java
@@ -30,11 +30,17 @@ final class WireResponseBodyConverter<T extends Message<T, ?>>
   }
 
   @Override public T convert(ResponseBody value) throws IOException {
+    BufferedSource source = null;
     try {
-      BufferedSource source = value.source();
+      source = value.source();
       return adapter.decode(source);
     } finally {
-      Utils.closeQuietly(value);
+      if (source != null) {
+        try {
+          source.close();
+        } catch (IOException ignored) {
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Hello I just created a project, which is supposed to make use of Retrofit in an Eclipse RCP Application.

I did this by converting retrofit and it's dependencies to OSGi artifacts. See https://github.com/SimonScholz/retrofit-osgi

Due to different classloaders for every jar artifact in an OSGi runtime the split packages between retrofit and it's converter projects cause problems in OSGi.
The package private retrofit.Utils class cannot be used properly by the converter classes in an OSGi environment right now. Therefore this patch makes the  closeQuietly method and the Utils class iself public.

In case you apply this patch I can make proper use of the converted OSGi bundles of Retrofit, so the Eclipse community can also make use of Retrofit libraries, which would be awesome.

I also just signed the CLA.

![retrofit eclipse 4 sample application _103](https://cloud.githubusercontent.com/assets/7559962/11023612/75250c22-867e-11e5-8bc0-0dda1682d740.png)
