### PR TITLE
Added a checkstyle rule for the line indentation

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -119,5 +119,8 @@
         <!--module name="FinalParameters"/-->
         <!--module name="TodoComment"/-->
         <module name="UpperEll"/>
+        <module name="Indentation">
+          <property name="basicOffset" value="2"/>
+        </module>
     </module>
 </module>


### PR DESCRIPTION
In PR 1266 (https://github.com/square/retrofit/pull/1266) I used the wrong indentation for my contribution. In order to avoid such issues I just added the Indentation module as checkstyle rule.