### PR TITLE
Fix for when no 'Content-Length' header is returned on 204 response

### DIFF
--- a/retrofit/src/main/java/retrofit/client/OkClient.java
+++ b/retrofit/src/main/java/retrofit/client/OkClient.java
@@ -95,7 +95,7 @@ public class OkClient implements Client {
   }
 
   private static TypedInput createResponseBody(final ResponseBody body) {
-    if (body.contentLength() == 0) {
+    if (body.contentLength() <= 0) {
       return null;
     }
     return new TypedInput() {


### PR DESCRIPTION
According to http://tools.ietf.org/html/rfc7230#section-3.3.2 :

> A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).

However, having the server return a 204 response with no 'Content-Length' header yields in a retrofit conversion error, even if 'Void' type is being used as the expected body type.