### PR TITLE
Add string converter support for all non-body annotation types.

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
@@ -62,14 +62,14 @@ public final class RxJavaCallAdapterFactory implements CallAdapter.Factory {
   }
 
   private CallAdapter<Observable<?>> getCallAdapter(Type returnType) {
-    Type observableType = Utils.getSingleParameterUpperBound((ParameterizedType) returnType);
+    Type observableType = Utils.getParameterUpperBound(0, (ParameterizedType) returnType);
     Class<?> rawObservableType = Utils.getRawType(observableType);
     if (rawObservableType == Response.class) {
       if (!(observableType instanceof ParameterizedType)) {
         throw new IllegalStateException("Response must be parameterized"
             + " as Response<Foo> or Response<? extends Foo>");
       }
-      Type responseType = Utils.getSingleParameterUpperBound((ParameterizedType) observableType);
+      Type responseType = Utils.getParameterUpperBound(0, (ParameterizedType) observableType);
       return new ResponseCallAdapter(responseType);
     }
 
@@ -78,7 +78,7 @@ public final class RxJavaCallAdapterFactory implements CallAdapter.Factory {
         throw new IllegalStateException("Result must be parameterized"
             + " as Result<Foo> or Result<? extends Foo>");
       }
-      Type responseType = Utils.getSingleParameterUpperBound((ParameterizedType) observableType);
+      Type responseType = Utils.getParameterUpperBound(0, (ParameterizedType) observableType);
       return new ResultCallAdapter(responseType);
     }
 

--- a/retrofit-adapters/rxjava/src/test/java/retrofit/RxJavaCallAdapterFactoryTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit/RxJavaCallAdapterFactoryTest.java
@@ -245,7 +245,7 @@ public final class RxJavaCallAdapterFactoryTest {
 
   static class StringConverterFactory extends Converter.Factory {
     @Override
-    public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+    public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
       return new Converter<ResponseBody, String>() {
         @Override public String convert(ResponseBody value) throws IOException {
           return value.string();
@@ -253,7 +253,7 @@ public final class RxJavaCallAdapterFactoryTest {
       };
     }
 
-    @Override public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+    @Override public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
       return new Converter<String, RequestBody>() {
         @Override public RequestBody convert(String value) throws IOException {
           return RequestBody.create(MediaType.parse("text/plain"), value);

--- a/retrofit-converters/gson/src/main/java/retrofit/GsonConverterFactory.java
+++ b/retrofit-converters/gson/src/main/java/retrofit/GsonConverterFactory.java
@@ -56,12 +56,13 @@ public final class GsonConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+  public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
     TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
     return new GsonResponseBodyConverter<>(adapter);
   }
 
-  @Override public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+  @Override
+  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
     TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
     return new GsonRequestBodyConverter<>(gson, adapter);
   }

--- a/retrofit-converters/jackson/src/main/java/retrofit/JacksonConverterFactory.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit/JacksonConverterFactory.java
@@ -51,13 +51,14 @@ public final class JacksonConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+  public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
     JavaType javaType = mapper.getTypeFactory().constructType(type);
     ObjectReader reader = mapper.reader(javaType);
     return new JacksonResponseBodyConverter<>(reader);
   }
 
-  @Override public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+  @Override
+  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
     JavaType javaType = mapper.getTypeFactory().constructType(type);
     ObjectWriter writer = mapper.writerWithType(javaType);
     return new JacksonRequestBodyConverter<>(writer);

--- a/retrofit-converters/moshi/src/main/java/retrofit/MoshiConverterFactory.java
+++ b/retrofit-converters/moshi/src/main/java/retrofit/MoshiConverterFactory.java
@@ -49,12 +49,13 @@ public final class MoshiConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+  public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
     JsonAdapter<?> adapter = moshi.adapter(type);
     return new MoshiResponseBodyConverter<>(adapter);
   }
 
-  @Override public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+  @Override
+  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
     JsonAdapter<?> adapter = moshi.adapter(type);
     return new MoshiRequestBodyConverter<>(adapter);
   }

--- a/retrofit-converters/protobuf/src/main/java/retrofit/ProtoConverterFactory.java
+++ b/retrofit-converters/protobuf/src/main/java/retrofit/ProtoConverterFactory.java
@@ -35,7 +35,7 @@ public final class ProtoConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+  public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
     if (!(type instanceof Class<?>)) {
       return null;
     }
@@ -56,7 +56,8 @@ public final class ProtoConverterFactory extends Converter.Factory {
     return new ProtoResponseBodyConverter<>(parser);
   }
 
-  @Override public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+  @Override
+  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
     if (!(type instanceof Class<?>)) {
       return null;
     }

--- a/retrofit-converters/simplexml/src/main/java/retrofit/SimpleXmlConverterFactory.java
+++ b/retrofit-converters/simplexml/src/main/java/retrofit/SimpleXmlConverterFactory.java
@@ -63,7 +63,7 @@ public final class SimpleXmlConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+  public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
     if (!(type instanceof Class)) {
       return null;
     }
@@ -71,7 +71,8 @@ public final class SimpleXmlConverterFactory extends Converter.Factory {
     return new SimpleXmlResponseBodyConverter<>(cls, serializer, strict);
   }
 
-  @Override public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+  @Override
+  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
     if (!(type instanceof Class)) {
       return null;
     }

--- a/retrofit-converters/wire/src/main/java/retrofit/WireConverterFactory.java
+++ b/retrofit-converters/wire/src/main/java/retrofit/WireConverterFactory.java
@@ -36,7 +36,7 @@ public final class WireConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+  public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
     if (!(type instanceof Class<?>)) {
       return null;
     }
@@ -49,7 +49,8 @@ public final class WireConverterFactory extends Converter.Factory {
     return new WireResponseBodyConverter<>(adapter);
   }
 
-  @Override public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+  @Override
+  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
     if (!(type instanceof Class<?>)) {
       return null;
     }

--- a/retrofit/src/main/java/retrofit/Converter.java
+++ b/retrofit/src/main/java/retrofit/Converter.java
@@ -20,6 +20,15 @@ import com.squareup.okhttp.ResponseBody;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import retrofit.http.Body;
+import retrofit.http.Field;
+import retrofit.http.FieldMap;
+import retrofit.http.Header;
+import retrofit.http.Part;
+import retrofit.http.PartMap;
+import retrofit.http.Path;
+import retrofit.http.Query;
+import retrofit.http.QueryMap;
 
 /**
  * Convert objects to and from their representation in HTTP. Register a converter with Retrofit
@@ -32,17 +41,32 @@ public interface Converter<F, T> {
   abstract class Factory {
     /**
      * Returns a {@link Converter} for converting an HTTP response body to {@code type}, or null if
-     * {@code type} cannot be handled by this factory.
+     * {@code type} cannot be handled by this factory. This is used to create converters for
+     * response types such as {@code SimpleResponse} from a {@code Call<SimpleResponse>}
+     * declaration.
      */
-    public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+    public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
       return null;
     }
 
     /**
      * Returns a {@link Converter} for converting {@code type} to an HTTP request body, or null if
-     * {@code type} cannot be handled by this factory.
+     * {@code type} cannot be handled by this factory. This is used to create converters for types
+     * specified by {@link Body @Body}, {@link Part @Part}, and {@link PartMap @PartMap}
+     * values.
      */
-    public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+    public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
+      return null;
+    }
+
+    /**
+     * Returns a {@link Converter} for converting {@code type} to a {@link String}, or null if
+     * {@code type} cannot be handled by this factory. This is used to create converters for types
+     * specified by {@link Field @Field}, {@link FieldMap @FieldMap} values,
+     * {@link Header @Header}, {@link Path @Path}, {@link Query @Query}, and
+     * {@link QueryMap @QueryMap} values.
+     */
+    public Converter<?, String> stringConverter(Type type, Annotation[] annotations) {
       return null;
     }
   }

--- a/retrofit/src/main/java/retrofit/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit/OkHttpCall.java
@@ -117,7 +117,7 @@ final class OkHttpCall<T> implements Call<T> {
     return parseResponse(rawCall.execute());
   }
 
-  private com.squareup.okhttp.Call createRawCall() {
+  private com.squareup.okhttp.Call createRawCall() throws IOException {
     return client.newCall(requestFactory.create(args));
   }
 

--- a/retrofit/src/main/java/retrofit/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit/RequestFactory.java
@@ -18,6 +18,7 @@ package retrofit;
 import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.Request;
+import java.io.IOException;
 
 final class RequestFactory {
   private final String method;
@@ -44,7 +45,7 @@ final class RequestFactory {
     this.requestActions = requestActions;
   }
 
-  Request create(Object... args) {
+  Request create(Object... args) throws IOException {
     RequestBuilder requestBuilder =
         new RequestBuilder(method, baseUrl.url(), relativeUrl, headers, contentType, hasBody,
             isFormEncoded, isMultipart);

--- a/retrofit/src/main/java/retrofit/Retrofit.java
+++ b/retrofit/src/main/java/retrofit/Retrofit.java
@@ -171,6 +171,8 @@ public final class Retrofit {
   /**
    * Returns the {@link CallAdapter} for {@code returnType} from the available {@linkplain
    * #callAdapterFactories() factories}.
+   *
+   * @throws IllegalArgumentException if no call adapter available for {@code type}.
    */
   public CallAdapter<?> callAdapter(Type returnType, Annotation[] annotations) {
     return nextCallAdapter(null, returnType, annotations);
@@ -179,6 +181,8 @@ public final class Retrofit {
   /**
    * Returns the {@link CallAdapter} for {@code returnType} from the available {@linkplain
    * #callAdapterFactories() factories} except {@code skipPast}.
+   *
+   * @throws IllegalArgumentException if no call adapter available for {@code type}.
    */
   public CallAdapter<?> nextCallAdapter(CallAdapter.Factory skipPast, Type returnType,
       Annotation[] annotations) {
@@ -218,6 +222,8 @@ public final class Retrofit {
   /**
    * Returns a {@link Converter} for {@code type} to {@link RequestBody} from the available
    * {@linkplain #converterFactories() factories}.
+   *
+   * @throws IllegalArgumentException if no converter available for {@code type}.
    */
   public <T> Converter<T, RequestBody> requestConverter(Type type, Annotation[] annotations) {
     checkNotNull(type, "type == null");
@@ -225,7 +231,7 @@ public final class Retrofit {
 
     for (int i = 0, count = converterFactories.size(); i < count; i++) {
       Converter<?, RequestBody> converter =
-          converterFactories.get(i).toRequestBody(type, annotations);
+          converterFactories.get(i).requestBodyConverter(type, annotations);
       if (converter != null) {
         //noinspection unchecked
         return (Converter<T, RequestBody>) converter;
@@ -244,6 +250,8 @@ public final class Retrofit {
   /**
    * Returns a {@link Converter} for {@link ResponseBody} to {@code type} from the available
    * {@linkplain #converterFactories() factories}.
+   *
+   * @throws IllegalArgumentException if no converter available for {@code type}.
    */
   public <T> Converter<ResponseBody, T> responseConverter(Type type, Annotation[] annotations) {
     checkNotNull(type, "type == null");
@@ -251,7 +259,7 @@ public final class Retrofit {
 
     for (int i = 0, count = converterFactories.size(); i < count; i++) {
       Converter<ResponseBody, ?> converter =
-          converterFactories.get(i).fromResponseBody(type, annotations);
+          converterFactories.get(i).responseBodyConverter(type, annotations);
       if (converter != null) {
         //noinspection unchecked
         return (Converter<ResponseBody, T>) converter;
@@ -265,6 +273,28 @@ public final class Retrofit {
       builder.append("\n * ").append(converterFactory.getClass().getName());
     }
     throw new IllegalArgumentException(builder.toString());
+  }
+
+  /**
+   * Returns a {@link Converter} for {@code type} to {@link String} from the available
+   * {@linkplain #converterFactories() factories}.
+   */
+  public <T> Converter<T, String> stringConverter(Type type, Annotation[] annotations) {
+    checkNotNull(type, "type == null");
+    checkNotNull(annotations, "annotations == null");
+
+    for (int i = 0, count = converterFactories.size(); i < count; i++) {
+      Converter<?, String> converter =
+          converterFactories.get(i).stringConverter(type, annotations);
+      if (converter != null) {
+        //noinspection unchecked
+        return (Converter<T, String>) converter;
+      }
+    }
+
+    // Nothing matched. Resort to default converter which just calls toString().
+    //noinspection unchecked
+    return (Converter<T, String>) BuiltInConverters.ToStringConverter.INSTANCE;
   }
 
   public Executor callbackExecutor() {

--- a/retrofit/src/main/java/retrofit/Utils.java
+++ b/retrofit/src/main/java/retrofit/Utils.java
@@ -89,13 +89,13 @@ final class Utils {
     }
   }
 
-  public static Type getSingleParameterUpperBound(ParameterizedType type) {
+  public static Type getParameterUpperBound(int index, ParameterizedType type) {
     Type[] types = type.getActualTypeArguments();
-    if (types.length != 1) {
+    if (types.length <= index) {
       throw new IllegalArgumentException(
-          "Expected one type argument but got: " + Arrays.toString(types));
+          "Expected at least " + index + " type argument(s) but got: " + Arrays.toString(types));
     }
-    Type paramType = types[0];
+    Type paramType = types[index];
     if (paramType instanceof WildcardType) {
       return ((WildcardType) paramType).getUpperBounds()[0];
     }
@@ -185,7 +185,7 @@ final class Utils {
       throw new IllegalArgumentException(
           "Call return type must be parameterized as Call<Foo> or Call<? extends Foo>");
     }
-    final Type responseType = getSingleParameterUpperBound((ParameterizedType) returnType);
+    final Type responseType = getParameterUpperBound(0, (ParameterizedType) returnType);
 
     // Ensure the Call response type is not Response, we automatically deliver the Response object.
     if (getRawType(responseType) == retrofit.Response.class) {

--- a/retrofit/src/test/java/retrofit/CallTest.java
+++ b/retrofit/src/test/java/retrofit/CallTest.java
@@ -191,7 +191,7 @@ public final class CallTest {
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
           @Override
-          public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+          public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
             return new Converter<String, RequestBody>() {
               @Override public RequestBody convert(String value) throws IOException {
                 throw new UnsupportedOperationException("I am broken!");
@@ -216,7 +216,7 @@ public final class CallTest {
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
           @Override
-          public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+          public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
             return new Converter<String, RequestBody>() {
               @Override public RequestBody convert(String value) throws IOException {
                 throw new UnsupportedOperationException("I am broken!");
@@ -250,7 +250,7 @@ public final class CallTest {
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
           @Override
-          public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+          public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
             return new Converter<ResponseBody, String>() {
               @Override public String convert(ResponseBody value) throws IOException {
                 throw new UnsupportedOperationException("I am broken!");
@@ -294,7 +294,7 @@ public final class CallTest {
         .client(client)
         .addConverterFactory(new ToStringConverterFactory() {
           @Override
-          public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+          public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
             return new Converter<ResponseBody, String>() {
               @Override public String convert(ResponseBody value) throws IOException {
                 try {
@@ -326,7 +326,7 @@ public final class CallTest {
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
           @Override
-          public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+          public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
             return new Converter<ResponseBody, String>() {
               @Override public String convert(ResponseBody value) throws IOException {
                 throw new UnsupportedOperationException("I am broken!");
@@ -367,7 +367,7 @@ public final class CallTest {
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
           @Override
-          public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+          public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
             return converter;
           }
         })
@@ -392,7 +392,7 @@ public final class CallTest {
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
           @Override
-          public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+          public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
             return converter;
           }
         })

--- a/retrofit/src/test/java/retrofit/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit/RequestBuilderTest.java
@@ -1261,15 +1261,15 @@ public final class RequestBuilderTest {
     class Example {
       @Multipart //
       @POST("/foo/bar/") //
-      Call<ResponseBody> method(@PartMap Map<String, Object> parts) {
+      Call<ResponseBody> method(@PartMap Map<String, RequestBody> parts) {
         return null;
       }
     }
 
-    Map<String, Object> params = new LinkedHashMap<>();
-    params.put("ping", "pong");
+    Map<String, RequestBody> params = new LinkedHashMap<>();
+    params.put("ping", RequestBody.create(null, "pong"));
     params.put("foo", null); // Should be skipped.
-    params.put("kit", "kat");
+    params.put("kit", RequestBody.create(null, "kat"));
 
     Request request = buildRequest(Example.class, params);
     assertThat(request.method()).isEqualTo("POST");
@@ -1298,15 +1298,15 @@ public final class RequestBuilderTest {
     class Example {
       @Multipart //
       @POST("/foo/bar/") //
-      Call<ResponseBody> method(@PartMap(encoding = "8-bit") Map<String, Object> parts) {
+      Call<ResponseBody> method(@PartMap(encoding = "8-bit") Map<String, RequestBody> parts) {
         return null;
       }
     }
 
-    Map<String, Object> params = new LinkedHashMap<>();
-    params.put("ping", "pong");
+    Map<String, RequestBody> params = new LinkedHashMap<>();
+    params.put("ping", RequestBody.create(null, "pong"));
     params.put("foo", null); // Should be skipped.
-    params.put("kit", "kat");
+    params.put("kit", RequestBody.create(null, "kat"));
 
     Request request = buildRequest(Example.class, params);
     assertThat(request.method()).isEqualTo("POST");
@@ -1337,14 +1337,14 @@ public final class RequestBuilderTest {
     class Example {
       @Multipart //
       @POST("/foo/bar/") //
-      Call<ResponseBody> method(@PartMap Map<String, Object> parts) {
+      Call<ResponseBody> method(@PartMap Map<String, RequestBody> parts) {
         return null;
       }
     }
 
-    Map<String, Object> params = new LinkedHashMap<>();
-    params.put("ping", "pong");
-    params.put(null, "kat");
+    Map<String, RequestBody> params = new LinkedHashMap<>();
+    params.put("ping", RequestBody.create(null, "pong"));
+    params.put(null, RequestBody.create(null, "kat"));
 
     try {
       buildRequest(Example.class, params);

--- a/retrofit/src/test/java/retrofit/ToStringConverterFactory.java
+++ b/retrofit/src/test/java/retrofit/ToStringConverterFactory.java
@@ -26,7 +26,7 @@ class ToStringConverterFactory extends Converter.Factory {
   private static final MediaType MEDIA_TYPE = MediaType.parse("text/plain");
 
   @Override
-  public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+  public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations) {
     if (String.class.equals(type)) {
       return new Converter<ResponseBody, String>() {
         @Override public String convert(ResponseBody value) throws IOException {
@@ -37,7 +37,7 @@ class ToStringConverterFactory extends Converter.Factory {
     return null;
   }
 
-  @Override public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+  @Override public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
     if (String.class.equals(type)) {
       return new Converter<String, RequestBody>() {
         @Override public RequestBody convert(String value) throws IOException {


### PR DESCRIPTION
This also changes body-based annotation types to go through the request body converter at parsing time.

Closes #816.