### PR TITLE
为Call添加CacheControl参数,允许在请求的时候指定缓存策略.

### DIFF
--- a/retrofit/src/main/java/retrofit/Call.java
+++ b/retrofit/src/main/java/retrofit/Call.java
@@ -15,6 +15,8 @@
  */
 package retrofit;
 
+import com.squareup.okhttp.CacheControl;
+
 import java.io.IOException;
 
 /**
@@ -41,10 +43,24 @@ public interface Call<T> extends Cloneable {
   Response<T> execute() throws IOException;
 
   /**
+   * Synchronously send the request with custom {@link CacheControl} and return its response.
+   * @param cacheControl Cache policy specified for http requests.
+   * @return
+   * @throws IOException
+   */
+  Response<T> execute(CacheControl cacheControl) throws IOException;
+
+  /**
    * Asynchronously send the request and notify {@code callback} of its response or if an error
    * occurred talking to the server, creating the request, or processing the response.
    */
   void enqueue(Callback<T> callback);
+
+  /**
+   * Asynchronously send the request with custom {@link CacheControl} and notify {@code callback} of its response or if an error
+   * occurred talking to the server, creating the request, or processing the response.
+   */
+  void enqueue(Callback<T> callback,CacheControl cacheControl);
 
   /**
    * Returns true if this call has been either {@linkplain #execute() executed} or {@linkplain

--- a/retrofit/src/main/java/retrofit/ExecutorCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit/ExecutorCallAdapterFactory.java
@@ -15,6 +15,8 @@
  */
 package retrofit;
 
+import com.squareup.okhttp.CacheControl;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -54,6 +56,11 @@ final class ExecutorCallAdapterFactory implements CallAdapter.Factory {
     }
 
     @Override public void enqueue(final Callback<T> callback) {
+      enqueue(callback,null);
+    }
+
+    @Override
+    public void enqueue(final Callback<T> callback, CacheControl cacheControl) {
       delegate.enqueue(new Callback<T>() {
         @Override public void onResponse(final Response<T> response) {
           callbackExecutor.execute(new Runnable() {
@@ -75,7 +82,7 @@ final class ExecutorCallAdapterFactory implements CallAdapter.Factory {
             }
           });
         }
-      });
+      },cacheControl);
     }
 
     @Override public boolean isExecuted() {
@@ -83,7 +90,12 @@ final class ExecutorCallAdapterFactory implements CallAdapter.Factory {
     }
 
     @Override public Response<T> execute() throws IOException {
-      return delegate.execute();
+      return delegate.execute(null);
+    }
+
+    @Override
+    public Response<T> execute(CacheControl cacheControl) throws IOException {
+      return delegate.execute(cacheControl);
     }
 
     @Override public void cancel() {

--- a/retrofit/src/main/java/retrofit/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit/RequestFactory.java
@@ -15,9 +15,11 @@
  */
 package retrofit;
 
+import com.squareup.okhttp.CacheControl;
 import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.Request;
+
 import java.io.IOException;
 
 final class RequestFactory {
@@ -45,9 +47,16 @@ final class RequestFactory {
     this.requestActions = requestActions;
   }
 
-  Request create(Object... args) throws IOException {
+  Request create(CacheControl cacheControl,Object... args) throws IOException {
+    Headers requestHeader = headers;
+    if (cacheControl != null) {
+      String value = cacheControl.toString();
+      if (!value.isEmpty()) {
+        requestHeader = headers.newBuilder().set("Cache-Control", value).build();
+      }
+    }
     RequestBuilder requestBuilder =
-        new RequestBuilder(method, baseUrl.url(), relativeUrl, headers, contentType, hasBody,
+        new RequestBuilder(method, baseUrl.url(), relativeUrl, requestHeader, contentType, hasBody,
             isFormEncoded, isMultipart);
 
     if (args != null) {


### PR DESCRIPTION
In some scenarios we need to refresh the data, such as Android's ListView, it should provide an entry for the operation