### PR TITLE
[resolves #1192] Fixes the type passed to Jackson writer

### DIFF
--- a/retrofit-converters/jackson/src/main/java/retrofit2/JacksonConverterFactory.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/JacksonConverterFactory.java
@@ -61,8 +61,7 @@ public final class JacksonConverterFactory extends Converter.Factory {
   @Override
   public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
       Retrofit retrofit) {
-    JavaType javaType = mapper.getTypeFactory().constructType(type);
-    ObjectWriter writer = mapper.writerWithType(javaType);
+    ObjectWriter writer = mapper.writer();
     return new JacksonRequestBodyConverter<>(writer);
   }
 }


### PR DESCRIPTION
Addresses the issue: https://github.com/square/retrofit/issues/1192