### PR TITLE
Add buildRequest() and proper implementation

### DIFF
--- a/retrofit/src/main/java/retrofit2/Call.java
+++ b/retrofit/src/main/java/retrofit2/Call.java
@@ -16,7 +16,6 @@
 package retrofit2;
 
 import com.squareup.okhttp.Request;
-
 import java.io.IOException;
 
 /**
@@ -68,9 +67,10 @@ public interface Call<T> extends Cloneable {
    * has already been.
    */
   Call<T> clone();
-  
+
   /**
    * Builds a new {@link Request} identical to the one that Retrofit uses to dispatch the call.
+   * It may cause a {@link IOException} in case the RequestFactory throws one.
    */
   Request buildRequest() throws IOException;
 }

--- a/retrofit/src/main/java/retrofit2/Call.java
+++ b/retrofit/src/main/java/retrofit2/Call.java
@@ -15,6 +15,8 @@
  */
 package retrofit2;
 
+import com.squareup.okhttp.Request;
+
 import java.io.IOException;
 
 /**
@@ -66,4 +68,9 @@ public interface Call<T> extends Cloneable {
    * has already been.
    */
   Call<T> clone();
+  
+  /**
+   * Builds a new {@link Request} identical to the one that Retrofit uses to dispatch the call.
+   */
+  Request buildRequest() throws IOException;
 }

--- a/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
@@ -16,7 +16,6 @@
 package retrofit2;
 
 import com.squareup.okhttp.Request;
-
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;

--- a/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
@@ -15,6 +15,8 @@
  */
 package retrofit2;
 
+import com.squareup.okhttp.Request;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -97,6 +99,10 @@ final class ExecutorCallAdapterFactory implements CallAdapter.Factory {
     @SuppressWarnings("CloneDoesntCallSuperClone") // Performing deep clone.
     @Override public Call<T> clone() {
       return new ExecutorCallbackCall<>(callbackExecutor, delegate.clone());
+    }
+
+    @Override public Request buildRequest() throws IOException {
+      return delegate.buildRequest();
     }
   }
 }

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -20,7 +20,6 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.ResponseBody;
 import java.io.IOException;
-
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.ForwardingSource;
@@ -247,8 +246,7 @@ final class OkHttpCall<T> implements Call<T> {
     }
   }
 
-  @Override
-  public Request buildRequest() throws IOException {
+  @Override public Request buildRequest() throws IOException {
     try {
       return requestFactory.create(args);
     }catch(IOException e){

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -20,6 +20,7 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.ResponseBody;
 import java.io.IOException;
+
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.ForwardingSource;
@@ -243,6 +244,15 @@ final class OkHttpCall<T> implements Call<T> {
       if (thrownException != null) {
         throw thrownException;
       }
+    }
+  }
+
+  @Override
+  public Request buildRequest() throws IOException {
+    try {
+      return requestFactory.create(args);
+    }catch(IOException e){
+      throw e;
     }
   }
 }

--- a/retrofit/src/test/java/retrofit2/ExecutorCallAdapterFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/ExecutorCallAdapterFactoryTest.java
@@ -21,7 +21,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.concurrent.Executor;
-
 import com.squareup.okhttp.Request;
 import org.junit.Test;
 

--- a/retrofit/src/test/java/retrofit2/ExecutorCallAdapterFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/ExecutorCallAdapterFactoryTest.java
@@ -21,6 +21,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.concurrent.Executor;
+
+import com.squareup.okhttp.Request;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -168,6 +170,10 @@ public final class ExecutorCallAdapterFactoryTest {
     }
 
     @Override public Call<String> clone() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public Request buildRequest() throws IOException {
       throw new UnsupportedOperationException();
     }
   }


### PR DESCRIPTION
This PR fixes #1367, which is a basic issue:

* Once you instantiate a `Call<T>`, you may need to inspect the URL (which now contains set query params), as well as all body and header data that will be send in the future if you dispatch the call (by either `enqueue()` or `execute()`