### PR TITLE
Add Call.Factory for alternate HTTP client implementations.

### DIFF
--- a/retrofit/src/main/java/retrofit2/Call.java
+++ b/retrofit/src/main/java/retrofit2/Call.java
@@ -15,6 +15,7 @@
  */
 package retrofit2;
 
+import com.squareup.okhttp.ResponseBody;
 import java.io.IOException;
 
 /**
@@ -66,4 +67,13 @@ public interface Call<T> extends Cloneable {
    * has already been.
    */
   Call<T> clone();
+
+  /** Creates {@link Call} instances. */
+  interface Factory {
+    /**
+     * Returns a {@link Call} which will send {@code request} when executed or enqueue and use
+     * {@code converter} to parse the response. May not return null.
+     */
+    <T> Call<T> create(DeferredRequest request, Converter<ResponseBody, T> converter);
+  }
 }

--- a/retrofit/src/main/java/retrofit2/DeferredRequest.java
+++ b/retrofit/src/main/java/retrofit2/DeferredRequest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2;
+
+import com.squareup.okhttp.Request;
+import java.io.IOException;
+
+/**
+ * An un-built HTTP request. This class defers any work necessary to create an HTTP request until
+ * {@link #get()} is called.
+ */
+public interface DeferredRequest {
+  /** Perform the work necessary to create and then return the {@link Request}. */
+  Request get() throws IOException;
+}

--- a/retrofit/src/main/java/retrofit2/OkHttpCallFactory.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCallFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2;
+
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.ResponseBody;
+
+final class OkHttpCallFactory implements Call.Factory {
+  final OkHttpClient client;
+
+  OkHttpCallFactory(OkHttpClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public <T> Call<T> create(DeferredRequest request, Converter<ResponseBody, T> converter) {
+    return new OkHttpCall<>(client, request, converter);
+  }
+}

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -45,6 +45,14 @@ final class RequestFactory {
     this.requestActions = requestActions;
   }
 
+  DeferredRequest defer(final Object... args) {
+    return new DeferredRequest() {
+      @Override public Request get() throws IOException {
+        return create(args);
+      }
+    };
+  }
+
   Request create(Object... args) throws IOException {
     RequestBuilder requestBuilder =
         new RequestBuilder(method, baseUrl.url(), relativeUrl, headers, contentType, hasBody,


### PR DESCRIPTION
Closes #1377. Also solves #1149 indirectly!

For #924 we'll do a `WebSocketCall` and it will have its own `Factory`. Calling `client` on `Retrofit.Builder` will populate that instance automatically just like it does for `Call.Factory`.