### PR TITLE
Forbid Retrofit and OkHttp Response types as response body type.

### DIFF
--- a/retrofit/src/main/java/retrofit2/MethodHandler.java
+++ b/retrofit/src/main/java/retrofit2/MethodHandler.java
@@ -24,6 +24,11 @@ final class MethodHandler {
   static MethodHandler create(Retrofit retrofit, Method method) {
     CallAdapter<?> callAdapter = createCallAdapter(method, retrofit);
     Type responseType = callAdapter.responseType();
+    if (responseType == Response.class || responseType == okhttp3.Response.class) {
+      throw Utils.methodError(method, "'"
+          + Utils.getRawType(responseType).getName()
+          + "' is not a valid response body type. Did you mean ResponseBody?");
+    }
     Converter<ResponseBody, ?> responseConverter =
         createResponseConverter(method, retrofit, responseType);
     RequestFactory requestFactory = RequestFactoryParser.parse(method, responseType, retrofit);

--- a/retrofit/src/main/java/retrofit2/Utils.java
+++ b/retrofit/src/main/java/retrofit2/Utils.java
@@ -181,15 +181,7 @@ final class Utils {
       throw new IllegalArgumentException(
           "Call return type must be parameterized as Call<Foo> or Call<? extends Foo>");
     }
-    final Type responseType = getParameterUpperBound(0, (ParameterizedType) returnType);
-
-    // Ensure the Call response type is not Response, we automatically deliver the Response object.
-    if (getRawType(responseType) == retrofit2.Response.class) {
-      throw new IllegalArgumentException(
-          "Call<T> cannot use Response as its generic parameter. "
-              + "Specify the response body type only (e.g., Call<TweetResponse>).");
-    }
-    return responseType;
+    return getParameterUpperBound(0, (ParameterizedType) returnType);
   }
 
   private Utils() {

--- a/retrofit/src/test/java/retrofit2/ExecutorCallAdapterFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/ExecutorCallAdapterFactoryTest.java
@@ -55,17 +55,6 @@ public final class ExecutorCallAdapterFactoryTest {
     }
   }
 
-  @Test public void responseThrows() {
-    Type returnType = new TypeToken<Call<Response<String>>>() {}.getType();
-    try {
-      factory.get(returnType, NO_ANNOTATIONS, retrofit);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Call<T> cannot use Response as its generic parameter. "
-          + "Specify the response body type only (e.g., Call<TweetResponse>).");
-    }
-  }
-
   @Test public void responseType() {
     Type classType = new TypeToken<Call<String>>() {}.getType();
     assertThat(factory.get(classType, NO_ANNOTATIONS, retrofit).responseType())

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -48,11 +48,16 @@ public final class RetrofitTest {
   interface CallMethod {
     @GET("/") Call<String> disallowed();
     @POST("/") Call<ResponseBody> disallowed(@Body String body);
+
+    @GET("/") Call<retrofit2.Response> badType1();
+    @GET("/") Call<okhttp3.Response> badType2();
+
     @GET("/") Call<ResponseBody> getResponseBody();
     @GET("/") Call<Void> getVoid();
     @POST("/") Call<ResponseBody> postRequestBody(@Body RequestBody body);
     @GET("/") Call<ResponseBody> queryString(@Query("foo") String foo);
     @GET("/") Call<ResponseBody> queryObject(@Query("foo") Object foo);
+
   }
   interface FutureMethod {
     @GET("/") Future<String> method();
@@ -109,6 +114,36 @@ public final class RetrofitTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage("API interfaces must not extend other interfaces.");
+    }
+  }
+
+  @Test public void responseTypeCannotBeRetrofitResponse() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .build();
+    CallMethod service = retrofit.create(CallMethod.class);
+    try {
+      service.badType1();
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(
+          "'retrofit2.Response' is not a valid response body type. Did you mean ResponseBody?\n"
+              + "    for method CallMethod.badType1");
+    }
+  }
+
+  @Test public void responseTypeCannotBeOkHttpResponse() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .build();
+    CallMethod service = retrofit.create(CallMethod.class);
+    try {
+      service.badType2();
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(
+          "'okhttp3.Response' is not a valid response body type. Did you mean ResponseBody?\n"
+              + "    for method CallMethod.badType2");
     }
   }
 


### PR DESCRIPTION
Previously only Retrofit's Response type was detected and only when used in a Call.