### PR TITLE
Added more tests for RxJava Single type support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <animal.sniffer.version>1.14</animal.sniffer.version>
 
     <!-- Adapter Dependencies -->
-    <rxjava.version>1.0.14</rxjava.version>
+    <rxjava.version>1.1.0</rxjava.version>
 
     <!-- Converter Dependencies -->
     <gson.version>2.4</gson.version>


### PR DESCRIPTION
`Single.toBlocking()` is present since [RxJava 1.0.16](https://github.com/ReactiveX/RxJava/releases/tag/v1.0.16) version so I removed TODO and implemented new tests which are consistent with corresponding observable ones. 
I've upgraded RxJava to the newest 1.1.0 version. `Single` has been [promoted](https://github.com/ReactiveX/RxJava/releases/tag/1.1.0) to the Beta in this version.