### PR TITLE
Supply method annotations to factory when invoking requestBodyConverter.

### DIFF
--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/RxJavaCallAdapterFactoryTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/RxJavaCallAdapterFactoryTest.java
@@ -341,7 +341,7 @@ public final class RxJavaCallAdapterFactoryTest {
     }
 
     @Override public Converter<?, RequestBody> requestBodyConverter(Type type,
-        Annotation[] annotations, Retrofit retrofit) {
+        Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
       return new Converter<String, RequestBody>() {
         @Override public RequestBody convert(String value) throws IOException {
           return RequestBody.create(MediaType.parse("text/plain"), value);

--- a/retrofit-converters/gson/src/main/java/retrofit2/GsonConverterFactory.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/GsonConverterFactory.java
@@ -63,8 +63,8 @@ public final class GsonConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
-      Retrofit retrofit) {
+  public Converter<?, RequestBody> requestBodyConverter(Type type,
+      Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
     TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
     return new GsonRequestBodyConverter<>(gson, adapter);
   }

--- a/retrofit-converters/jackson/src/main/java/retrofit2/JacksonConverterFactory.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/JacksonConverterFactory.java
@@ -59,8 +59,8 @@ public final class JacksonConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
-      Retrofit retrofit) {
+  public Converter<?, RequestBody> requestBodyConverter(Type type,
+      Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
     JavaType javaType = mapper.getTypeFactory().constructType(type);
     ObjectWriter writer = mapper.writerWithType(javaType);
     return new JacksonRequestBodyConverter<>(writer);

--- a/retrofit-converters/moshi/src/main/java/retrofit2/MoshiConverterFactory.java
+++ b/retrofit-converters/moshi/src/main/java/retrofit2/MoshiConverterFactory.java
@@ -56,8 +56,8 @@ public final class MoshiConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
-      Retrofit retrofit) {
+  public Converter<?, RequestBody> requestBodyConverter(Type type,
+      Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
     JsonAdapter<?> adapter = moshi.adapter(type);
     return new MoshiRequestBodyConverter<>(adapter);
   }

--- a/retrofit-converters/protobuf/src/main/java/retrofit2/ProtoConverterFactory.java
+++ b/retrofit-converters/protobuf/src/main/java/retrofit2/ProtoConverterFactory.java
@@ -58,8 +58,8 @@ public final class ProtoConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
-      Retrofit retrofit) {
+  public Converter<?, RequestBody> requestBodyConverter(Type type,
+      Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
     if (!(type instanceof Class<?>)) {
       return null;
     }

--- a/retrofit-converters/scalars/src/main/java/retrofit2/ScalarsConverterFactory.java
+++ b/retrofit-converters/scalars/src/main/java/retrofit2/ScalarsConverterFactory.java
@@ -32,8 +32,8 @@ public final class ScalarsConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
-      Retrofit retrofit) {
+  public Converter<?, RequestBody> requestBodyConverter(Type type,
+      Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
     if (type == String.class
         || type == boolean.class
         || type == Boolean.class

--- a/retrofit-converters/simplexml/src/main/java/retrofit2/SimpleXmlConverterFactory.java
+++ b/retrofit-converters/simplexml/src/main/java/retrofit2/SimpleXmlConverterFactory.java
@@ -73,8 +73,8 @@ public final class SimpleXmlConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
-      Retrofit retrofit) {
+  public Converter<?, RequestBody> requestBodyConverter(Type type,
+      Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
     if (!(type instanceof Class)) {
       return null;
     }

--- a/retrofit-converters/wire/src/main/java/retrofit2/WireConverterFactory.java
+++ b/retrofit-converters/wire/src/main/java/retrofit2/WireConverterFactory.java
@@ -51,8 +51,8 @@ public final class WireConverterFactory extends Converter.Factory {
   }
 
   @Override
-  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
-      Retrofit retrofit) {
+  public Converter<?, RequestBody> requestBodyConverter(Type type,
+      Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
     if (!(type instanceof Class<?>)) {
       return null;
     }

--- a/retrofit/src/main/java/retrofit2/BuiltInConverters.java
+++ b/retrofit/src/main/java/retrofit2/BuiltInConverters.java
@@ -39,8 +39,8 @@ final class BuiltInConverters extends Converter.Factory {
   }
 
   @Override
-  public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
-      Retrofit retrofit) {
+  public Converter<?, RequestBody> requestBodyConverter(Type type,
+      Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
     if (RequestBody.class.isAssignableFrom(Utils.getRawType(type))) {
       return RequestBodyConverter.INSTANCE;
     }

--- a/retrofit/src/main/java/retrofit2/Converter.java
+++ b/retrofit/src/main/java/retrofit2/Converter.java
@@ -57,8 +57,8 @@ public interface Converter<F, T> {
      * specified by {@link Body @Body}, {@link Part @Part}, and {@link PartMap @PartMap}
      * values.
      */
-    public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
-        Retrofit retrofit) {
+    public Converter<?, RequestBody> requestBodyConverter(Type type,
+        Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
       return null;
     }
 

--- a/retrofit/src/main/java/retrofit2/RequestFactoryParser.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactoryParser.java
@@ -201,6 +201,7 @@ final class RequestFactoryParser {
 
   private void parseParameters(Retrofit retrofit) {
     Type[] methodParameterTypes = method.getGenericParameterTypes();
+    Annotation[] methodAnnotations = method.getAnnotations();
     Annotation[][] methodParameterAnnotationArrays = method.getParameterAnnotations();
 
     boolean gotField = false;
@@ -425,16 +426,19 @@ final class RequestFactoryParser {
               ParameterizedType parameterizedType = (ParameterizedType) methodParameterType;
               Type iterableType = Utils.getParameterUpperBound(0, parameterizedType);
               Converter<?, RequestBody> valueConverter =
-                  retrofit.requestBodyConverter(iterableType, methodParameterAnnotations);
+                  retrofit.requestBodyConverter(iterableType, methodParameterAnnotations,
+                      methodAnnotations);
               action = new RequestAction.Part<>(headers, valueConverter).iterable();
             } else if (rawParameterType.isArray()) {
               Class<?> arrayComponentType = boxIfPrimitive(rawParameterType.getComponentType());
               Converter<?, RequestBody> valueConverter =
-                  retrofit.requestBodyConverter(arrayComponentType, methodParameterAnnotations);
+                  retrofit.requestBodyConverter(arrayComponentType, methodParameterAnnotations,
+                      methodAnnotations);
               action = new RequestAction.Part<>(headers, valueConverter).array();
             } else {
               Converter<?, RequestBody> valueConverter =
-                  retrofit.requestBodyConverter(methodParameterType, methodParameterAnnotations);
+                  retrofit.requestBodyConverter(methodParameterType, methodParameterAnnotations,
+                      methodAnnotations);
               action = new RequestAction.Part<>(headers, valueConverter);
             }
 
@@ -458,7 +462,8 @@ final class RequestFactoryParser {
             }
             Type valueType = Utils.getParameterUpperBound(1, parameterizedType);
             Converter<?, RequestBody> valueConverter =
-                retrofit.requestBodyConverter(valueType, methodParameterAnnotations);
+                retrofit.requestBodyConverter(valueType, methodParameterAnnotations,
+                    methodAnnotations);
 
             PartMap partMap = (PartMap) methodParameterAnnotation;
             action = new RequestAction.PartMap<>(valueConverter, partMap.encoding());
@@ -476,7 +481,8 @@ final class RequestFactoryParser {
             Converter<?, RequestBody> converter;
             try {
               converter =
-                  retrofit.requestBodyConverter(methodParameterType, methodParameterAnnotations);
+                  retrofit.requestBodyConverter(methodParameterType, methodParameterAnnotations,
+                      methodAnnotations);
             } catch (RuntimeException e) { // Wide exception range because factories are user code.
               throw parameterError(e, i, "Unable to create @Body converter for %s",
                   methodParameterType);

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -241,8 +241,9 @@ public final class Retrofit {
    *
    * @throws IllegalArgumentException if no converter available for {@code type}.
    */
-  public <T> Converter<T, RequestBody> requestBodyConverter(Type type, Annotation[] annotations) {
-    return nextRequestBodyConverter(null, type, annotations);
+  public <T> Converter<T, RequestBody> requestBodyConverter(Type type,
+      Annotation[] parameterAnnotations, Annotation[] methodAnnotations) {
+    return nextRequestBodyConverter(null, type, parameterAnnotations, methodAnnotations);
   }
 
   /**
@@ -252,14 +253,16 @@ public final class Retrofit {
    * @throws IllegalArgumentException if no converter available for {@code type}.
    */
   public <T> Converter<T, RequestBody> nextRequestBodyConverter(Converter.Factory skipPast,
-      Type type, Annotation[] annotations) {
+      Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations) {
     checkNotNull(type, "type == null");
-    checkNotNull(annotations, "annotations == null");
+    checkNotNull(parameterAnnotations, "parameterAnnotations == null");
+    checkNotNull(methodAnnotations, "methodAnnotations == null");
 
     int start = converterFactories.indexOf(skipPast) + 1;
     for (int i = start, count = converterFactories.size(); i < count; i++) {
+      Converter.Factory factory = converterFactories.get(i);
       Converter<?, RequestBody> converter =
-          converterFactories.get(i).requestBodyConverter(type, annotations, this);
+          factory.requestBodyConverter(type, parameterAnnotations, methodAnnotations, this);
       if (converter != null) {
         //noinspection unchecked
         return (Converter<T, RequestBody>) converter;

--- a/retrofit/src/test/java/retrofit2/CallTest.java
+++ b/retrofit/src/test/java/retrofit2/CallTest.java
@@ -191,7 +191,8 @@ public final class CallTest {
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
           @Override
-          public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
+          public Converter<?, RequestBody> requestBodyConverter(Type type,
+              Annotation[] parameterAnnotations, Annotation[] methodAnnotations,
               Retrofit retrofit) {
             return new Converter<String, RequestBody>() {
               @Override public RequestBody convert(String value) throws IOException {
@@ -217,7 +218,8 @@ public final class CallTest {
         .baseUrl(server.url("/"))
         .addConverterFactory(new ToStringConverterFactory() {
           @Override
-          public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
+          public Converter<?, RequestBody> requestBodyConverter(Type type,
+              Annotation[] parameterAnnotations, Annotation[] methodAnnotations,
               Retrofit retrofit) {
             return new Converter<String, RequestBody>() {
               @Override public RequestBody convert(String value) throws IOException {

--- a/retrofit/src/test/java/retrofit2/ToStringConverterFactory.java
+++ b/retrofit/src/test/java/retrofit2/ToStringConverterFactory.java
@@ -39,7 +39,7 @@ class ToStringConverterFactory extends Converter.Factory {
   }
 
   @Override public Converter<?, RequestBody> requestBodyConverter(Type type,
-      Annotation[] annotations, Retrofit retrofit) {
+      Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
     if (String.class.equals(type)) {
       return new Converter<String, RequestBody>() {
         @Override public RequestBody convert(String value) throws IOException {

--- a/samples/src/main/java/com/example/retrofit/ChunkingConverter.java
+++ b/samples/src/main/java/com/example/retrofit/ChunkingConverter.java
@@ -49,11 +49,11 @@ public final class ChunkingConverter {
    */
   static class ChunkingConverterFactory extends Converter.Factory {
     @Override
-    public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] annotations,
-        Retrofit retrofit) {
+    public Converter<?, RequestBody> requestBodyConverter(Type type,
+        Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
       boolean isBody = false;
       boolean isChunked = false;
-      for (Annotation annotation : annotations) {
+      for (Annotation annotation : parameterAnnotations) {
         isBody |= annotation instanceof Body;
         isChunked |= annotation instanceof Chunked;
       }
@@ -63,7 +63,7 @@ public final class ChunkingConverter {
 
       // Look up the real converter to delegate to.
       final Converter<Object, RequestBody> delegate =
-          retrofit.nextRequestBodyConverter(this, type, annotations);
+          retrofit.nextRequestBodyConverter(this, type, parameterAnnotations, methodAnnotations);
       // Wrap it in a Converter which removes the content length from the delegate's body.
       return new Converter<Object, RequestBody>() {
         @Override public RequestBody convert(Object value) throws IOException {


### PR DESCRIPTION
I'm using Retrofit for JSON-RPC over HTTP using a [custom converter factory](https://github.com/segmentio/java-jsonrpc/blob/master/jsonrpc/src/main/java/com/segment/jsonrpc/JsonRPCConverterFactory.java).

Currently `Converter.Factory#requestBodyConverter` is only supplied the annotations on the method parameter. In the JSON-RPC case, this requires the use 2 separate annotations — one that is available to the response converter (to transparently unwrap the response from the server ) and one that is available to the request converter (to transparently encode the request for JSON-RPC and encode the name of the RPC method).

```java
interface MultiplicationService {
    @JsonRPC @POST("/rpc")
    Call<Integer> multiply(@Body @Method("Arith.Multiply") MultiplicationArgs args);
}
```

By supplying the method annotations to both the request and response converter factory methods, we can consolidate the annotations into a single one and simplify their service declaration.

```java
interface MultiplicationService {
    @JsonRPC("Arith.Multiply") @POST("/rpc")
    Call<Integer> multiply(@Body MultiplicationArgs args);
}
```

This implementation is NOT backwards compatible — all the existing converters will have to updated (first part converters have been updated).