### PR TITLE
Adds RequestBuildInterceptor

### DIFF
--- a/retrofit/src/main/java/retrofit2/DefaultRequestBuildInterceptorFactory.java
+++ b/retrofit/src/main/java/retrofit2/DefaultRequestBuildInterceptorFactory.java
@@ -1,0 +1,26 @@
+package retrofit2;
+
+import okhttp3.Request;
+
+import java.lang.reflect.Method;
+
+/**
+ * a default implementation which is passing the request through, without
+ * modifying it
+ */
+final class DefaultRequestBuildInterceptorFactory implements RequestBuildInterceptor {
+  static final Factory FACTORY = new Factory() {
+    @Override
+    public RequestBuildInterceptor get(Method method) {
+      return new DefaultRequestBuildInterceptorFactory();
+    }
+  };
+
+  DefaultRequestBuildInterceptorFactory() {
+  }
+
+  @Override
+  public Request build(Request request) {
+    return request;
+  }
+}

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -184,7 +184,9 @@ final class OkHttpCall<T> implements Call<T> {
   private okhttp3.Call createRawCall() throws IOException {
     Request request = requestFactory.create(args);
     try {
-      request = requestBuildInterceptor.build(request);
+      request = Utils.checkNotNull(requestBuildInterceptor.build(request),
+              String.format("The %s must not return null!",
+                      RequestBuildInterceptor.class.getSimpleName()));
     } catch (RuntimeException e) {
       throw new RuntimeException("Could not create request", e);
     }

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -27,6 +27,7 @@ import okio.Okio;
 final class OkHttpCall<T> implements Call<T> {
   private final okhttp3.Call.Factory callFactory;
   private final RequestFactory requestFactory;
+  private final RequestBuildInterceptor requestBuildInterceptor;
   private final Object[] args;
   private final Converter<ResponseBody, T> responseConverter;
 
@@ -37,17 +38,20 @@ final class OkHttpCall<T> implements Call<T> {
   private Throwable creationFailure; // Either a RuntimeException or IOException.
   private boolean executed;
 
-  OkHttpCall(okhttp3.Call.Factory callFactory, RequestFactory requestFactory, Object[] args,
+  OkHttpCall(okhttp3.Call.Factory callFactory, RequestFactory requestFactory,
+      RequestBuildInterceptor requestBuildInterceptor, Object[] args,
       Converter<ResponseBody, T> responseConverter) {
     this.callFactory = callFactory;
     this.requestFactory = requestFactory;
+    this.requestBuildInterceptor = requestBuildInterceptor;
     this.args = args;
     this.responseConverter = responseConverter;
   }
 
   @SuppressWarnings("CloneDoesntCallSuperClone") // We are a final type & this saves clearing state.
   @Override public OkHttpCall<T> clone() {
-    return new OkHttpCall<>(callFactory, requestFactory, args, responseConverter);
+    return new OkHttpCall<>(callFactory, requestFactory, requestBuildInterceptor,
+            args, responseConverter);
   }
 
   @Override public synchronized Request request() {
@@ -178,7 +182,13 @@ final class OkHttpCall<T> implements Call<T> {
   }
 
   private okhttp3.Call createRawCall() throws IOException {
-    okhttp3.Call call = callFactory.newCall(requestFactory.create(args));
+    Request request = requestFactory.create(args);
+    try {
+      request = requestBuildInterceptor.build(request);
+    } catch (RuntimeException e) {
+      throw new RuntimeException("Could not create request", e);
+    }
+    okhttp3.Call call = callFactory.newCall(request);
     if (call == null) {
       throw new NullPointerException("Call.Factory returned null.");
     }

--- a/retrofit/src/main/java/retrofit2/Platform.java
+++ b/retrofit/src/main/java/retrofit2/Platform.java
@@ -53,6 +53,10 @@ class Platform {
     return DefaultCallAdapter.FACTORY;
   }
 
+  RequestBuildInterceptor.Factory defaultRequestBuildInterceptorFactory() {
+    return DefaultRequestBuildInterceptorFactory.FACTORY;
+  }
+
   boolean isDefaultMethod(Method method) {
     return false;
   }

--- a/retrofit/src/main/java/retrofit2/RequestBuildInterceptor.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuildInterceptor.java
@@ -1,0 +1,25 @@
+package retrofit2;
+
+import java.lang.reflect.Method;
+
+import okhttp3.Request;
+
+/**
+ * With this interceptor, you can intercept the request build process and modify
+ * the request as you want it to be executed. i.e. adding headers based on annotations
+ */
+public interface RequestBuildInterceptor {
+
+  /**
+   * @param request the request object as it has been generated based on the method
+   * @return a (modified) request, as you want it to be called
+   */
+  Request build(Request request);
+
+  /**
+   * Creates {@link RequestBuildInterceptor} based on the method which has been called
+   */
+  interface Factory {
+    RequestBuildInterceptor get(Method method);
+  }
+}

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -60,17 +60,20 @@ public final class Retrofit {
   private final Map<Method, MethodHandler> methodHandlerCache = new LinkedHashMap<>();
 
   private final okhttp3.Call.Factory callFactory;
+  private final RequestBuildInterceptor.Factory requestBuildInterceptorFactory;
   private final BaseUrl baseUrl;
   private final List<Converter.Factory> converterFactories;
   private final List<CallAdapter.Factory> adapterFactories;
   private final Executor callbackExecutor;
   private final boolean validateEagerly;
 
-  Retrofit(okhttp3.Call.Factory callFactory, BaseUrl baseUrl,
+  Retrofit(okhttp3.Call.Factory callFactory,
+      RequestBuildInterceptor.Factory requestBuildInterceptorFactory, BaseUrl baseUrl,
       List<Converter.Factory> converterFactories, List<CallAdapter.Factory> adapterFactories,
       Executor callbackExecutor, boolean validateEagerly) {
     this.callFactory = callFactory;
     this.baseUrl = baseUrl;
+    this.requestBuildInterceptorFactory = requestBuildInterceptorFactory;
     this.converterFactories = converterFactories;
     this.adapterFactories = adapterFactories;
     this.callbackExecutor = callbackExecutor;
@@ -174,6 +177,10 @@ public final class Retrofit {
    */
   public okhttp3.Call.Factory callFactory() {
     return callFactory;
+  }
+
+  public RequestBuildInterceptor.Factory requestBuildInterceptorFactory() {
+    return requestBuildInterceptorFactory;
   }
 
   public BaseUrl baseUrl() {
@@ -362,6 +369,7 @@ public final class Retrofit {
    */
   public static final class Builder {
     private okhttp3.Call.Factory callFactory;
+    private RequestBuildInterceptor.Factory requestBuildInterceptorFactory;
     private BaseUrl baseUrl;
     private List<Converter.Factory> converterFactories = new ArrayList<>();
     private List<CallAdapter.Factory> adapterFactories = new ArrayList<>();
@@ -500,6 +508,14 @@ public final class Retrofit {
     }
 
     /**
+     * Add an interceptor, which will be called on request creation
+     */
+    public Builder addRequestBuildInterceptorFactory(RequestBuildInterceptor.Factory factory) {
+      requestBuildInterceptorFactory = checkNotNull(factory, "factory == null");
+      return this;
+    }
+
+    /**
      * The executor on which {@link Callback} methods are invoked when returning {@link Call} from
      * your service method.
      * <p>
@@ -536,6 +552,12 @@ public final class Retrofit {
         callFactory = new OkHttpClient();
       }
 
+      RequestBuildInterceptor.Factory requestBuildInterceptorFactory =
+              this.requestBuildInterceptorFactory;
+      if (requestBuildInterceptorFactory == null) {
+        requestBuildInterceptorFactory = Platform.get().defaultRequestBuildInterceptorFactory();
+      }
+
       // Make a defensive copy of the adapters and add the default Call adapter.
       List<CallAdapter.Factory> adapterFactories = new ArrayList<>(this.adapterFactories);
       adapterFactories.add(Platform.get().defaultCallAdapterFactory(callbackExecutor));
@@ -543,8 +565,8 @@ public final class Retrofit {
       // Make a defensive copy of the converters.
       List<Converter.Factory> converterFactories = new ArrayList<>(this.converterFactories);
 
-      return new Retrofit(callFactory, baseUrl, converterFactories, adapterFactories,
-          callbackExecutor, validateEagerly);
+      return new Retrofit(callFactory, requestBuildInterceptorFactory, baseUrl, converterFactories,
+              adapterFactories, callbackExecutor, validateEagerly);
     }
   }
 }


### PR DESCRIPTION
The user can add a RequestBuildInterceptor.Factory to retrofit, which hooks into a point directly after the request has been generated via the retrofit2.RequestBuilder. On this way the request can be modified depending on whatever the user wants to add (using request.newBuilder)
This is a possible solution for #1422, #1500

PS: The naming could be improved, since "RequestBuildInterceptor.Factory" is quite a long name.