### PR TITLE
Bugfix/issue 1364 partial fix respect encoding for path characters

### DIFF
--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -85,10 +85,10 @@ final class RequestBuilder {
       // The relative URL is cleared when the first query parameter is set.
       throw new AssertionError();
     }
-    relativeUrl = relativeUrl.replace("{" + name + "}", canonicalize(value, encoded));
+    relativeUrl = relativeUrl.replace("{" + name + "}", canonicalizeForPath(value, encoded));
   }
 
-  private static String canonicalize(String input, boolean alreadyEncoded) {
+  private static String canonicalizeForPath(String input, boolean alreadyEncoded) {
     int codePoint;
     for (int i = 0, limit = input.length(); i < limit; i += Character.charCount(codePoint)) {
       codePoint = input.codePointAt(i);
@@ -97,7 +97,7 @@ final class RequestBuilder {
         // Slow path: the character at i requires encoding!
         Buffer out = new Buffer();
         out.writeUtf8(input, 0, i);
-        canonicalize(out, input, i, limit, alreadyEncoded);
+        canonicalizeForPath(out, input, i, limit, alreadyEncoded);
         return out.readUtf8();
       }
     }
@@ -106,8 +106,8 @@ final class RequestBuilder {
     return input;
   }
 
-  private static void canonicalize(Buffer out, String input, int pos, int limit,
-      boolean alreadyEncoded) {
+  private static void canonicalizeForPath(Buffer out, String input, int pos, int limit,
+                                          boolean alreadyEncoded) {
     Buffer utf8Buffer = null; // Lazily allocated.
     int codePoint;
     for (int i = pos; i < limit; i += Character.charCount(codePoint)) {

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -29,7 +29,7 @@ import okio.BufferedSink;
 final class RequestBuilder {
   private static final char[] HEX_DIGITS =
       { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
-  private static final String PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|/\\?#";
+  private static final String PATH_SEGMENT_ALWAYS_ENCODE_SET = " \"<>^`{}|\\?#";
 
   private final String method;
 
@@ -94,8 +94,8 @@ final class RequestBuilder {
       codePoint = input.codePointAt(i);
       if (codePoint < 0x20
           || codePoint >= 0x7f
-          || (!alreadyEncoded
-              && (PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1 || codePoint == '%'))) {
+          || PATH_SEGMENT_ALWAYS_ENCODE_SET.indexOf(codePoint) != -1
+          || (!alreadyEncoded && (codePoint == '/' || codePoint == '%'))) {
         // Slow path: the character at i requires encoding!
         Buffer out = new Buffer();
         out.writeUtf8(input, 0, i);
@@ -118,9 +118,9 @@ final class RequestBuilder {
           && (codePoint == '\t' || codePoint == '\n' || codePoint == '\f' || codePoint == '\r')) {
         // Skip this character.
       } else if (codePoint < 0x20
-          || codePoint >= 0x7f
-          || (!alreadyEncoded
-              && (PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1 || codePoint == '%'))) {
+                 || codePoint >= 0x7f
+                 || PATH_SEGMENT_ALWAYS_ENCODE_SET.indexOf(codePoint) != -1
+                 || (!alreadyEncoded && (codePoint == '/' || codePoint == '%'))) {
         // Percent encode this character.
         if (utf8Buffer == null) {
           utf8Buffer = new Buffer();

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -95,8 +95,7 @@ final class RequestBuilder {
       if (codePoint < 0x20
           || codePoint >= 0x7f
           || (!alreadyEncoded
-              && PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1)
-          || (codePoint == '%' && !alreadyEncoded)) {
+              && (PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1 || codePoint == '%'))) {
         // Slow path: the character at i requires encoding!
         Buffer out = new Buffer();
         out.writeUtf8(input, 0, i);
@@ -121,8 +120,7 @@ final class RequestBuilder {
       } else if (codePoint < 0x20
           || codePoint >= 0x7f
           || (!alreadyEncoded
-              && PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1)
-              || (codePoint == '%' && !alreadyEncoded)) {
+              && (PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1 || codePoint == '%'))) {
         // Percent encode this character.
         if (utf8Buffer == null) {
           utf8Buffer = new Buffer();

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -92,8 +92,10 @@ final class RequestBuilder {
     int codePoint;
     for (int i = 0, limit = input.length(); i < limit; i += Character.charCount(codePoint)) {
       codePoint = input.codePointAt(i);
-      if (codePoint < 0x20 || codePoint >= 0x7f
-          || PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1
+      if (codePoint < 0x20
+          || codePoint >= 0x7f
+          || (!alreadyEncoded
+              && PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1)
           || (codePoint == '%' && !alreadyEncoded)) {
         // Slow path: the character at i requires encoding!
         Buffer out = new Buffer();
@@ -118,8 +120,9 @@ final class RequestBuilder {
         // Skip this character.
       } else if (codePoint < 0x20
           || codePoint >= 0x7f
-          || PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1
-          || (codePoint == '%' && !alreadyEncoded)) {
+          || (!alreadyEncoded
+              && PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1)
+              || (codePoint == '%' && !alreadyEncoded)) {
         // Percent encode this character.
         if (utf8Buffer == null) {
           utf8Buffer = new Buffer();

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -92,8 +92,9 @@ final class RequestBuilder {
     int codePoint;
     for (int i = 0, limit = input.length(); i < limit; i += Character.charCount(codePoint)) {
       codePoint = input.codePointAt(i);
-      if (shouldSkipCodePoint(codePoint)
-          || (!alreadyEncoded && shouldEncodeCodePoint(codePoint))) {
+      if (codePoint < 0x20 || codePoint >= 0x7f
+          || PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1
+          || (codePoint == '%' && !alreadyEncoded)) {
         // Slow path: the character at i requires encoding!
         Buffer out = new Buffer();
         out.writeUtf8(input, 0, i);
@@ -113,9 +114,12 @@ final class RequestBuilder {
     for (int i = pos; i < limit; i += Character.charCount(codePoint)) {
       codePoint = input.codePointAt(i);
       if (alreadyEncoded
-          && shouldSkipCodePoint(codePoint)) {
+          && (codePoint == '\t' || codePoint == '\n' || codePoint == '\f' || codePoint == '\r')) {
         // Skip this character.
-      } else if (!alreadyEncoded && shouldEncodeCodePoint(codePoint)) {
+      } else if (codePoint < 0x20
+          || codePoint >= 0x7f
+          || PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1
+          || (codePoint == '%' && !alreadyEncoded)) {
         // Percent encode this character.
         if (utf8Buffer == null) {
           utf8Buffer = new Buffer();
@@ -132,17 +136,6 @@ final class RequestBuilder {
         out.writeUtf8CodePoint(codePoint);
       }
     }
-  }
-
-  private static boolean shouldSkipCodePoint(final int codePoint) {
-    return codePoint == '\t' || codePoint == '\n' || codePoint == '\f' || codePoint == '\r';
-  }
-
-  private static boolean shouldEncodeCodePoint(final int codePoint) {
-    return codePoint < 0x20
-         || codePoint >= 0x7f
-         || PATH_SEGMENT_ENCODE_SET.indexOf(codePoint) != -1
-         || codePoint == '%';
   }
 
   void addQueryParam(String name, String value, boolean encoded) {

--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -670,48 +670,6 @@ public final class RequestBuilderTest {
     assertThat(request.body()).isNull();
   }
 
-  @Test public void getWithEncodedPathSegments() {
-    class Example {
-      @GET("/foo/bar/{ping}/") //
-      Call<ResponseBody> method(@Path(value = "ping", encoded = true) String ping) {
-        return null;
-      }
-    }
-    Request request = buildRequest(Example.class, "baz/pong/more");
-    assertThat(request.method()).isEqualTo("GET");
-    assertThat(request.headers().size()).isZero();
-    assertThat(request.url().toString()).isEqualTo("http://example.com/foo/bar/baz/pong/more/");
-    assertThat(request.body()).isNull();
-  }
-
-  @Test public void getWithUnencodedPathSegmentsPreventsRequestSplitting() {
-    class Example {
-      @GET("/foo/bar/{ping}/") //
-      Call<ResponseBody> method(@Path(value = "ping", encoded = false) String ping) {
-        return null;
-      }
-    }
-    Request request = buildRequest(Example.class, "baz/\r\nheader: blue");
-    assertThat(request.method()).isEqualTo("GET");
-    assertThat(request.headers().size()).isZero();
-    assertThat(request.url().toString()).isEqualTo("http://example.com/foo/bar/baz%2F%0D%0Aheader:%20blue/");
-    assertThat(request.body()).isNull();
-  }
-
-  @Test public void getWithEncodedPathStillPreventsRequestSplitting() {
-    class Example {
-      @GET("/foo/bar/{ping}/") //
-      Call<ResponseBody> method(@Path(value = "ping", encoded = true) String ping) {
-        return null;
-      }
-    }
-    Request request = buildRequest(Example.class, "baz/\r\npong");
-    assertThat(request.method()).isEqualTo("GET");
-    assertThat(request.headers().size()).isZero();
-    assertThat(request.url().toString()).isEqualTo("http://example.com/foo/bar/baz/pong/");
-    assertThat(request.body()).isNull();
-  }
-
   @Test public void pathParamRequired() {
     class Example {
       @GET("/foo/bar/{ping}/") //


### PR DESCRIPTION
This is a partial fix for #1364 to fix the `RequestBuilder` to respect the encoded value for path parameters.

I wanted to make sure that the logic for skipping potentially dangerous chars like `\n` remains intact.

Added three tests to verify this change.

This change allows for temporary workaround of #1364, allowing the API owner to set certain path parameters as pre-encoded.