### PR TITLE
Rely on rx.Single class instead of className String in RxJavaCallAdapterFactory

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactory.java
@@ -46,7 +46,7 @@ public final class RxJavaCallAdapterFactory extends CallAdapter.Factory {
   @Override
   public CallAdapter<?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
     Class<?> rawType = getRawType(returnType);
-    boolean isSingle = "rx.Single".equals(rawType.getCanonicalName());
+    boolean isSingle = rawType == rx.Single.class;
     if (rawType != Observable.class && !isSingle) {
       return null;
     }


### PR DESCRIPTION
Fixes issue #1584
Rely on class not on string.
Class may be proguarded and String becomes out of date.