### PR TITLE
Use Gson instance as factory for reader to honor config.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <rxjava.version>1.1.0</rxjava.version>
 
     <!-- Converter Dependencies -->
-    <gson.version>2.4</gson.version>
+    <gson.version>2.6.1</gson.version>
     <protobuf.version>2.5.0</protobuf.version>
     <jackson.version>2.4.3</jackson.version>
     <wire.version>2.1.0</wire.version>

--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonConverterFactory.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonConverterFactory.java
@@ -61,7 +61,7 @@ public final class GsonConverterFactory extends Converter.Factory {
   public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
       Retrofit retrofit) {
     TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
-    return new GsonResponseBodyConverter<>(adapter);
+    return new GsonResponseBodyConverter<>(gson, adapter);
   }
 
   @Override

--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonResponseBodyConverter.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonResponseBodyConverter.java
@@ -15,21 +15,26 @@
  */
 package retrofit2.converter.gson;
 
+import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
 import java.io.IOException;
 import okhttp3.ResponseBody;
 import retrofit2.Converter;
 
 final class GsonResponseBodyConverter<T> implements Converter<ResponseBody, T> {
+  private final Gson gson;
   private final TypeAdapter<T> adapter;
 
-  GsonResponseBodyConverter(TypeAdapter<T> adapter) {
+  GsonResponseBodyConverter(Gson gson, TypeAdapter<T> adapter) {
+    this.gson = gson;
     this.adapter = adapter;
   }
 
   @Override public T convert(ResponseBody value) throws IOException {
+    JsonReader jsonReader = gson.newJsonReader(value.charStream());
     try {
-      return adapter.fromJson(value.charStream());
+      return adapter.read(jsonReader);
     } finally {
       value.close();
     }

--- a/retrofit-converters/gson/src/test/java/retrofit2/converter/gson/GsonConverterFactoryTest.java
+++ b/retrofit-converters/gson/src/test/java/retrofit2/converter/gson/GsonConverterFactoryTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import retrofit2.Call;
 import retrofit2.Response;
 import retrofit2.Retrofit;
-import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
 
@@ -90,6 +89,7 @@ public final class GsonConverterFactoryTest {
   @Before public void setUp() {
     Gson gson = new GsonBuilder()
         .registerTypeAdapter(AnInterface.class, new AnInterfaceAdapter())
+        .setLenient()
         .create();
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl(server.url("/"))
@@ -132,5 +132,13 @@ public final class GsonConverterFactoryTest {
     RecordedRequest request = server.takeRequest();
     assertThat(request.getBody().readUtf8()).isEqualTo("{}"); // Null value was not serialized.
     assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
+  }
+
+  @Test public void deserializeUsesConfiguration() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setBody("{/* a comment! */}"));
+
+    Response<AnImplementation> response =
+        service.anImplementation(new AnImplementation("value")).execute();
+    assertThat(response.body().getName()).isNull();
   }
 }


### PR DESCRIPTION
This allows settings like support for leniency to be honored.

Closes #1465.