### PR TITLE
(feat) Add success(body, headers) to Response.

### DIFF
--- a/retrofit/src/main/java/retrofit2/Response.java
+++ b/retrofit/src/main/java/retrofit2/Response.java
@@ -33,6 +33,21 @@ public final class Response<T> {
   }
 
   /**
+   * Create a synthetic successful response using {@code headers} with {@code body} as the
+   * deserialized body.
+   */
+  public static <T> Response<T> success(T body, Headers headers) {
+    if (headers == null) throw new NullPointerException("headers == null");
+    return success(body, new okhttp3.Response.Builder() //
+        .code(200)
+        .message("OK")
+        .protocol(Protocol.HTTP_1_1)
+        .headers(headers)
+        .request(new Request.Builder().url("http://localhost").build())
+        .build());
+  }
+
+  /**
    * Create a successful response from {@code rawResponse} with {@code body} as the deserialized
    * body.
    */

--- a/retrofit/src/test/java/retrofit2/ResponseTest.java
+++ b/retrofit/src/test/java/retrofit2/ResponseTest.java
@@ -57,12 +57,13 @@ public final class ResponseTest {
 
   @Test public void successWithHeaders() {
     Object body = new Object();
-    Response<Object> response = Response.success(body, Headers.of("foo", "bar"));
+    Headers headers = Headers.of("foo", "bar");
+    Response<Object> response = Response.success(body, headers);
     assertThat(response.raw()).isNotNull();
     assertThat(response.code()).isEqualTo(200);
     assertThat(response.message()).isEqualTo("OK");
     assertThat(response.headers().size()).isEqualTo(1);
-    assertThat(response.headers().get("foo")).isEqualTo("bar");
+    assertThat(response.headers().get("foo")).isSameAs("bar");
     assertThat(response.isSuccess()).isTrue();
     assertThat(response.body()).isSameAs(body);
     assertThat(response.errorBody()).isNull();

--- a/retrofit/src/test/java/retrofit2/ResponseTest.java
+++ b/retrofit/src/test/java/retrofit2/ResponseTest.java
@@ -15,6 +15,7 @@
  */
 package retrofit2;
 
+import okhttp3.Headers;
 import okhttp3.Protocol;
 import okhttp3.ResponseBody;
 import org.junit.Test;
@@ -54,6 +55,28 @@ public final class ResponseTest {
     assertThat(response.body()).isNull();
   }
 
+  @Test public void successWithHeaders() {
+    Object body = new Object();
+    Response<Object> response = Response.success(body, Headers.of("foo", "bar"));
+    assertThat(response.raw()).isNotNull();
+    assertThat(response.code()).isEqualTo(200);
+    assertThat(response.message()).isEqualTo("OK");
+    assertThat(response.headers().size()).isEqualTo(1);
+    assertThat(response.headers().get("foo")).isEqualTo("bar");
+    assertThat(response.isSuccess()).isTrue();
+    assertThat(response.body()).isSameAs(body);
+    assertThat(response.errorBody()).isNull();
+  }
+
+  @Test public void succesWithNullHeadersThrows() {
+    try {
+      Response.success("", (okhttp3.Headers) null);
+      fail();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("headers == null");
+    }
+  }
+
   @Test public void successWithRawResponse() {
     Object body = new Object();
     Response<Object> response = Response.success(body, successResponse);
@@ -68,7 +91,7 @@ public final class ResponseTest {
 
   @Test public void successWithNullRawResponseThrows() {
     try {
-      Response.success("", null);
+      Response.success("", (okhttp3.Response) null);
       fail();
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("rawResponse == null");


### PR DESCRIPTION
**Note:** I had to add an explicit cast to `successWithNullRawResponseThrows()` in `ResponseTest`.