### PR TITLE
Bumped Jackson to current version 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- Converter Dependencies -->
     <gson.version>2.6.1</gson.version>
     <protobuf.version>2.5.0</protobuf.version>
-    <jackson.version>2.4.3</jackson.version>
+    <jackson.version>2.7.1</jackson.version>
     <wire.version>2.1.0</wire.version>
     <simplexml.version>2.7.1</simplexml.version>
     <moshi.version>1.1.0</moshi.version>


### PR DESCRIPTION
This is needed to Support multiple names for the same class on Subtypes.

See https://github.com/FasterXML/jackson-databind/issues/1139 for more details and code samples