### PR TITLE
Make build pass on Windows

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -4,7 +4,9 @@
     "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
     <module name="FileLength"/>
     <module name="FileTabCharacter"/>
 


### PR DESCRIPTION
The `NewlineAtEndOfFileCheck` uses the system's default line separator.
It's better to explicitly set it to lf.