### PR TITLE
Support for primitive return types

### DIFF
--- a/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarsConverterFactory.java
+++ b/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarsConverterFactory.java
@@ -73,28 +73,28 @@ public final class ScalarsConverterFactory extends Converter.Factory {
     if (type == String.class) {
       return StringResponseBodyConverter.INSTANCE;
     }
-    if (type == Boolean.class) {
+    if (type == Boolean.class || type == boolean.class) {
       return BooleanResponseBodyConverter.INSTANCE;
     }
-    if (type == Byte.class) {
+    if (type == Byte.class || type == byte.class) {
       return ByteResponseBodyConverter.INSTANCE;
     }
-    if (type == Character.class) {
+    if (type == Character.class || type == char.class) {
       return CharacterResponseBodyConverter.INSTANCE;
     }
-    if (type == Double.class) {
+    if (type == Double.class || type == double.class) {
       return DoubleResponseBodyConverter.INSTANCE;
     }
-    if (type == Float.class) {
+    if (type == Float.class || type == float.class) {
       return FloatResponseBodyConverter.INSTANCE;
     }
-    if (type == Integer.class) {
+    if (type == Integer.class || type == int.class) {
       return IntegerResponseBodyConverter.INSTANCE;
     }
-    if (type == Long.class) {
+    if (type == Long.class || type == long.class) {
       return LongResponseBodyConverter.INSTANCE;
     }
-    if (type == Short.class) {
+    if (type == Short.class || type == short.class) {
       return ShortResponseBodyConverter.INSTANCE;
     }
     return null;

--- a/retrofit-converters/scalars/src/test/java/retrofit2/converter/scalars/ScalarsConverterPrimitivesFactoryTest.java
+++ b/retrofit-converters/scalars/src/test/java/retrofit2/converter/scalars/ScalarsConverterPrimitivesFactoryTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.converter.scalars;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import retrofit2.Call;
+import retrofit2.CallAdapter;
+import retrofit2.Retrofit;
+import retrofit2.converter.scalars.ScalarsConverterFactory;
+import retrofit2.http.GET;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public final class ScalarsConverterPrimitivesFactoryTest {
+  interface Service {
+      @GET("/") Object object();
+
+      @GET("/") String stringObject();
+
+      @GET("/") boolean booleanPrimitive();
+      @GET("/") byte bytePrimitive();
+      @GET("/") char charPrimitive();
+      @GET("/") double doublePrimitive();
+      @GET("/") float floatPrimitive();
+      @GET("/") int integerPrimitive();
+      @GET("/") long longPrimitive();
+      @GET("/") short shortPrimitive();
+
+      @GET("/") Boolean booleanObject();
+      @GET("/") Byte byteObject();
+      @GET("/") Character charObject();
+      @GET("/") Double doubleObject();
+      @GET("/") Float floatObject();
+      @GET("/") Integer integerObject();
+      @GET("/") Long longObject();
+      @GET("/") Short shortObject();
+  }
+
+  static class DirectCallIOException extends RuntimeException {
+  
+	  DirectCallIOException(IOException e) {
+    	  super(e);
+      }
+  }
+  
+  static class DirectCallAdapterFactory extends CallAdapter.Factory {
+
+	@Override
+	public CallAdapter<?> get( final Type returnType, Annotation[] annotations, Retrofit retrofit )
+	{
+		return new CallAdapter()
+		{
+
+			@Override
+			public Type responseType()
+			{
+				return returnType;
+			}
+
+			@Override
+			public Object adapt( Call call )
+			{
+				try {
+					return call.execute().body();
+				}
+				catch( final IOException e ) {
+					throw new DirectCallIOException( e );
+				}
+			}
+		};
+	}}
+  
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  private Service service;
+
+  @Before public void setUp() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(ScalarsConverterFactory.create())
+        .addCallAdapterFactory( new DirectCallAdapterFactory() )
+        .build();
+    service = retrofit.create(Service.class);
+  }
+
+  @Test public void unsupportedResponseTypesNotMatched() {
+    try {
+      service.object();
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(""
+          + "Unable to create converter for class java.lang.Object\n"
+          + "    for method Service.object");
+      assertThat(e.getCause()).hasMessage(""
+          + "Could not locate ResponseBody converter for class java.lang.Object.\n"
+          + "  Tried:\n"
+          + "   * retrofit2.BuiltInConverters\n"
+          + "   * retrofit2.converter.scalars.ScalarsConverterFactory");
+    }
+  }
+
+  @Test public void supportedResponseTypes() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setBody("true"));
+    boolean booleanResponse = service.booleanPrimitive();
+    assertThat(booleanResponse).isTrue();
+
+    server.enqueue(new MockResponse().setBody("5"));
+    byte byteResponse = service.bytePrimitive();
+    assertThat(byteResponse).isEqualTo((byte) 5);
+
+    server.enqueue(new MockResponse().setBody("b"));
+    char characterResponse = service.charPrimitive();
+    assertThat(characterResponse).isEqualTo('b');
+
+    server.enqueue(new MockResponse().setBody(""));
+    try {
+      service.charPrimitive();
+    } catch (DirectCallIOException e) {
+      assertThat(e).hasMessageEndingWith("Expected body of length 1 for Character conversion but was 0");
+    }
+
+    server.enqueue(new MockResponse().setBody("bb"));
+    try {
+      service.charPrimitive();
+    } catch (DirectCallIOException e) {
+      assertThat(e).hasMessageEndingWith("Expected body of length 1 for Character conversion but was 2");
+    }
+
+    server.enqueue(new MockResponse().setBody("13.13"));
+    double doubleResponse = service.doublePrimitive();
+    assertThat(doubleResponse).isEqualTo(13.13);
+
+    server.enqueue(new MockResponse().setBody("13.13"));
+    float floatResponse = service.floatPrimitive();
+    assertThat(floatResponse).isEqualTo(13.13f);
+
+    server.enqueue(new MockResponse().setBody("13"));
+    int integerResponse = service.integerPrimitive();
+    assertThat(integerResponse).isEqualTo(13);
+
+    server.enqueue(new MockResponse().setBody("1347"));
+    long longResponse = service.longPrimitive();
+    assertThat(longResponse).isEqualTo(1347L);
+
+    server.enqueue(new MockResponse().setBody("134"));
+    short shortResponse = service.shortPrimitive();
+    assertThat(shortResponse).isEqualTo((short) 134);
+  }
+
+  @Test public void supportedObjectResponseTypes() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setBody("test"));
+    String stringResponse = service.stringObject();
+    assertThat(stringResponse).isEqualTo("test");
+
+    server.enqueue(new MockResponse().setBody("true"));
+    Boolean booleanResponse = service.booleanObject();
+    assertThat(booleanResponse).isTrue();
+
+    server.enqueue(new MockResponse().setBody("5"));
+    Byte byteResponse = service.byteObject();
+    assertThat(byteResponse).isEqualTo((byte) 5);
+
+    server.enqueue(new MockResponse().setBody("b"));
+    Character characterResponse = service.charObject();
+    assertThat(characterResponse).isEqualTo('b');
+
+    server.enqueue(new MockResponse().setBody(""));
+    try {
+      service.charObject();
+    } catch (DirectCallIOException e) {
+      assertThat(e).hasMessageEndingWith("Expected body of length 1 for Character conversion but was 0");
+    }
+
+    server.enqueue(new MockResponse().setBody("bb"));
+    try {
+      service.charObject();
+    } catch (DirectCallIOException e) {
+      assertThat(e).hasMessageEndingWith("Expected body of length 1 for Character conversion but was 2");
+    }
+
+    server.enqueue(new MockResponse().setBody("13.13"));
+    Double doubleResponse = service.doubleObject();
+    assertThat(doubleResponse).isEqualTo(13.13);
+
+    server.enqueue(new MockResponse().setBody("13.13"));
+    Float floatResponse = service.floatObject();
+    assertThat(floatResponse).isEqualTo(13.13f);
+
+    server.enqueue(new MockResponse().setBody("13"));
+    Integer integerResponse = service.integerObject();
+    assertThat(integerResponse).isEqualTo(13);
+
+    server.enqueue(new MockResponse().setBody("1347"));
+    Long longResponse = service.longObject();
+    assertThat(longResponse).isEqualTo(1347L);
+
+    server.enqueue(new MockResponse().setBody("134"));
+    Short shortResponse = service.shortObject();
+    assertThat(shortResponse).isEqualTo((short) 134);
+  }
+
+}


### PR DESCRIPTION
If the Call pattern was not used, methods like

	@GET("...") int getValue()

were not handled properly.