### PR TITLE
Propagate callback executor even when not explicitly specified.

### DIFF
--- a/retrofit/src/main/java/retrofit2/Platform.java
+++ b/retrofit/src/main/java/retrofit2/Platform.java
@@ -53,6 +53,10 @@ class Platform {
     return new Platform();
   }
 
+  Executor defaultCallbackExecutor() {
+    return null;
+  }
+
   CallAdapter.Factory defaultCallAdapterFactory(Executor callbackExecutor) {
     if (callbackExecutor != null) {
       return new ExecutorCallAdapterFactory(callbackExecutor);
@@ -89,10 +93,11 @@ class Platform {
   }
 
   static class Android extends Platform {
+    @Override public Executor defaultCallbackExecutor() {
+      return new MainThreadExecutor();
+    }
+
     @Override CallAdapter.Factory defaultCallAdapterFactory(Executor callbackExecutor) {
-      if (callbackExecutor == null) {
-        callbackExecutor = new MainThreadExecutor();
-      }
       return new ExecutorCallAdapterFactory(callbackExecutor);
     }
 
@@ -106,10 +111,11 @@ class Platform {
   }
 
   static class IOS extends Platform {
+    @Override public Executor defaultCallbackExecutor() {
+      return new MainThreadExecutor();
+    }
+
     @Override CallAdapter.Factory defaultCallAdapterFactory(Executor callbackExecutor) {
-      if (callbackExecutor == null) {
-        callbackExecutor = new MainThreadExecutor();
-      }
       return new ExecutorCallAdapterFactory(callbackExecutor);
     }
 

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1156,11 +1157,24 @@ public final class RetrofitTest {
     }
   }
 
-  @Test public void callbackExecutorNoDefault() {
+  @Test public void callbackExecutorPropagatesDefaultJvm() {
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl("http://example.com/")
         .build();
     assertThat(retrofit.callbackExecutor()).isNull();
+  }
+
+  @Test public void callbackExecutorPropagatesDefaultAndroid() {
+    final Executor executor = Executors.newSingleThreadExecutor();
+    Platform platform = new Platform() {
+      @Override Executor defaultCallbackExecutor() {
+        return executor;
+      }
+    };
+    Retrofit retrofit = new Retrofit.Builder(platform)
+        .baseUrl("http://example.com/")
+        .build();
+    assertThat(retrofit.callbackExecutor()).isSameAs(executor);
   }
 
   @Test public void callbackExecutorPropagated() {


### PR DESCRIPTION
This lets custom CallAdapter implementations use the platform default for their callbacks.

Closes #1632.