### PR TITLE
Add body/part/partmap option to pass nulls to underlying converter.

### DIFF
--- a/retrofit-converters/gson/src/test/java/retrofit2/converter/gson/GsonConverterFactoryTest.java
+++ b/retrofit-converters/gson/src/test/java/retrofit2/converter/gson/GsonConverterFactoryTest.java
@@ -78,7 +78,7 @@ public final class GsonConverterFactoryTest {
   }
 
   interface Service {
-    @POST("/") Call<AnImplementation> anImplementation(@Body AnImplementation impl);
+    @POST("/") Call<AnImplementation> anImplementation(@Body(ignoreNull = false) AnImplementation impl);
     @POST("/") Call<AnInterface> anInterface(@Body AnInterface impl);
   }
 
@@ -131,6 +131,16 @@ public final class GsonConverterFactoryTest {
 
     RecordedRequest request = server.takeRequest();
     assertThat(request.getBody().readUtf8()).isEqualTo("{}"); // Null value was not serialized.
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
+  }
+
+  @Test public void serializeNull() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setBody("{}"));
+
+    service.anImplementation(null).execute();
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getBody().readUtf8()).isEqualTo("null"); // Top-level null literal.
     assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
   }
 

--- a/retrofit-converters/jackson/src/test/java/retrofit2/converter/jackson/JacksonConverterFactoryTest.java
+++ b/retrofit-converters/jackson/src/test/java/retrofit2/converter/jackson/JacksonConverterFactoryTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 import retrofit2.Call;
 import retrofit2.Response;
 import retrofit2.Retrofit;
-import retrofit2.converter.jackson.JacksonConverterFactory;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
 
@@ -102,7 +101,7 @@ public class JacksonConverterFactoryTest {
   }
 
   interface Service {
-    @POST("/") Call<AnImplementation> anImplementation(@Body AnImplementation impl);
+    @POST("/") Call<AnImplementation> anImplementation(@Body(ignoreNull = false) AnImplementation impl);
     @POST("/") Call<AnInterface> anInterface(@Body AnInterface impl);
   }
 
@@ -154,6 +153,16 @@ public class JacksonConverterFactoryTest {
     RecordedRequest request = server.takeRequest();
     // TODO figure out how to get Jackson to stop using AnInterface's serializer here.
     assertThat(request.getBody().readUtf8()).isEqualTo("{\"name\":\"value\"}");
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
+  }
+
+  @Test public void serializeNull() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setBody("{}"));
+
+    service.anImplementation(null).execute();
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getBody().readUtf8()).isEqualTo("null"); // Top-level null literal.
     assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
   }
 }

--- a/retrofit-converters/moshi/src/test/java/retrofit2/converter/moshi/MoshiConverterFactoryTest.java
+++ b/retrofit-converters/moshi/src/test/java/retrofit2/converter/moshi/MoshiConverterFactoryTest.java
@@ -79,7 +79,7 @@ public final class MoshiConverterFactoryTest {
   }
 
   interface Service {
-    @POST("/") Call<AnImplementation> anImplementation(@Body AnImplementation impl);
+    @POST("/") Call<AnImplementation> anImplementation(@Body(ignoreNull = false) AnImplementation impl);
     @POST("/") Call<AnInterface> anInterface(@Body AnInterface impl);
   }
 
@@ -150,5 +150,15 @@ public final class MoshiConverterFactoryTest {
     Response<AnImplementation> response = call2.execute();
     AnImplementation body = response.body();
     assertThat(body.theName).isEqualTo("value");
+  }
+
+  @Test public void serializeNull() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setBody("{}"));
+
+    service.anImplementation(null).execute();
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getBody().readUtf8()).isEqualTo("null"); // Top-level null literal.
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
   }
 }

--- a/retrofit-converters/protobuf/src/main/java/retrofit2/converter/protobuf/ProtoRequestBodyConverter.java
+++ b/retrofit-converters/protobuf/src/main/java/retrofit2/converter/protobuf/ProtoRequestBodyConverter.java
@@ -25,6 +25,9 @@ final class ProtoRequestBodyConverter<T extends MessageLite> implements Converte
   private static final MediaType MEDIA_TYPE = MediaType.parse("application/x-protobuf");
 
   @Override public RequestBody convert(T value) throws IOException {
+    if (value == null) {
+      throw new IllegalStateException("Unable to serialize null message.");
+    }
     byte[] bytes = value.toByteArray();
     return RequestBody.create(MEDIA_TYPE, bytes);
   }

--- a/retrofit-converters/protobuf/src/test/java/retrofit2/converter/protobuf/ProtoConverterFactoryTest.java
+++ b/retrofit-converters/protobuf/src/test/java/retrofit2/converter/protobuf/ProtoConverterFactoryTest.java
@@ -40,7 +40,7 @@ import static retrofit2.converter.protobuf.PhoneProtos.Phone;
 public final class ProtoConverterFactoryTest {
   interface Service {
     @GET("/") Call<Phone> get();
-    @POST("/") Call<Phone> post(@Body Phone impl);
+    @POST("/") Call<Phone> post(@Body(ignoreNull = false) Phone impl);
     @GET("/") Call<String> wrongClass();
     @GET("/") Call<List<String>> wrongType();
   }
@@ -129,6 +129,16 @@ public final class ProtoConverterFactoryTest {
     } catch (RuntimeException e) {
       assertThat(e.getCause()).isInstanceOf(InvalidProtocolBufferException.class)
           .hasMessageContaining("input ended unexpectedly");
+    }
+  }
+
+  @Test public void serializeNullThrows() throws IOException {
+    Call<Phone> call = service.post(null);
+    try {
+      call.execute();
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Unable to serialize null message.");
     }
   }
 }

--- a/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarRequestBodyConverter.java
+++ b/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarRequestBodyConverter.java
@@ -23,11 +23,15 @@ import retrofit2.Converter;
 final class ScalarRequestBodyConverter<T> implements Converter<T, RequestBody> {
   static final ScalarRequestBodyConverter<Object> INSTANCE = new ScalarRequestBodyConverter<>();
   private static final MediaType MEDIA_TYPE = MediaType.parse("text/plain; charset=UTF-8");
+  private static final RequestBody EMPTY_BODY = RequestBody.create(null, new byte[0]);
 
   private ScalarRequestBodyConverter() {
   }
 
   @Override public RequestBody convert(T value) throws IOException {
+    if (value == null) {
+      return EMPTY_BODY;
+    }
     return RequestBody.create(MEDIA_TYPE, String.valueOf(value));
   }
 }

--- a/retrofit-converters/scalars/src/test/java/retrofit2/converter/scalars/ScalarsConverterFactoryTest.java
+++ b/retrofit-converters/scalars/src/test/java/retrofit2/converter/scalars/ScalarsConverterFactoryTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import retrofit2.Call;
 import retrofit2.Response;
 import retrofit2.Retrofit;
-import retrofit2.converter.scalars.ScalarsConverterFactory;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
@@ -38,7 +37,7 @@ public final class ScalarsConverterFactoryTest {
   interface Service {
       @POST("/") Call<ResponseBody> object(@Body Object body);
 
-      @POST("/") Call<ResponseBody> stringObject(@Body String body);
+      @POST("/") Call<ResponseBody> stringObject(@Body(ignoreNull = false) String body);
       @POST("/") Call<ResponseBody> booleanPrimitive(@Body boolean body);
       @POST("/") Call<ResponseBody> booleanObject(@Body Boolean body);
       @POST("/") Call<ResponseBody> bytePrimitive(@Body byte body);
@@ -95,6 +94,14 @@ public final class ScalarsConverterFactoryTest {
           + "   * retrofit2.BuiltInConverters\n"
           + "   * retrofit2.converter.scalars.ScalarsConverterFactory");
     }
+  }
+
+  @Test public void serializeNullToEmptyBody() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse());
+    service.stringObject(null).execute();
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeader("Content-Type")).isNull();
+    assertThat(request.getBody().size()).isZero();
   }
 
   @Test public void supportedRequestTypes() throws IOException, InterruptedException {

--- a/retrofit-converters/simplexml/src/main/java/retrofit2/converter/simplexml/SimpleXmlRequestBodyConverter.java
+++ b/retrofit-converters/simplexml/src/main/java/retrofit2/converter/simplexml/SimpleXmlRequestBodyConverter.java
@@ -34,6 +34,9 @@ final class SimpleXmlRequestBodyConverter<T> implements Converter<T, RequestBody
   }
 
   @Override public RequestBody convert(T value) throws IOException {
+    if (value == null) {
+      throw new IllegalStateException("Unable to serialize null object.");
+    }
     Buffer buffer = new Buffer();
     try {
       OutputStreamWriter osw = new OutputStreamWriter(buffer.outputStream(), CHARSET);

--- a/retrofit-converters/simplexml/src/test/java/retrofit2/converter/simplexml/SimpleXmlConverterFactoryTest.java
+++ b/retrofit-converters/simplexml/src/test/java/retrofit2/converter/simplexml/SimpleXmlConverterFactoryTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.fail;
 public class SimpleXmlConverterFactoryTest {
   interface Service {
     @GET("/") Call<MyObject> get();
-    @POST("/") Call<MyObject> post(@Body MyObject impl);
+    @POST("/") Call<MyObject> post(@Body(ignoreNull = false) MyObject impl);
     @GET("/") Call<String> wrongClass();
   }
 
@@ -97,6 +97,16 @@ public class SimpleXmlConverterFactoryTest {
       fail();
     } catch (RuntimeException e) {
       assertThat(e).hasMessage("Could not deserialize body as class java.lang.String");
+    }
+  }
+
+  @Test public void serializeNullThrows() throws IOException {
+    Call<MyObject> call = service.post(null);
+    try {
+      call.execute();
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Unable to serialize null object.");
     }
   }
 }

--- a/retrofit-converters/wire/src/main/java/retrofit2/converter/wire/WireRequestBodyConverter.java
+++ b/retrofit-converters/wire/src/main/java/retrofit2/converter/wire/WireRequestBodyConverter.java
@@ -33,6 +33,9 @@ final class WireRequestBodyConverter<T extends Message<T, ?>> implements Convert
   }
 
   @Override public RequestBody convert(T value) throws IOException {
+    if (value == null) {
+      throw new IllegalStateException("Unable to serialize null message.");
+    }
     Buffer buffer = new Buffer();
     adapter.encode(buffer, value);
     return RequestBody.create(MEDIA_TYPE, buffer.snapshot());

--- a/retrofit-converters/wire/src/test/java/retrofit2/converter/wire/WireConverterFactoryTest.java
+++ b/retrofit-converters/wire/src/test/java/retrofit2/converter/wire/WireConverterFactoryTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.fail;
 public final class WireConverterFactoryTest {
   interface Service {
     @GET("/") Call<Phone> get();
-    @POST("/") Call<Phone> post(@Body Phone impl);
+    @POST("/") Call<Phone> post(@Body(ignoreNull = false) Phone impl);
     @GET("/") Call<String> wrongClass();
     @GET("/") Call<List<String>> wrongType();
   }
@@ -126,6 +126,16 @@ public final class WireConverterFactoryTest {
       call.execute();
       fail();
     } catch (EOFException ignored) {
+    }
+  }
+
+  @Test public void serializeNullThrows() throws IOException {
+    Call<Phone> call = service.post(null);
+    try {
+      call.execute();
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Unable to serialize null message.");
     }
   }
 }

--- a/retrofit/src/main/java/retrofit2/Converter.java
+++ b/retrofit/src/main/java/retrofit2/Converter.java
@@ -45,6 +45,8 @@ public interface Converter<F, T> {
      * {@code type} cannot be handled by this factory. This is used to create converters for
      * response types such as {@code SimpleResponse} from a {@code Call<SimpleResponse>}
      * declaration.
+     * <p>
+     * The returned converter will never be passed a {@code null} value.
      */
     public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
         Retrofit retrofit) {
@@ -56,6 +58,8 @@ public interface Converter<F, T> {
      * {@code type} cannot be handled by this factory. This is used to create converters for types
      * specified by {@link Body @Body}, {@link Part @Part}, and {@link PartMap @PartMap}
      * values.
+     * <p>
+     * The returned converter is expected to handle {@code null} values.
      */
     public Converter<?, RequestBody> requestBodyConverter(Type type,
         Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -193,8 +193,7 @@ final class RequestBuilder {
       } else if (multipartBuilder != null) {
         body = multipartBuilder.build();
       } else if (hasBody) {
-        // Body is absent, make an empty body.
-        body = RequestBody.create(null, new byte[0]);
+        body = Utils.EMPTY_BODY;
       }
     }
 

--- a/retrofit/src/main/java/retrofit2/Utils.java
+++ b/retrofit/src/main/java/retrofit2/Utils.java
@@ -25,10 +25,13 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
+import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import okio.Buffer;
 
 final class Utils {
+  static final RequestBody EMPTY_BODY = RequestBody.create(null, new byte[0]);
+
   static <T> T checkNotNull(T object, String message) {
     if (object == null) {
       throw new NullPointerException(message);

--- a/retrofit/src/main/java/retrofit2/http/Body.java
+++ b/retrofit/src/main/java/retrofit2/http/Body.java
@@ -39,4 +39,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(PARAMETER)
 @Retention(RUNTIME)
 public @interface Body {
+  /**
+   * When true a {@code null} value will be ignored and an empty body will be used. Otherwise
+   * {@code null} will be passed to the {@link Converter} for this endpoint.
+   */
+  boolean ignoreNull() default true;
 }

--- a/retrofit/src/main/java/retrofit2/http/Part.java
+++ b/retrofit/src/main/java/retrofit2/http/Part.java
@@ -51,6 +51,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 public @interface Part {
   String value();
+
   /** The {@code Content-Transfer-Encoding} of this part. */
   String encoding() default "binary";
+
+  /**
+   * When true a {@code null} value will cause this part to be omitted. Otherwise {@code null} will
+   * be passed to the {@link Converter} for this part.
+   */
+  boolean ignoreNull() default true;
 }

--- a/retrofit/src/main/java/retrofit2/http/PartMap.java
+++ b/retrofit/src/main/java/retrofit2/http/PartMap.java
@@ -51,4 +51,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface PartMap {
   /** The {@code Content-Transfer-Encoding} of the parts. */
   String encoding() default "binary";
+
+  /**
+   * When true a {@code null} values will cause their part to be omitted. Otherwise {@code null}
+   * values will be passed to the {@link Converter} for these parts.
+   */
+  boolean ignoreNull() default true;
 }

--- a/retrofit/src/test/java/retrofit2/helpers/ToStringConverterFactory.java
+++ b/retrofit/src/test/java/retrofit2/helpers/ToStringConverterFactory.java
@@ -45,6 +45,9 @@ public class ToStringConverterFactory extends Converter.Factory {
     if (String.class.equals(type)) {
       return new Converter<String, RequestBody>() {
         @Override public RequestBody convert(String value) throws IOException {
+          if (value == null) {
+            return RequestBody.create(MEDIA_TYPE, "NULL!!!");
+          }
           return RequestBody.create(MEDIA_TYPE, value);
         }
       };


### PR DESCRIPTION
This also changes the default behavior of null passed to a body parameter to become an empty body.

Closes #1488.