### PR TITLE
Add support for OkHttp's MultipartBody.Part.

### DIFF
--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Array;
 import java.net.URI;
 import java.util.Map;
 import okhttp3.Headers;
+import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 
 import static retrofit2.Utils.checkNotNull;
@@ -217,6 +218,19 @@ abstract class ParameterHandler<T> {
         throw new RuntimeException("Unable to convert " + value + " to RequestBody", e);
       }
       builder.addPart(headers, body);
+    }
+  }
+
+  static final class RawPart extends ParameterHandler<MultipartBody.Part> {
+    static final RawPart INSTANCE = new RawPart();
+
+    private RawPart() {
+    }
+
+    @Override void apply(RequestBuilder builder, MultipartBody.Part value) throws IOException {
+      if (value != null) { // Skip null values.
+        builder.addPart(value);
+      }
     }
   }
 

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -167,6 +167,10 @@ final class RequestBuilder {
     multipartBuilder.addPart(headers, body);
   }
 
+  void addPart(MultipartBody.Part part) {
+    multipartBuilder.addPart(part);
+  }
+
   void setBody(RequestBody body) {
     this.body = body;
   }

--- a/retrofit/src/main/java/retrofit2/http/Part.java
+++ b/retrofit/src/main/java/retrofit2/http/Part.java
@@ -26,12 +26,16 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Denotes a single part of a multi-part request.
  * <p>
- * The parameter type on which this annotation exists will be processed in one of two ways:
+ * The parameter type on which this annotation exists will be processed in one of three ways:
  * <ul>
+ * <li>If the type is {@link okhttp3.MultipartBody.Part} the contents will be used directly. Omit
+ * the name from the annotation (i.e., {@code @Part MultipartBody.Part part}).</li>
  * <li>If the type is {@link okhttp3.RequestBody RequestBody} the value will be used
- * directly with its content type.</li>
+ * directly with its content type. Supply the part name in the annotation (e.g.,
+ * {@code @Part("foo") RequestBody foo}).</li>
  * <li>Other object types will be converted to an appropriate representation by using
- * {@linkplain Converter a converter}.</li>
+ * {@linkplain Converter a converter}. Supply the part name in the annotation (e.g.,
+ * {@code @Part("foo") RequestBody foo}).</li>
  * </ul>
  * <p>
  * Values may be {@code null} which will omit them from the request body.
@@ -50,7 +54,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(PARAMETER)
 @Retention(RUNTIME)
 public @interface Part {
-  String value();
+  /**
+   * The name of the part. Required for all parameter types except
+   * {@link okhttp3.MultipartBody.Part}.
+   */
+  String value() default "";
   /** The {@code Content-Transfer-Encoding} of this part. */
   String encoding() default "binary";
 }


### PR DESCRIPTION
To do this we need to make `@Part`'s value (i.e., name) optional, since `MultipartBody.Part` brings its name.

`MultipartBody.Part` is a replacement for Retrofit 1's `TypedOutput`/`TypedFile` for doing uploads of files with names.

Closes #1140. Closes #1467.