### PR TITLE
Pass the wrapped call to callbacks.

### DIFF
--- a/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
@@ -58,23 +58,23 @@ final class ExecutorCallAdapterFactory extends CallAdapter.Factory {
       if (callback == null) throw new NullPointerException("callback == null");
 
       delegate.enqueue(new Callback<T>() {
-        @Override public void onResponse(final Call<T> call, final Response<T> response) {
+        @Override public void onResponse(Call<T> call, final Response<T> response) {
           callbackExecutor.execute(new Runnable() {
             @Override public void run() {
               if (delegate.isCanceled()) {
                 // Emulate OkHttp's behavior of throwing/delivering an IOException on cancellation.
-                callback.onFailure(call, new IOException("Canceled"));
+                callback.onFailure(ExecutorCallbackCall.this, new IOException("Canceled"));
               } else {
-                callback.onResponse(call, response);
+                callback.onResponse(ExecutorCallbackCall.this, response);
               }
             }
           });
         }
 
-        @Override public void onFailure(final Call<T> call, final Throwable t) {
+        @Override public void onFailure(Call<T> call, final Throwable t) {
           callbackExecutor.execute(new Runnable() {
             @Override public void run() {
-              callback.onFailure(call, t);
+              callback.onFailure(ExecutorCallbackCall.this, t);
             }
           });
         }

--- a/retrofit/src/test/java/retrofit2/ExecutorCallAdapterFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/ExecutorCallAdapterFactoryTest.java
@@ -94,7 +94,7 @@ public final class ExecutorCallAdapterFactoryTest {
     Call<String> call = (Call<String>) adapter.adapt(originalCall);
     call.enqueue(callback);
     verify(callbackExecutor).execute(any(Runnable.class));
-    verify(callback).onResponse(originalCall, response);
+    verify(callback).onResponse(call, response);
   }
 
   @Test public void adaptedCallEnqueueUsesExecutorForFailureCallback() {
@@ -111,7 +111,7 @@ public final class ExecutorCallAdapterFactoryTest {
     call.enqueue(callback);
     verify(callbackExecutor).execute(any(Runnable.class));
     verifyNoMoreInteractions(callbackExecutor);
-    verify(callback).onFailure(originalCall, throwable);
+    verify(callback).onFailure(call, throwable);
     verifyNoMoreInteractions(callback);
   }
 


### PR DESCRIPTION
This ensures methods like `clone()` retain the correct behavior.

Closes #1716