### PR TITLE
fix Polymorph class of Jackson

### DIFF
--- a/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonConverterFactory.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonConverterFactory.java
@@ -63,8 +63,6 @@ public final class JacksonConverterFactory extends Converter.Factory {
   @Override
   public Converter<?, RequestBody> requestBodyConverter(Type type,
       Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
-    JavaType javaType = mapper.getTypeFactory().constructType(type);
-    ObjectWriter writer = mapper.writerWithType(javaType);
-    return new JacksonRequestBodyConverter<>(writer);
+    return new JacksonRequestBodyConverter<>(mapper);
   }
 }

--- a/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonConverterFactory.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonConverterFactory.java
@@ -18,7 +18,6 @@ package retrofit2.converter.jackson;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import okhttp3.RequestBody;

--- a/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonConverterFactory.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonConverterFactory.java
@@ -55,7 +55,7 @@ public final class JacksonConverterFactory extends Converter.Factory {
   public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
       Retrofit retrofit) {
     JavaType javaType = mapper.getTypeFactory().constructType(type);
-    ObjectReader reader = mapper.reader(javaType);
+    ObjectReader reader = mapper.readerFor(javaType);
     return new JacksonResponseBodyConverter<>(reader);
   }
 

--- a/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonRequestBodyConverter.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonRequestBodyConverter.java
@@ -15,6 +15,7 @@
  */
 package retrofit2.converter.jackson;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.IOException;
 import okhttp3.MediaType;
@@ -24,9 +25,9 @@ import retrofit2.Converter;
 final class JacksonRequestBodyConverter<T> implements Converter<T, RequestBody> {
   private static final MediaType MEDIA_TYPE = MediaType.parse("application/json; charset=UTF-8");
 
-  private final ObjectWriter adapter;
+  private final ObjectMapper adapter;
 
-  JacksonRequestBodyConverter(ObjectWriter adapter) {
+  JacksonRequestBodyConverter(ObjectMapper adapter) {
     this.adapter = adapter;
   }
 

--- a/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonRequestBodyConverter.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonRequestBodyConverter.java
@@ -16,7 +16,6 @@
 package retrofit2.converter.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.IOException;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;

--- a/retrofit-converters/jackson/src/test/java/retrofit2/converter/jackson/JacksonConverterFactoryPolymophTest.java
+++ b/retrofit-converters/jackson/src/test/java/retrofit2/converter/jackson/JacksonConverterFactoryPolymophTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.converter.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JacksonConverterFactoryPolymophTest {
+
+  static class AnImplementation {
+
+    private String theName;
+
+    AnImplementation() {
+    }
+
+    AnImplementation(String name) {
+      theName = name;
+    }
+
+    public String getName() {
+      return theName;
+    }
+  }
+
+  static class AChild extends AnImplementation {
+    private int age;
+
+
+    public AChild() {
+    }
+
+    public AChild(String name, int age) {
+      super(name);
+      this.age = age;
+    }
+  }
+
+
+  interface Service {
+    @POST("/")
+    Call<AnImplementation> anImplementation(@Body AnImplementation impl);
+
+    @POST("/")
+    Call<AChild> anChildOfImplementation(@Body AnImplementation impl);
+  }
+
+  @Rule
+  public final MockWebServer server = new MockWebServer();
+
+  private Service service;
+
+  @Before
+  public void setUp() {
+    ObjectMapper mapper = new ObjectMapper();
+
+    mapper.configure(MapperFeature.AUTO_DETECT_GETTERS, false);
+    mapper.configure(MapperFeature.AUTO_DETECT_SETTERS, false);
+    mapper.configure(MapperFeature.AUTO_DETECT_IS_GETTERS, false);
+    mapper.setVisibility(mapper.getSerializationConfig()
+        .getDefaultVisibilityChecker()
+        .withFieldVisibility(JsonAutoDetect.Visibility.ANY));
+
+
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(JacksonConverterFactory.create(mapper))
+        .build();
+    service = retrofit.create(Service.class);
+  }
+
+
+  @Test public void anImplementation() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setBody("{\"theName\":\"value\"}"));
+
+    Call<AnImplementation> call = service.anImplementation(new AnImplementation("value"));
+    Response<AnImplementation> response = call.execute();
+    AnImplementation body = response.body();
+    assertThat(body.theName).isEqualTo("value");
+
+    RecordedRequest request = server.takeRequest();
+    // TODO figure out how to get Jackson to stop using AnInterface's serializer here.
+    assertThat(request.getBody().readUtf8()).isEqualTo("{\"theName\":\"value\"}");
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
+  }
+
+  @Test public void anChildOfImplementation() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setBody("{\"theName\":\"value\", \"age\":10}}"));
+
+    Call<AChild> call = service.anChildOfImplementation(new AChild("value", 10));
+    Response<AChild> response = call.execute();
+    AChild body = response.body();
+    assertThat(body.getName()).isEqualTo("value");
+    assertThat(body.age).isEqualTo(10);
+
+    RecordedRequest request = server.takeRequest();
+    // TODO figure out how to get Jackson to stop using AnInterface's serializer here.
+    assertThat(request.getBody().readUtf8()).isEqualTo("{\"theName\":\"value\",\"age\":10}");
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/json; charset=UTF-8");
+  }
+
+}


### PR DESCRIPTION
If request body is defined super class and actual body is child,
then request body is always serialized of super.
so I change to object-mapper from object-writer in converter-jackson

ex)
```java
class A { String name; }
class B extends A { int age; }

interface Service {
  Call<B> b(A a);
}
```

If I request like this
`Service.b(new B("steve", 10));`
then it was like this
```json
//expect
{"name":"steve","age":10}

// actual
{"name":"steve"}
```


It was occured by ObjectWriter.
so I change to use ObjectMapper.