### PR TITLE
Don't create gson converters for scalars

### DIFF
--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonConverterFactory.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonConverterFactory.java
@@ -60,14 +60,52 @@ public final class GsonConverterFactory extends Converter.Factory {
   @Override
   public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
       Retrofit retrofit) {
-    TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
-    return new GsonResponseBodyConverter<>(gson, adapter);
+    if (type != String.class
+        && type != boolean.class
+        && type != Boolean.class
+        && type != byte.class
+        && type != Byte.class
+        && type != char.class
+        && type != Character.class
+        && type != double.class
+        && type != Double.class
+        && type != float.class
+        && type != Float.class
+        && type != int.class
+        && type != Integer.class
+        && type != long.class
+        && type != Long.class
+        && type != short.class
+        && type != Short.class) {
+      TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
+      return new GsonResponseBodyConverter<>(gson, adapter);
+    }
+    return null;
   }
 
   @Override
   public Converter<?, RequestBody> requestBodyConverter(Type type,
       Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
-    TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
-    return new GsonRequestBodyConverter<>(gson, adapter);
+    if (type != String.class
+        && type != boolean.class
+        && type != Boolean.class
+        && type != byte.class
+        && type != Byte.class
+        && type != char.class
+        && type != Character.class
+        && type != double.class
+        && type != Double.class
+        && type != float.class
+        && type != Float.class
+        && type != int.class
+        && type != Integer.class
+        && type != long.class
+        && type != Long.class
+        && type != short.class
+        && type != Short.class) {
+      TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
+      return new GsonRequestBodyConverter<>(gson, adapter);
+    }
+    return null;
   }
 }


### PR DESCRIPTION
Using a gson converter on scalar types is almost universally an error since serializing them results in invalid JSON.  By not creating gson converters for the scalar types, code will fail faster and the error will (hopefully) be more discoverable.

Inspired by this question -- https://github.com/square/retrofit/issues/1786.  