### PR TITLE
@JSON annotation

### DIFF
--- a/retrofit/src/main/java/retrofit2/JSONBody.java
+++ b/retrofit/src/main/java/retrofit2/JSONBody.java
@@ -1,0 +1,80 @@
+package retrofit2;
+
+import java.io.IOException;
+
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import okio.Buffer;
+import okio.BufferedSink;
+
+public class JSONBody extends RequestBody {
+  
+  private static final MediaType CONTENT_TYPE =
+      MediaType.parse("application/json");
+  private String jsonString;
+  
+  private JSONBody(String jsonString) {
+    this.jsonString = jsonString;
+  }
+
+  @Override
+  public MediaType contentType() {
+    return CONTENT_TYPE;
+  }
+
+  @Override public long contentLength() {
+    return writeOrCountBytes(null, true);
+  }
+
+  @Override public void writeTo(BufferedSink sink) throws IOException {
+    writeOrCountBytes(sink, false);
+  }
+
+  /**
+   * Either writes this request to {@code sink} or measures its content length. We have one method
+   * do double-duty to make sure the counting and content are consistent, particularly when it comes
+   * to awkward operations like measuring the encoded length of header strings, or the
+   * length-in-digits of an encoded integer.
+   */
+  private long writeOrCountBytes(BufferedSink sink, boolean countBytes) {
+    long byteCount = 0L;
+
+    Buffer buffer;
+    if (countBytes) {
+      buffer = new Buffer();
+    } else {
+      buffer = sink.buffer();
+    }
+
+    buffer.writeUtf8(jsonString);
+
+    if (countBytes) {
+      byteCount = buffer.size();
+      buffer.clear();
+    }
+
+    return byteCount;
+  }
+  
+  public static final class Builder {
+    private String jsonString;
+
+    /**
+     * Sets the JSON string to be used for the JSONBody.
+     * @param jsonString
+     */
+    public void setJSONString(String jsonString) {
+      if (jsonString == null) {
+        throw new IllegalArgumentException("jsonString must not be null.");
+      }
+      this.jsonString = jsonString;
+    }
+
+    public JSONBody build() {
+      if (jsonString == null) {
+        throw new IllegalStateException("No JSON string has been set");
+      }
+      return new JSONBody(jsonString);
+    }
+  }
+}

--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -18,6 +18,9 @@ package retrofit2;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
 import okhttp3.Headers;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
@@ -299,6 +302,29 @@ abstract class ParameterHandler<T> {
         throw new RuntimeException("Unable to convert " + value + " to RequestBody", e);
       }
       builder.setBody(body);
+    }
+  }
+  
+  static final class Root<T> extends ParameterHandler<T> {
+    private final String rootKey;
+    private final Converter<T, String> converter;
+    
+    Root(String rootKey, Converter<T, String> converter) {
+      this.rootKey = checkNotNull(rootKey, "root key == null");
+      this.converter = converter;
+    }
+
+    @Override void apply(RequestBuilder builder, T rootValue) throws IOException {
+      if (rootValue == null) {
+        throw new IllegalArgumentException("Root parameter value must not be null.");
+      }
+      String jsonString;
+      try {
+        jsonString = converter.convert(rootValue);
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to convert " + rootValue + " to RequestBody", e);
+      }
+      builder.setJSONRoot(this.rootKey, jsonString);
     }
   }
 }

--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -18,9 +18,6 @@ package retrofit2;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
-
 import okhttp3.Headers;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -43,10 +43,12 @@ final class RequestBuilder {
   private final boolean hasBody;
   private MultipartBody.Builder multipartBuilder;
   private FormBody.Builder formBuilder;
+  private JSONBody.Builder jsonBuilder;
   private RequestBody body;
 
   RequestBuilder(String method, HttpUrl baseUrl, String relativeUrl, Headers headers,
-      MediaType contentType, boolean hasBody, boolean isFormEncoded, boolean isMultipart) {
+      MediaType contentType, boolean hasBody, boolean isFormEncoded, boolean isMultipart,
+      boolean isJSON) {
     this.method = method;
     this.baseUrl = baseUrl;
     this.relativeUrl = relativeUrl;
@@ -65,6 +67,8 @@ final class RequestBuilder {
       // Will be set to 'body' in 'build'.
       multipartBuilder = new MultipartBody.Builder();
       multipartBuilder.setType(MultipartBody.FORM);
+    } else if (isJSON) {
+      jsonBuilder = new JSONBody.Builder();
     }
   }
 
@@ -171,6 +175,20 @@ final class RequestBuilder {
   void addPart(MultipartBody.Part part) {
     multipartBuilder.addPart(part);
   }
+  
+  void setJSON(String jsonValue) {
+    jsonBuilder.setJSONString(jsonValue);
+  }
+  
+  void setJSONRoot(String root, String jsonValue) {
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder.append("{\"");
+    stringBuilder.append(root);
+    stringBuilder.append("\":");
+    stringBuilder.append(jsonValue);
+    stringBuilder.append("}");
+    jsonBuilder.setJSONString(stringBuilder.toString());
+  }
 
   void setBody(RequestBody body) {
     this.body = body;
@@ -197,6 +215,8 @@ final class RequestBuilder {
         body = formBuilder.build();
       } else if (multipartBuilder != null) {
         body = multipartBuilder.build();
+      } else if (jsonBuilder != null) {
+        body = jsonBuilder.build();
       } else if (hasBody) {
         // Body is absent, make an empty body.
         body = RequestBody.create(null, new byte[0]);

--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -43,6 +43,7 @@ import retrofit2.http.HEAD;
 import retrofit2.http.HTTP;
 import retrofit2.http.Header;
 import retrofit2.http.HeaderMap;
+import retrofit2.http.JSON;
 import retrofit2.http.Multipart;
 import retrofit2.http.OPTIONS;
 import retrofit2.http.PATCH;
@@ -53,6 +54,7 @@ import retrofit2.http.PartMap;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
+import retrofit2.http.Root;
 import retrofit2.http.Url;
 
 /** Adapts an invocation of an interface method into an HTTP call. */
@@ -74,6 +76,7 @@ final class ServiceMethod<T> {
   private final boolean hasBody;
   private final boolean isFormEncoded;
   private final boolean isMultipart;
+  private final boolean isJSON;
   private final ParameterHandler<?>[] parameterHandlers;
 
   ServiceMethod(Builder<T> builder) {
@@ -88,13 +91,14 @@ final class ServiceMethod<T> {
     this.hasBody = builder.hasBody;
     this.isFormEncoded = builder.isFormEncoded;
     this.isMultipart = builder.isMultipart;
+    this.isJSON = builder.isJSON;
     this.parameterHandlers = builder.parameterHandlers;
   }
 
   /** Builds an HTTP request from method arguments. */
   Request toRequest(Object... args) throws IOException {
     RequestBuilder requestBuilder = new RequestBuilder(httpMethod, baseUrl, relativeUrl, headers,
-        contentType, hasBody, isFormEncoded, isMultipart);
+        contentType, hasBody, isFormEncoded, isMultipart, isJSON);
 
     @SuppressWarnings("unchecked") // It is an error to invoke a method with the wrong arg types.
     ParameterHandler<Object>[] handlers = (ParameterHandler<Object>[]) parameterHandlers;
@@ -132,6 +136,7 @@ final class ServiceMethod<T> {
     Type responseType;
     boolean gotField;
     boolean gotPart;
+    boolean gotJSON;
     boolean gotBody;
     boolean gotPath;
     boolean gotQuery;
@@ -140,6 +145,7 @@ final class ServiceMethod<T> {
     boolean hasBody;
     boolean isFormEncoded;
     boolean isMultipart;
+    boolean isJSON;
     String relativeUrl;
     Headers headers;
     MediaType contentType;
@@ -175,13 +181,17 @@ final class ServiceMethod<T> {
       }
 
       if (!hasBody) {
+        String badEncodingAnnotation = null;
         if (isMultipart) {
-          throw methodError(
-              "Multipart can only be specified on HTTP methods with request body (e.g., @POST).");
+          badEncodingAnnotation = "Multipart";
+        } else if (isFormEncoded) {
+          badEncodingAnnotation = "FormUrlEncoded";
+        } else if (isJSON) {
+          badEncodingAnnotation = "JSON";
         }
-        if (isFormEncoded) {
-          throw methodError("FormUrlEncoded can only be specified on HTTP methods with "
-              + "request body (e.g., @POST).");
+        if (badEncodingAnnotation != null) {
+          throw methodError(badEncodingAnnotation + " can only be specified on HTTP methods with "
+            + "request body (e.g., @POST).");
         }
       }
 
@@ -213,6 +223,9 @@ final class ServiceMethod<T> {
       }
       if (isMultipart && !gotPart) {
         throw methodError("Multipart method must contain at least one @Part.");
+      }
+      if (isJSON && !gotJSON) {
+        throw methodError("JSON-encoded method must contain @Root.");
       }
 
       return new ServiceMethod<>(this);
@@ -263,15 +276,20 @@ final class ServiceMethod<T> {
         }
         headers = parseHeaders(headersToParse);
       } else if (annotation instanceof Multipart) {
-        if (isFormEncoded) {
+        if (isFormEncoded || isJSON) {
           throw methodError("Only one encoding annotation is allowed.");
         }
         isMultipart = true;
       } else if (annotation instanceof FormUrlEncoded) {
-        if (isMultipart) {
+        if (isMultipart || isJSON) {
           throw methodError("Only one encoding annotation is allowed.");
         }
         isFormEncoded = true;
+      } else if (annotation instanceof JSON) {
+        if (isFormEncoded || isMultipart) {
+          throw methodError("Only one encoding annotation is allowed.");
+        }
+        isJSON = true;
       }
     }
 
@@ -660,10 +678,58 @@ final class ServiceMethod<T> {
         PartMap partMap = (PartMap) annotation;
         return new ParameterHandler.PartMap<>(valueConverter, partMap.encoding());
 
+      } else if (annotation instanceof Root) {
+        Root root = (Root) annotation;
+        String rootKey = root.value();
+        
+        if (!isJSON) {
+          throw parameterError(p, "@Root parameters can only be used with JSON encoding.");
+        }
+        if (gotBody) {
+          throw parameterError(p, "@Root cannot be used with @Body method annotation.");
+        }
+        // TODO: Add test
+        if (gotJSON) {
+          throw parameterError(p, "Multiple @Root method annotations found.");
+        }
+
+        gotJSON = true;
+        gotBody = true;
+                
+        // Copied from Field implementation
+        /*
+        Class<?> rawParameterType = Utils.getRawType(type);
+        if (Iterable.class.isAssignableFrom(rawParameterType)) {
+          if (!(type instanceof ParameterizedType)) {
+            throw parameterError(p, rawParameterType.getSimpleName()
+                + " must include generic type (e.g., "
+                + rawParameterType.getSimpleName()
+                + "<String>)");
+          }
+          ParameterizedType parameterizedType = (ParameterizedType) type;
+          Type iterableType = Utils.getParameterUpperBound(0, parameterizedType);
+          Converter<?, String> converter =
+              retrofit.stringConverter(iterableType, annotations);
+          return new ParameterHandler.Root<>(rootKey, converter).iterable();
+        } else if (rawParameterType.isArray()) {
+          Class<?> arrayComponentType = boxIfPrimitive(rawParameterType.getComponentType());
+          Converter<?, String> converter =
+              retrofit.stringConverter(arrayComponentType, annotations);
+          return new ParameterHandler.Root<>(rootKey, converter).array();
+        } else {
+        */
+          Converter<?, String> converter =
+              retrofit.stringConverter(type, annotations);
+          return new ParameterHandler.Root<>(rootKey, converter);
+//        }
+        
       } else if (annotation instanceof Body) {
         if (isFormEncoded || isMultipart) {
           throw parameterError(p,
               "@Body parameters cannot be used with form or multi-part encoding.");
+        }
+        if (gotJSON) {
+          throw parameterError(p, "@Root cannot be used with @Body method annotation.");
         }
         if (gotBody) {
           throw parameterError(p, "Multiple @Body method annotations found.");

--- a/retrofit/src/main/java/retrofit2/http/JSON.java
+++ b/retrofit/src/main/java/retrofit2/http/JSON.java
@@ -1,0 +1,21 @@
+package retrofit2.http;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes that the request body is in JSON format. 
+ * Requests made with this annotation will have {@code application/json} MIME type.
+ * 
+ * A root key may be specific with {@link Root @Root}.
+ */
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface JSON {
+	
+}

--- a/retrofit/src/main/java/retrofit2/http/Root.java
+++ b/retrofit/src/main/java/retrofit2/http/Root.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.http;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Denotes the root key of a JSON request.
+ * <p>
+ * Simple Example:
+ * <pre><code>
+ * &#64;JSON
+ * &#64;POST("/")
+ * Call&lt;ResponseBody&gt; example(
+ *     &#64;Root("name") String yourName);
+ * </code></pre>
+ * Calling with {@code foo.example("Bob Smith")} yields a request body of
+ * <code>{name=>"Bob Smith"}</code>.
+ * <p>
+ * Array Example:
+ * <pre><code>
+ * &#64;JSON
+ * &#64;POST("/")
+ * Call&lt;ResponseBody&gt; example(
+ *     &#64;Root("name") List<String> names);
+ * </code></pre>
+ * Calling with {@code foo.example("Bob Smith", "Jane Doe")} yields a request body of
+ * <code>{name=>["Bob Smith", "Jane Doe"]}</code>.
+ * @see JSON
+ */
+@Documented
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface Root {
+  /**
+   * The value of the JSON root.
+   * Results in {"value" : object}
+   */
+  String value();
+}

--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -47,6 +47,7 @@ import retrofit2.http.HTTP;
 import retrofit2.http.Header;
 import retrofit2.http.HeaderMap;
 import retrofit2.http.Headers;
+import retrofit2.http.JSON;
 import retrofit2.http.Multipart;
 import retrofit2.http.OPTIONS;
 import retrofit2.http.PATCH;
@@ -57,6 +58,7 @@ import retrofit2.http.PartMap;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
+import retrofit2.http.Root;
 import retrofit2.http.Url;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -118,6 +120,24 @@ public final class RequestBuilderTest {
   @Test public void onlyOneEncodingIsAllowedFormEncodingFirst() {
     class Example {
       @FormUrlEncoded //
+      @Multipart //
+      @POST("/") //
+      Call<ResponseBody> method() {
+        return null;
+      }
+    }
+    try {
+      buildRequest(Example.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(
+          "Only one encoding annotation is allowed.\n    for method Example.method");
+    }
+  }
+  
+  @Test public void onlyOneEncodingIsAllowedJSONEncodingFirst() {
+    class Example {
+      @JSON //
       @Multipart //
       @POST("/") //
       Call<ResponseBody> method() {
@@ -358,6 +378,56 @@ public final class RequestBuilderTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage("Form-encoded method must contain at least one @Field.\n    for method Example.method");
+    }
+  }
+  
+  // JSON
+  @Test public void implicitJSONEncodingByRootForbidden() {
+    class Example {
+      @POST("/") //
+      Call<ResponseBody> method(@Root("a") int a) {
+        return null;
+      }
+    }
+    try {
+      buildRequest(Example.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(
+          "@Root parameters can only be used with JSON encoding. (parameter #1)\n    for method Example.method");
+    }
+  }
+
+  @Test public void JSONEncodingFailsOnNonBodyMethod() {
+    class Example {
+      @JSON //
+      @GET("/") //
+      Call<ResponseBody> method() {
+        return null;
+      }
+    }
+    try {
+      buildRequest(Example.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(
+          "JSON can only be specified on HTTP methods with request body (e.g., @POST).\n    for method Example.method");
+    }
+  }
+
+  @Test public void JSONEncodingFailsWithNoParts() {
+    class Example {
+      @JSON //
+      @POST("/") //
+      Call<ResponseBody> method() {
+        return null;
+      }
+    }
+    try {
+      buildRequest(Example.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("JSON-encoded method must contain @Root.\n    for method Example.method");
     }
   }
 
@@ -660,6 +730,41 @@ public final class RequestBuilderTest {
           "Multiple @Body method annotations found. (parameter #2)\n    for method Example.method");
     }
   }
+  
+  @Test public void bodyAndRoot() {
+    class Example {
+      @JSON
+      @POST("/") //
+      Call<ResponseBody> method(@Body String o1, @Root("key") String o2) {
+        return null;
+      }
+    }
+    try {
+      buildRequest(Example.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(
+          "@Root cannot be used with @Body method annotation. (parameter #2)\n    for method Example.method");
+    }
+  }
+  
+  @Test public void rootAndBody() {
+    class Example {
+      @JSON
+      @POST("/") //
+      Call<ResponseBody> method(@Root("key") String o1, @Body String o2) {
+        return null;
+      }
+    }
+    try {
+      buildRequest(Example.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(
+          "@Root cannot be used with @Body method annotation. (parameter #2)\n    for method Example.method");
+    }
+  }
+
 
   @Test public void bodyInNonBodyRequest() {
     class Example {
@@ -2121,7 +2226,7 @@ public final class RequestBuilderTest {
     Request request = buildRequest(Example.class, "bar", null, "kat");
     assertBody(request.body(), "foo=bar&kit=kat");
   }
-
+  
   @Test public void formEncodedFieldList() {
     class Example {
       @FormUrlEncoded //
@@ -2163,7 +2268,7 @@ public final class RequestBuilderTest {
     Request request = buildRequest(Example.class, values, "kat");
     assertBody(request.body(), "foo=1&foo=2&foo=3&kit=kat");
   }
-
+  
   @Test public void formEncodedWithEncodedNameFieldParamMap() {
     class Example {
       @FormUrlEncoded //
@@ -2294,6 +2399,143 @@ public final class RequestBuilderTest {
     request.body().writeTo(buffer);
     assertThat(buffer.readUtf8()).isEqualTo("hello=world");
   }
+  
+  // JSON Tests
+  
+  @Test public void rootJSONString() {
+    class Example {
+      @JSON //
+      @POST("/foo") //
+      Call<ResponseBody> method(@Root("key-foo") String bar) {
+        return null;
+      }
+    }
+    Request request = buildRequest(Example.class, "bar");
+    assertBody(request.body(), "{\"key-foo\":bar}");
+  }
+
+  @Test public void rootJSONList() {
+    class Example {
+      @JSON //
+      @POST("/foo") //
+      Call<ResponseBody> method(@Root("key-foo") List<Object> fields) {
+        return null;
+      }
+    }
+
+    // null?
+    List<Object> values = Arrays.<Object>asList("foo", "bar", 3);
+    Request request = buildRequest(Example.class, values);
+    assertBody(request.body(), "{\"key-foo\":[foo, bar, 3]}");
+  }
+
+  @Test public void rootJSONArray() {
+    class Example {
+      @JSON //
+      @POST("/foo") //
+      Call<ResponseBody> method(@Root("key-foo") Object[] fields) {
+        return null;
+      }
+    }
+
+    Object[] values = { 1, 2, "three" };
+    Request request = buildRequest(Example.class, values);
+    assertBody(request.body(), "{\"key-foo\":[1,2,\"three\"]}");
+  }
+
+  @Test public void rootJSONPrimitiveArray() {
+    class Example {
+      @JSON //
+      @POST("/foo") //
+      Call<ResponseBody> method(@Root("key-foo") int[] fields) {
+        return null;
+      }
+    }
+
+    int[] values = { 1, 2, 3 };
+    Request request = buildRequest(Example.class, values);
+    assertBody(request.body(), "{\"key-foo\":[1,2,3]}");
+  }
+  
+  @Test public void rootJSONMap() {
+    class Example {
+      @JSON //
+      @POST("/foo") //
+      Call<ResponseBody> method(@Root("key-bar") Map<String, Object> map) {
+        return null;
+      }
+    }
+
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("kit", "kat");
+    map.put("ping", "pong");
+
+    Request request = buildRequest(Example.class, map);
+//    assertBody(request.body(), "{\"key-bar\":{\"kit\":\"kat\",\"ping\":\"pong\"}}");
+    assertBody(request.body(), "{\"key-bar\":{kit=kat, ping=pong}}");
+}
+
+  // TODO: Maybe need these tests?
+  /*
+  @Test public void rootJSONMapRejectsNull() {
+    class Example {
+      @JSON //
+      @POST("/") //
+      Call<ResponseBody> method(@FieldMap Map<String, Object> a) {
+        return null;
+      }
+    }
+
+    try {
+      buildRequest(Example.class, new Object[] { null });
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("Field map was null.");
+    }
+  }
+
+  @Test public void fieldMapRejectsNullKeys() {
+    class Example {
+      @FormUrlEncoded //
+      @POST("/") //
+      Call<ResponseBody> method(@FieldMap Map<String, Object> a) {
+        return null;
+      }
+    }
+
+    Map<String, Object> fieldMap = new LinkedHashMap<>();
+    fieldMap.put("kit", "kat");
+    fieldMap.put(null, "pong");
+
+    try {
+      buildRequest(Example.class, fieldMap);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("Field map contained null key.");
+    }
+  }
+
+  @Test public void fieldMapRejectsNullValues() {
+    class Example {
+      @FormUrlEncoded //
+      @POST("/") //
+      Call<ResponseBody> method(@FieldMap Map<String, Object> a) {
+        return null;
+      }
+    }
+
+    Map<String, Object> fieldMap = new LinkedHashMap<>();
+    fieldMap.put("kit", "kat");
+    fieldMap.put("foo", null);
+
+    try {
+      buildRequest(Example.class, fieldMap);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("Field map contained null value for key 'foo'.");
+    }
+  }
+  */
 
   @Test public void simpleHeaders() {
     class Example {


### PR DESCRIPTION
I'm working with an JSON API which commonly uses a root key to encode a value.
A example for a login call would be:

    {"user":{ "username":Kevin,"password":"ThePassword"}}

I have added an `@JSON` tag to set `Content-Type` to `application\json` and a `@Root` tag to provide a root key for the object. My main goal is to avoid losing type information with method that just accepts a `Map` and avoid creating a bunch of dummy objects to maintain type and key information. 

The end result for sending a LoginRequest is shown below.

```java
public class LoginRequest {
    public String email;
    public String password;
}

// Before
@Headers("Content-Type: application/json")
@POST("users/sign_in.json")
Call<User> attemptLogin(@Body Map<String, LoginRequest> loginRequest);

Map<String, LoginRequest> request = new HashMap<>();
LoginRequest loginRequest = new LoginRequest("MyUsername", "MyPassword");
request.put("user", loginRequest);
attemptLogin(request)

// After
@JSON
@POST("login")
Call<User> attemptLogin(@Root("user") LoginRequest loginRequest);

LoginRequest loginRequest = new LoginRequest("MyUsername", "MyPassword");
attemptLogin(loginRequest);
```

I have only implemented having a single `@Root` key, but here is a more complicated example from the [GitHub API](https://developer.github.com/v3/git/commits/#create-a-commit) for creating a commit that would use many `@Root` keys.
```java
{
  "message": "my commit message",
  "author": {
    "name": "Scott Chacon",
    "email": "schacon@gmail.com",
    "date": "2008-07-09T16:13:30+12:00"
  },
  "parents": [
    "7d1b31e74ee336d15cbd21741bc88a537ed063a0"
  ],
  "tree": "827efc6d56897b048c772eb4087f854f46256132"
}

@JSON
@POST("login")
Call<Map<String, String> attemptLogin(
    @Root("message") String commitMessage,
    @Root("author") Author author,
    @Root("parents") List<String> parents,
    @Root("tree") String parentSHA);
```

I have added some tests and everything passes besides the C-style arrays (`rootJSONArray()` and `rootJSONPrimitiveArray()` - verified with `mvn clean verify`). I would really appreciate some assistance implementing that (as well as any other improvements). 

I realize this fork isn't ready to be merged but I wanted to get some initial feedback/assistance.