### PR TITLE
Update okhttp to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
     <!-- Dependencies -->
     <android.version>4.1.1.4</android.version>
-    <okhttp.version>3.2.0</okhttp.version>
+    <okhttp.version>3.3.0</okhttp.version>
     <animal.sniffer.version>1.14</animal.sniffer.version>
 
     <!-- Adapter Dependencies -->


### PR DESCRIPTION
Update to latest okhttp release.  Among other things, this has improved support for properly handling TrustManagers on various JVMs.