### PR TITLE
Fix test to not rely on the order

### DIFF
--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -210,8 +210,9 @@ public final class RequestBuilderTest {
       buildRequest(Example.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage(
-          "Only one HTTP method is allowed. Found: PATCH and POST.\n    for method Example.method");
+        assertThat(e.getMessage())
+            .isIn("Only one HTTP method is allowed. Found: PATCH and POST.\n    for method Example.method",
+                  "Only one HTTP method is allowed. Found: POST and PATCH.\n    for method Example.method");
     }
   }
 


### PR DESCRIPTION
The test assumes that the order in which annotations are returned by the JVM are the same across all implementations and is consistent with the declaration order; this assumption does not hold.

This fixes the assumption by allowing any of the two possible orders to appear in the exception message.