### PR TITLE
fixed test to not rely on serialization order

### DIFF
--- a/retrofit-converters/simplexml/src/test/java/retrofit2/converter/simplexml/SimpleXmlConverterFactoryTest.java
+++ b/retrofit-converters/simplexml/src/test/java/retrofit2/converter/simplexml/SimpleXmlConverterFactoryTest.java
@@ -71,8 +71,9 @@ public class SimpleXmlConverterFactoryTest {
     assertThat(body.getCount()).isEqualTo(10);
 
     RecordedRequest request = server.takeRequest();
-    assertThat(request.getBody().readUtf8()).isEqualTo(
-        "<my-object><message>hello world</message><count>10</count></my-object>");
+    assertThat(request.getBody().readUtf8()).isIn(
+        "<my-object><message>hello world</message><count>10</count></my-object>",
+        "<my-object><count>10</count><message>hello world</message></my-object>");
     assertThat(request.getHeader("Content-Type")).isEqualTo("application/xml; charset=UTF-8");
   }
 


### PR DESCRIPTION
The request's body is obtained after serializing MyObject to XML but the order in which fields are serialized is not guaranteed.
The fix is to assert that any of the two orders may result.