### PR TITLE
Avoid leak on newJsonReader exception

### DIFF
--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonResponseBodyConverter.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonResponseBodyConverter.java
@@ -18,7 +18,10 @@ package retrofit2.converter.gson;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
+
 import java.io.IOException;
+import java.io.Reader;
+
 import okhttp3.ResponseBody;
 import retrofit2.Converter;
 
@@ -32,8 +35,9 @@ final class GsonResponseBodyConverter<T> implements Converter<ResponseBody, T> {
   }
 
   @Override public T convert(ResponseBody value) throws IOException {
-    JsonReader jsonReader = gson.newJsonReader(value.charStream());
+    Reader charStream = value.charStream();
     try {
+      JsonReader jsonReader = gson.newJsonReader(charStream);
       return adapter.read(jsonReader);
     } finally {
       value.close();


### PR DESCRIPTION
#### Problem

When converting a `ResponseBody` with the `GsonResponseBodyConverter`, if `gson.newJsonReader` throws an unchecked exception (such as `NullPointerException`), the body will remain open and will never be closed.

This was introduced in 473fd2473cc41e68eb61c6d2d4316d720edd46fb.

#### Solution

Mirroring what's in `ProtoResponseBodyConverter`, I have moved the creation of the `JsonReader` inside the `try` block.
This will ensure that after opening the body stream, it will always be closed.

CLA has been signed.