### PR TITLE
headers replace just like @Path replace

### DIFF
--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -93,6 +93,25 @@ abstract class ParameterHandler<T> {
     }
   }
 
+  static final class Head<T> extends ParameterHandler<T> {
+    private final String name;
+    private final Converter<T, String> valueConverter;
+
+    Head(String name, Converter<T, String> valueConverter) {
+      this.name = checkNotNull(name, "name == null");
+      this.valueConverter = valueConverter;
+    }
+
+    @Override void apply(RequestBuilder builder, T value) throws IOException {
+      if (value == null) {
+        throw new IllegalArgumentException(
+                "Path parameter \"" + name + "\" value must not be null.");
+      }
+      builder.addHeaderParams(name, valueConverter.convert(value));
+    }
+  }
+
+
   static final class Query<T> extends ParameterHandler<T> {
     private final String name;
     private final Converter<T, String> valueConverter;

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -44,6 +44,7 @@ final class RequestBuilder {
   private MultipartBody.Builder multipartBuilder;
   private FormBody.Builder formBuilder;
   private RequestBody body;
+  private Headers.Builder mHeaders;
 
   RequestBuilder(String method, HttpUrl baseUrl, String relativeUrl, Headers headers,
       MediaType contentType, boolean hasBody, boolean isFormEncoded, boolean isMultipart) {
@@ -56,6 +57,9 @@ final class RequestBuilder {
 
     if (headers != null) {
       requestBuilder.headers(headers);
+      mHeaders = headers.newBuilder();
+    }else {
+      mHeaders = new Headers.Builder();
     }
 
     if (isFormEncoded) {
@@ -82,8 +86,31 @@ final class RequestBuilder {
       contentType = type;
     } else {
       requestBuilder.addHeader(name, value);
+      mHeaders.add(name,value);
     }
   }
+
+  void addHeaderParams(String name, String value) {
+    String partten = "{" + name + "}";
+      Headers headers = mHeaders.build();;
+      int size = headers.size();
+      Headers.Builder builder = new Headers.Builder();
+      for (int i = 0 ; i < size ; i++){
+        String itmeValue = headers.value(i);
+        String itemName = headers.name(i);
+        if(itmeValue.contains(partten)){
+          itmeValue = itmeValue.replace(partten,value);
+        }
+        if(itemName.contains(partten)){
+          itemName = itemName.replaceAll(partten,value);
+        }
+        builder.add(itemName,itmeValue);
+      }
+      mHeaders = builder;
+      requestBuilder.headers(mHeaders.build());
+
+  }
+
 
   void addPathParam(String name, String value, boolean encoded) {
     if (relativeUrl == null) {

--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -41,6 +41,7 @@ import retrofit2.http.FormUrlEncoded;
 import retrofit2.http.GET;
 import retrofit2.http.HEAD;
 import retrofit2.http.HTTP;
+import retrofit2.http.Head;
 import retrofit2.http.Header;
 import retrofit2.http.HeaderMap;
 import retrofit2.http.Multipart;
@@ -682,6 +683,12 @@ final class ServiceMethod<T> {
         }
         gotBody = true;
         return new ParameterHandler.Body<>(converter);
+      }else if (annotation instanceof Head) {
+        Head head = (Head) annotation;
+        String name = head.value();
+        Converter<?, String> converter = retrofit.stringConverter(type, annotations);
+        return new ParameterHandler.Head<>(name,converter);
+
       }
 
       return null; // Not a Retrofit annotation.

--- a/retrofit/src/main/java/retrofit2/http/Head.java
+++ b/retrofit/src/main/java/retrofit2/http/Head.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.http;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Named replacement in a header segment. Values are converted to string using
+ * {@link String#valueOf(Object)}
+ * <p>
+ * Simple example:
+ *  @Headers({"Range:byte={start}-{end}"})
+ *
+ *
+ * test(@Head("start")String start,@Head("end")String end) to replace like @Path repace.
+ *
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(PARAMETER)
+public @interface Head {
+  String value();
+
+}


### PR DESCRIPTION
here is a simple example:
@Headers({"Range:byte={start}-{end}"})
use test(@Head("start")String start,@Head("end")String end) to replace the "{start}" and "{end}"
it's just like @Path replace