### PR TITLE
Use string converter for String type.

### DIFF
--- a/retrofit/src/main/java/retrofit2/BuiltInConverters.java
+++ b/retrofit/src/main/java/retrofit2/BuiltInConverters.java
@@ -27,10 +27,9 @@ final class BuiltInConverters extends Converter.Factory {
   public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
       Retrofit retrofit) {
     if (type == ResponseBody.class) {
-      if (Utils.isAnnotationPresent(annotations, Streaming.class)) {
-        return StreamingResponseBodyConverter.INSTANCE;
-      }
-      return BufferingResponseBodyConverter.INSTANCE;
+      return Utils.isAnnotationPresent(annotations, Streaming.class)
+          ? StreamingResponseBodyConverter.INSTANCE
+          : BufferingResponseBodyConverter.INSTANCE;
     }
     if (type == Void.class) {
       return VoidResponseBodyConverter.INSTANCE;
@@ -45,22 +44,6 @@ final class BuiltInConverters extends Converter.Factory {
       return RequestBodyConverter.INSTANCE;
     }
     return null;
-  }
-
-  @Override public Converter<?, String> stringConverter(Type type, Annotation[] annotations,
-      Retrofit retrofit) {
-    if (type == String.class) {
-      return StringConverter.INSTANCE;
-    }
-    return null;
-  }
-
-  static final class StringConverter implements Converter<String, String> {
-    static final StringConverter INSTANCE = new StringConverter();
-
-    @Override public String convert(String value) throws IOException {
-      return value;
-    }
   }
 
   static final class VoidResponseBodyConverter implements Converter<ResponseBody, Void> {

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -399,11 +399,13 @@ public final class RetrofitTest {
     assertThat(annotations).hasAtLeastOneElementOfType(Annotated.Foo.class);
   }
 
-  @Test public void stringConverterNotCalledForString() {
+  @Test public void stringConverterCalledForString() {
+    final AtomicBoolean factoryCalled = new AtomicBoolean();
     class MyConverterFactory extends Converter.Factory {
       @Override public Converter<?, String> stringConverter(Type type, Annotation[] annotations,
           Retrofit retrofit) {
-        throw new AssertionError();
+        factoryCalled.set(true);
+        return null;
       }
     }
     Retrofit retrofit = new Retrofit.Builder()
@@ -413,7 +415,7 @@ public final class RetrofitTest {
     CallMethod service = retrofit.create(CallMethod.class);
     Call<ResponseBody> call = service.queryString(null);
     assertThat(call).isNotNull();
-    // We also implicitly assert the above factory was not called as it would have thrown.
+    assertThat(factoryCalled.get()).isTrue();
   }
 
   @Test public void stringConverterReturningNullResultsInDefault() {


### PR DESCRIPTION
Unlike RequestBody and ResponseBody which are library types that must be handled by default, String is a platform type and we want to offer the flexibility of doing things like using annotations to transform the contents.

Closes #1876.