### PR TITLE
Skip a UTF-8 BOM if present for the Moshi converter.

### DIFF
--- a/retrofit-converters/moshi/pom.xml
+++ b/retrofit-converters/moshi/pom.xml
@@ -23,6 +23,12 @@
       <groupId>com.squareup.moshi</groupId>
       <artifactId>moshi</artifactId>
     </dependency>
+    <!-- TODO remove this dependency once Moshi or OkHttp ships with 1.9.0 or newer. -->
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+      <version>1.9.0</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/retrofit-converters/moshi/src/main/java/retrofit2/converter/moshi/MoshiResponseBodyConverter.java
+++ b/retrofit-converters/moshi/src/main/java/retrofit2/converter/moshi/MoshiResponseBodyConverter.java
@@ -18,9 +18,13 @@ package retrofit2.converter.moshi;
 import com.squareup.moshi.JsonAdapter;
 import java.io.IOException;
 import okhttp3.ResponseBody;
+import okio.BufferedSource;
+import okio.ByteString;
 import retrofit2.Converter;
 
 final class MoshiResponseBodyConverter<T> implements Converter<ResponseBody, T> {
+  private static final ByteString UTF8_BOM = ByteString.decodeHex("EFBBBF");
+
   private final JsonAdapter<T> adapter;
 
   MoshiResponseBodyConverter(JsonAdapter<T> adapter) {
@@ -28,8 +32,14 @@ final class MoshiResponseBodyConverter<T> implements Converter<ResponseBody, T> 
   }
 
   @Override public T convert(ResponseBody value) throws IOException {
+    BufferedSource source = value.source();
     try {
-      return adapter.fromJson(value.source());
+      // Moshi has no document-level API so the responsibility of BOM skipping falls to whatever
+      // is delegating to it. Since it's a UTF-8-only library as well we only honor the UTF-8 BOM.
+      if (source.rangeEquals(0, UTF8_BOM)) {
+        source.skip(UTF8_BOM.size());
+      }
+      return adapter.fromJson(source);
     } finally {
       value.close();
     }


### PR DESCRIPTION
Refs #1875.