### PR TITLE
Removing test redundant for retrofit2.RequestBuilderTest.bodyResponseBody

### DIFF
--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -735,7 +735,7 @@ public final class RequestBuilderTest {
           "HEAD method must use Void as response type.\n    for method Example.method");
     }
   }
-
+ @Ignore
   @Test public void post() {
     class Example {
       @POST("/foo/bar/") //


### PR DESCRIPTION
We are researchers working on identifying redundant tests in a test suite. Our analysis of finding redundant tests involve each test's dynamic code coverage and their potential fault-detection capability.

Through our analysis, we found that the tests retrofit2.RequestBuilderTest.bodyResponseBody, retrofit2.RequestBuilderTest.post are redundant with respect to one another. In this pull request, we are proposing to keep only the test retrofit2.RequestBuilderTest.bodyResponseBody while adding @Ignore annotations to the remaining test. However, as we believe these tests are identical, any one of them can be kept while skipping the remaining test.

If you do not believe any of these tests should be ignored, we would greatly appreciate it if you could follow up on this pull request and let us know your reasons.