### PR TITLE
NDJSON support converter

### DIFF
--- a/retrofit-converters/ndjson/README.md
+++ b/retrofit-converters/ndjson/README.md
@@ -1,0 +1,17 @@
+NDJSON Converter
+==============
+
+A `Converter` for the [NDJSON][1] format serialization.
+There is currently no standard for transporting instances of JSON text within a stream protocol,
+apart from `Websockets`, which is unnecessarily complex for non-browser applications.
+A common use case for `NDJSON` is delivering multiple instances of JSON text through streaming
+protocols like TCP or UNIX Pipes. It can also be used to store semi-structured data.
+
+An instance of `NDJsonConverter` will be created and it will use a `ResponseBody` to create
+a `NDJsonResponse` object.
+The `NDJsonResponse` object created will split the raw content into valid `JSON` strings, that
+will be stored into an array. After that, this content can be parsed using any `JSON` parsing
+libraries into the right `DTOs` objects.
+
+
+ [1]: http://ndjson.org/

--- a/retrofit-converters/ndjson/pom.xml
+++ b/retrofit-converters/ndjson/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.squareup.retrofit2</groupId>
+        <artifactId>retrofit-converters</artifactId>
+        <version>2.1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>converter-ndjson</artifactId>
+    <name>Converter: NDJSON</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>retrofit</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/retrofit-converters/ndjson/src/main/java/retrofit2/converter/ndjson/BaseResponse.java
+++ b/retrofit-converters/ndjson/src/main/java/retrofit2/converter/ndjson/BaseResponse.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.converter.ndjson;
+
+import android.support.annotation.IntDef;
+
+import java.io.Serializable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import okio.BufferedSource;
+
+/**
+ * Base class for all responses received from the server
+ * <p>
+ * Created by Cotuna Aurelian on 7/2/2016.
+ */
+
+public class BaseResponse extends ResponseBody implements Serializable {
+    /**
+     * Flag for no response or default one
+     */
+    public static final int NO_RESPONSE = 0;
+
+    /**
+     * Flag for the NDJSON format response
+     */
+    public static final int NDJSON_RESPONSE = 1;
+
+    @IntDef({NDJSON_RESPONSE, NO_RESPONSE})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface ResponseType {
+    }
+
+    private int responseType;
+
+    /**
+     * Creates a new instance of this class, and sets it's response type to
+     * {@link #NO_RESPONSE}. The response type can be altered in the future using the
+     * {@link #setResponseType(int)} method.
+     */
+    public BaseResponse() {
+        this.responseType = NO_RESPONSE;
+    }
+
+    /**
+     * Creates a new instance of this class and sets it's response type accordingly.
+     *
+     * @param response One of the already defined response types {@link #NO_RESPONSE} or
+     *                 {@link #NDJSON_RESPONSE}
+     */
+    public BaseResponse(@ResponseType int response) {
+        this.responseType = response;
+    }
+
+    @Override
+    public MediaType contentType() {
+        return null;
+    }
+
+    @Override
+    public long contentLength() {
+        return 0;
+    }
+
+    @Override
+    public BufferedSource source() {
+        return null;
+    }
+
+    @ResponseType
+    public int getResponseType() {
+        return responseType;
+    }
+
+    public void setResponseType(@ResponseType int responseType) {
+        this.responseType = responseType;
+    }
+}

--- a/retrofit-converters/ndjson/src/main/java/retrofit2/converter/ndjson/NDJsonConverter.java
+++ b/retrofit-converters/ndjson/src/main/java/retrofit2/converter/ndjson/NDJsonConverter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package retrofit2.converter.ndjson;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+/**
+ * Converter for the new line delimited JSON format
+ * <p>
+ * <p>
+ * Created by Cotuna Aurelian on 7/2/2016.
+ */
+
+public class NDJsonConverter extends Converter.Factory implements Converter<ResponseBody, BaseResponse> {
+
+    /**
+     * Creates a new instance of this converter
+     */
+    public static NDJsonConverter newInstance() {
+        return new NDJsonConverter();
+    }
+
+    @Override
+    public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
+        return new NDJsonConverter();
+    }
+
+    @Override
+    public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations,
+                    Retrofit retrofit) {
+        return null;
+    }
+
+    @Override
+    public Converter<?, String> stringConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
+        return super.stringConverter(type, annotations, retrofit);
+    }
+
+
+    @Override
+    public BaseResponse convert(ResponseBody value) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(value.byteStream()));
+        StringBuilder responseStringBuilder = new StringBuilder();
+
+        String line = "";
+        while ((line = bufferedReader.readLine()) != null) {
+            responseStringBuilder.append(line);
+        }
+
+        //Close the buffers after we've done with them
+        bufferedReader.close();
+        value.close();
+
+        if (responseStringBuilder.toString().trim().length() == 0) {
+            //No Data received
+            return null;
+        }
+        return new NDJsonResponse(responseStringBuilder.toString());
+    }
+}

--- a/retrofit-converters/ndjson/src/main/java/retrofit2/converter/ndjson/NDJsonResponse.java
+++ b/retrofit-converters/ndjson/src/main/java/retrofit2/converter/ndjson/NDJsonResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.converter.ndjson;
+
+
+import java.io.Serializable;
+
+/**
+ * NDJSon response wrapper. This class holds accessible JSON content parts
+ * Created by Cotuna Aurelian on 7/2/2016.
+ */
+
+public class NDJsonResponse extends BaseResponse implements Serializable {
+
+    /**
+     * JSON parts from the raw content returned in the NDJSON format
+     */
+    private String[] splitJSONContent;
+
+    public NDJsonResponse(String rawContent) {
+        //We make sure that the NDJSON format is respected and there is a new line character after
+        //each part, and before the next one. We are going to split the segments of NDJSON based
+        //on that caracter
+        String filteredRawContent = rawContent.replaceAll("\\}\\s*\\{", "\\}\\%n\\{");
+
+        this.splitJSONContent = filteredRawContent.split("%n");
+        setResponseType(NDJSON_RESPONSE);
+    }
+
+    public String[] getSplitJSONContent() {
+        return splitJSONContent;
+    }
+}


### PR DESCRIPTION
Adds converter for the NDJSON format.

There is currently no standard for transporting instances of JSON text within a stream protocol, apart from `Websockets`, which is unnecessarily complex for non-browser applications.

A common use case for NDJSON is delivering multiple instances of JSON text through streaming protocols like TCP or UNIX Pipes. It can also be used to store semi-structured data.

NDJSON example
     {"some":"thing"}
     {"foo":17,"bar":false,"quux":true}
     {"may":{"include":"nested","objects":["and","arrays"]}}