### PR TITLE
Defer retrieval of Gson's TypeAdapters until convert() is called

### DIFF
--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonAdapterProvider.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonAdapterProvider.java
@@ -1,0 +1,8 @@
+package retrofit2.converter.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+
+interface GsonAdapterProvider {
+  <T> TypeAdapter<T> get(TypeToken<T> type);
+}

--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonConverterFactory.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonConverterFactory.java
@@ -60,14 +60,20 @@ public final class GsonConverterFactory extends Converter.Factory {
   @Override
   public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
       Retrofit retrofit) {
-    TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
-    return new GsonResponseBodyConverter<>(gson, adapter);
+    return new GsonResponseBodyConverter<>(gson, gsonAdapterProvider, TypeToken.get(type));
   }
 
   @Override
   public Converter<?, RequestBody> requestBodyConverter(Type type,
       Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
-    TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
-    return new GsonRequestBodyConverter<>(gson, adapter);
+    return new GsonRequestBodyConverter<>(gson, gsonAdapterProvider, TypeToken.get(type));
   }
+
+  private final GsonAdapterProvider gsonAdapterProvider = new GsonAdapterProvider() {
+    @Override
+    public <T> TypeAdapter<T> get(TypeToken<T> type) {
+      return gson.getAdapter(type);
+    }
+  };
+
 }

--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonRequestBodyConverter.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonRequestBodyConverter.java
@@ -16,7 +16,7 @@
 package retrofit2.converter.gson;
 
 import com.google.gson.Gson;
-import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -32,18 +32,20 @@ final class GsonRequestBodyConverter<T> implements Converter<T, RequestBody> {
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private final Gson gson;
-  private final TypeAdapter<T> adapter;
+  private final GsonAdapterProvider adapterProvider;
+  private final TypeToken<T> typeToken;
 
-  GsonRequestBodyConverter(Gson gson, TypeAdapter<T> adapter) {
+  GsonRequestBodyConverter(Gson gson, GsonAdapterProvider adapterProvider, TypeToken<T> typeToken) {
     this.gson = gson;
-    this.adapter = adapter;
+    this.adapterProvider = adapterProvider;
+    this.typeToken = typeToken;
   }
 
   @Override public RequestBody convert(T value) throws IOException {
     Buffer buffer = new Buffer();
     Writer writer = new OutputStreamWriter(buffer.outputStream(), UTF_8);
     JsonWriter jsonWriter = gson.newJsonWriter(writer);
-    adapter.write(jsonWriter, value);
+    adapterProvider.get(typeToken).write(jsonWriter, value);
     jsonWriter.close();
     return RequestBody.create(MEDIA_TYPE, buffer.readByteString());
   }

--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonResponseBodyConverter.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonResponseBodyConverter.java
@@ -16,7 +16,7 @@
 package retrofit2.converter.gson;
 
 import com.google.gson.Gson;
-import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import java.io.IOException;
 import okhttp3.ResponseBody;
@@ -24,17 +24,20 @@ import retrofit2.Converter;
 
 final class GsonResponseBodyConverter<T> implements Converter<ResponseBody, T> {
   private final Gson gson;
-  private final TypeAdapter<T> adapter;
+  private final GsonAdapterProvider adapterProvider;
+  private final TypeToken<T> typeToken;
 
-  GsonResponseBodyConverter(Gson gson, TypeAdapter<T> adapter) {
+  GsonResponseBodyConverter(Gson gson, GsonAdapterProvider adapterProvider,
+                            TypeToken<T> typeToken) {
     this.gson = gson;
-    this.adapter = adapter;
+    this.adapterProvider = adapterProvider;
+    this.typeToken = typeToken;
   }
 
   @Override public T convert(ResponseBody value) throws IOException {
     JsonReader jsonReader = gson.newJsonReader(value.charStream());
     try {
-      return adapter.read(jsonReader);
+      return adapterProvider.get(typeToken).read(jsonReader);
     } finally {
       value.close();
     }


### PR DESCRIPTION
Prevents Gson adapters from being created on the main thread when a client method is called from the main thread.