### PR TITLE
Implement proper error handling for Rx types.

### DIFF
--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableTest.java
@@ -16,20 +16,27 @@
 package retrofit2.adapter.rxjava;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import retrofit2.Retrofit;
 import retrofit2.http.GET;
 import rx.Completable;
+import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
+import rx.plugins.RxJavaErrorHandler;
+import rx.plugins.RxJavaPlugins;
 
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class CompletableTest {
   @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final TestRule pluginsReset = new RxJavaPluginsResetRule();
   @Rule public final RecordingSubscriber.Rule subscriberRule = new RecordingSubscriber.Rule();
 
   interface Service {
@@ -68,5 +75,57 @@ public final class CompletableTest {
     RecordingSubscriber<Void> subscriber = subscriberRule.create();
     service.completable().unsafeSubscribe(subscriber);
     subscriber.assertError(IOException.class);
+  }
+
+  @Test public void bodyThrowingInOnCompletedDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<String> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.completable().unsafeSubscribe(new ForwardingSubscriber<String>(subscriber) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    assertThat(throwableRef.get()).isSameAs(e);
+  }
+
+  @Test public void bodyThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<String> subscriber = subscriberRule.create();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final RuntimeException e = new RuntimeException();
+    service.completable().unsafeSubscribe(new ForwardingSubscriber<String>(subscriber) {
+      @Override public void onError(Throwable throwable) {
+        if (!errorRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+        throw e;
+      }
+    });
+
+    //noinspection ThrowableResultOfMethodCallIgnored
+    CompositeException composite = (CompositeException) throwableRef.get();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
   }
 }

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/ForwardingSubscriber.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/ForwardingSubscriber.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.adapter.rxjava;
+
+import rx.Subscriber;
+
+abstract class ForwardingSubscriber<T> extends Subscriber<T> {
+  private final Subscriber<T> delegate;
+
+  ForwardingSubscriber(Subscriber<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public void onNext(T value) {
+    delegate.onNext(value);
+  }
+
+  @Override public void onCompleted() {
+    delegate.onCompleted();
+  }
+
+  @Override public void onError(Throwable throwable) {
+    delegate.onError(throwable);
+  }
+}

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/ObservableTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/ObservableTest.java
@@ -16,21 +16,28 @@
 package retrofit2.adapter.rxjava;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.http.GET;
 import rx.Observable;
+import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
+import rx.plugins.RxJavaErrorHandler;
+import rx.plugins.RxJavaPlugins;
 
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class ObservableTest {
   @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final TestRule pluginsReset = new RxJavaPluginsResetRule();
   @Rule public final RecordingSubscriber.Rule subscriberRule = new RecordingSubscriber.Rule();
 
   interface Service {
@@ -89,6 +96,73 @@ public final class ObservableTest {
     assertThat(server.getRequestCount()).isEqualTo(1);
   }
 
+  @Test public void bodyThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    RecordingSubscriber<String> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.body().unsafeSubscribe(new ForwardingSubscriber<String>(subscriber) {
+      @Override public void onNext(String value) {
+        throw e;
+      }
+    });
+
+    subscriber.assertError(e);
+  }
+
+  @Test public void bodyThrowingInOnCompletedDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<String> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.body().unsafeSubscribe(new ForwardingSubscriber<String>(subscriber) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    subscriber.assertValue("Hi");
+    assertThat(throwableRef.get()).isSameAs(e);
+  }
+
+  @Test public void bodyThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<String> subscriber = subscriberRule.create();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final RuntimeException e = new RuntimeException();
+    service.body().unsafeSubscribe(new ForwardingSubscriber<String>(subscriber) {
+      @Override public void onError(Throwable throwable) {
+        if (!errorRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+        throw e;
+      }
+    });
+
+    //noinspection ThrowableResultOfMethodCallIgnored
+    CompositeException composite = (CompositeException) throwableRef.get();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
+  }
+
   @Test public void responseSuccess200() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
@@ -128,6 +202,73 @@ public final class ObservableTest {
 
     subscriber.requestMore(Long.MAX_VALUE); // Subsequent requests do not trigger HTTP requests.
     assertThat(server.getRequestCount()).isEqualTo(1);
+  }
+
+  @Test public void responseThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    RecordingSubscriber<Response<String>> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.response().unsafeSubscribe(new ForwardingSubscriber<Response<String>>(subscriber) {
+      @Override public void onNext(Response<String> value) {
+        throw e;
+      }
+    });
+
+    subscriber.assertError(e);
+  }
+
+  @Test public void responseThrowingInOnCompletedDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<Response<String>> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.response().unsafeSubscribe(new ForwardingSubscriber<Response<String>>(subscriber) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    assertThat(subscriber.takeValue().body()).isEqualTo("Hi");
+    assertThat(throwableRef.get()).isSameAs(e);
+  }
+
+  @Test public void responseThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<Response<String>> subscriber = subscriberRule.create();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final RuntimeException e = new RuntimeException();
+    service.response().unsafeSubscribe(new ForwardingSubscriber<Response<String>>(subscriber) {
+      @Override public void onError(Throwable throwable) {
+        if (!errorRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+        throw e;
+      }
+    });
+
+    //noinspection ThrowableResultOfMethodCallIgnored
+    CompositeException composite = (CompositeException) throwableRef.get();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
   }
 
   @Test public void resultSuccess200() {
@@ -170,5 +311,74 @@ public final class ObservableTest {
 
     subscriber.requestMore(Long.MAX_VALUE); // Subsequent requests do not trigger HTTP requests.
     assertThat(server.getRequestCount()).isEqualTo(1);
+  }
+
+  @Test public void resultThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    RecordingSubscriber<Result<String>> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.result().unsafeSubscribe(new ForwardingSubscriber<Result<String>>(subscriber) {
+      @Override public void onNext(Result<String> value) {
+        throw e;
+      }
+    });
+
+    subscriber.assertError(e);
+  }
+
+  @Test public void resultThrowingInOnCompletedDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<Result<String>> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.result().unsafeSubscribe(new ForwardingSubscriber<Result<String>>(subscriber) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    assertThat(subscriber.takeValue().response().body()).isEqualTo("Hi");
+    assertThat(throwableRef.get()).isSameAs(e);
+  }
+
+  @Test public void resultThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<Result<String>> subscriber = subscriberRule.create();
+    final RuntimeException first = new RuntimeException();
+    final RuntimeException second = new RuntimeException();
+    service.result().unsafeSubscribe(new ForwardingSubscriber<Result<String>>(subscriber) {
+      @Override public void onNext(Result<String> value) {
+        // The only way to trigger onError for a result is if onNext throws.
+        throw first;
+      }
+
+      @Override public void onError(Throwable throwable) {
+        throw second;
+      }
+    });
+
+    //noinspection ThrowableResultOfMethodCallIgnored
+    CompositeException composite = (CompositeException) throwableRef.get();
+    assertThat(composite.getExceptions()).containsExactly(first, second);
   }
 }

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/RxJavaPluginsResetRule.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/RxJavaPluginsResetRule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.adapter.rxjava;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import rx.plugins.RxJavaPlugins;
+
+/** A JUnit @Rule which resets RxJava's plugins before and after each test. */
+final class RxJavaPluginsResetRule implements TestRule {
+  @Override public Statement apply(final Statement base, Description description) {
+    return new Statement() {
+      @Override public void evaluate() throws Throwable {
+        RxJavaPlugins.getInstance().reset();
+        try {
+          base.evaluate();
+        } finally {
+          RxJavaPlugins.getInstance().reset();
+        }
+      }
+    };
+  }
+}

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleTest.java
@@ -16,21 +16,29 @@
 package retrofit2.adapter.rxjava;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.http.GET;
 import rx.Single;
+import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
+import rx.plugins.RxJavaErrorHandler;
+import rx.plugins.RxJavaPlugins;
 
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class SingleTest {
   @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final TestRule pluginsReset = new RxJavaPluginsResetRule();
   @Rule public final RecordingSubscriber.Rule subscriberRule = new RecordingSubscriber.Rule();
 
   interface Service {
@@ -74,6 +82,73 @@ public final class SingleTest {
     subscriber.assertError(IOException.class);
   }
 
+  @Test public void bodyThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    RecordingSubscriber<String> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.body().unsafeSubscribe(new ForwardingSubscriber<String>(subscriber) {
+      @Override public void onNext(String value) {
+        throw e;
+      }
+    });
+
+    subscriber.assertError(e);
+  }
+
+  @Test public void bodyThrowingInOnCompletedDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<String> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.body().unsafeSubscribe(new ForwardingSubscriber<String>(subscriber) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    subscriber.assertValue("Hi");
+    assertThat(throwableRef.get()).isSameAs(e);
+  }
+
+  @Test public void bodyThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<String> subscriber = subscriberRule.create();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final RuntimeException e = new RuntimeException();
+    service.body().unsafeSubscribe(new ForwardingSubscriber<String>(subscriber) {
+      @Override public void onError(Throwable throwable) {
+        if (!errorRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+        throw e;
+      }
+    });
+
+    //noinspection ThrowableResultOfMethodCallIgnored
+    CompositeException composite = (CompositeException) throwableRef.get();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
+  }
+
   @Test public void responseSuccess200() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
@@ -98,6 +173,73 @@ public final class SingleTest {
     RecordingSubscriber<Response<String>> subscriber = subscriberRule.create();
     service.response().unsafeSubscribe(subscriber);
     subscriber.assertError(IOException.class);
+  }
+
+  @Test public void responseThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    RecordingSubscriber<Response<String>> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.response().unsafeSubscribe(new ForwardingSubscriber<Response<String>>(subscriber) {
+      @Override public void onNext(Response<String> value) {
+        throw e;
+      }
+    });
+
+    subscriber.assertError(e);
+  }
+
+  @Test public void responseThrowingInOnCompletedDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<Response<String>> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.response().unsafeSubscribe(new ForwardingSubscriber<Response<String>>(subscriber) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    assertThat(subscriber.takeValue().body()).isEqualTo("Hi");
+    assertThat(throwableRef.get()).isSameAs(e);
+  }
+
+  @Test public void responseThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<Response<String>> subscriber = subscriberRule.create();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final RuntimeException e = new RuntimeException();
+    service.response().unsafeSubscribe(new ForwardingSubscriber<Response<String>>(subscriber) {
+      @Override public void onError(Throwable throwable) {
+        if (!errorRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+        throw e;
+      }
+    });
+
+    //noinspection ThrowableResultOfMethodCallIgnored
+    CompositeException composite = (CompositeException) throwableRef.get();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
   }
 
   @Test public void resultSuccess200() {
@@ -125,5 +267,75 @@ public final class SingleTest {
     service.result().unsafeSubscribe(subscriber);
     assertThat(subscriber.takeValue().error()).isInstanceOf(IOException.class);
     subscriber.assertCompleted();
+  }
+
+  @Test public void resultThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    RecordingSubscriber<Result<String>> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.result().unsafeSubscribe(new ForwardingSubscriber<Result<String>>(subscriber) {
+      @Override public void onNext(Result<String> value) {
+        throw e;
+      }
+    });
+
+    subscriber.assertError(e);
+  }
+
+  @Test public void resultThrowingInOnCompletedDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<Result<String>> subscriber = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.result().unsafeSubscribe(new ForwardingSubscriber<Result<String>>(subscriber) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    assertThat(subscriber.takeValue().response().body()).isEqualTo("Hi");
+    assertThat(throwableRef.get()).isSameAs(e);
+  }
+
+  @Ignore("Single's contract is onNext|onError so we have no way of triggering this case")
+  @Test public void resultThrowingInOnErrorDeliveredToPlugin() throws Throwable {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!throwableRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+      }
+    });
+
+    RecordingSubscriber<Result<String>> subscriber = subscriberRule.create();
+    final RuntimeException first = new RuntimeException("First");
+    final RuntimeException second = new RuntimeException("Second");
+    service.result().unsafeSubscribe(new ForwardingSubscriber<Result<String>>(subscriber) {
+      @Override public void onNext(Result<String> value) {
+        // The only way to trigger onError for a result is if onNext throws.
+        throw first;
+      }
+
+      @Override public void onError(Throwable throwable) {
+        throw second;
+      }
+    });
+
+    //noinspection ThrowableResultOfMethodCallIgnored
+    CompositeException composite = (CompositeException) throwableRef.get();
+    assertThat(composite.getExceptions()).containsExactly(first, second);
   }
 }


### PR DESCRIPTION
Since we've implemented our own observables instead of using the built-in factories we have to do the heavy lifting of these edge cases ourselves.