### PR TITLE
Propagate fatal exceptions even if already dispatching an error.

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/BodyOnSubscribe.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/BodyOnSubscribe.java
@@ -19,6 +19,7 @@ import retrofit2.Response;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
 import rx.plugins.RxJavaPlugins;
 
 final class BodyOnSubscribe<T> implements OnSubscribe<T> {
@@ -51,6 +52,7 @@ final class BodyOnSubscribe<T> implements OnSubscribe<T> {
         try {
           subscriber.onError(t);
         } catch (Throwable inner) {
+          Exceptions.throwIfFatal(inner);
           CompositeException composite = new CompositeException(t, inner);
           RxJavaPlugins.getInstance().getErrorHandler().handleError(composite);
         }

--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/CallOnSubscribe.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/CallOnSubscribe.java
@@ -82,6 +82,7 @@ final class CallOnSubscribe<T> implements OnSubscribe<Response<T>> {
           try {
             subscriber.onError(t);
           } catch (Throwable inner) {
+            Exceptions.throwIfFatal(inner);
             CompositeException composite = new CompositeException(t, inner);
             RxJavaPlugins.getInstance().getErrorHandler().handleError(composite);
           }

--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/ResultOnSubscribe.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/ResultOnSubscribe.java
@@ -19,6 +19,7 @@ import retrofit2.Response;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
 import rx.plugins.RxJavaPlugins;
 
 final class ResultOnSubscribe<T> implements OnSubscribe<Result<T>> {
@@ -51,6 +52,7 @@ final class ResultOnSubscribe<T> implements OnSubscribe<Result<T>> {
         try {
           subscriber.onError(t);
         } catch (Throwable inner) {
+          Exceptions.throwIfFatal(inner);
           CompositeException composite = new CompositeException(t, inner);
           RxJavaPlugins.getInstance().getErrorHandler().handleError(composite);
         }


### PR DESCRIPTION
Not in the mood for writing tests for these. I'll do it in a follow-up.