### PR TITLE
Add supprot for multi-values Maps

### DIFF
--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -54,6 +54,33 @@ abstract class ParameterHandler<T> {
 
   abstract static class NamedValuesHandler<T> {
     abstract void apply(RequestBuilder builder, String name, T value) throws IOException;
+
+    final NamedValuesHandler<Iterable<T>> iterable() {
+      return new NamedValuesHandler<Iterable<T>>() {
+        @Override
+        void apply(RequestBuilder builder, String name, Iterable<T> values) throws IOException {
+          if (values == null) return; // Skip null values.
+
+          for (T value : values) {
+            NamedValuesHandler.this.apply(builder, name, value);
+          }
+        }
+      };
+    }
+
+    final NamedValuesHandler<Object> array() {
+      return new NamedValuesHandler<Object>() {
+        @Override
+        void apply(RequestBuilder builder, String name, Object values) throws IOException {
+          if (values == null) return; // Skip null values.
+
+          for (int i = 0, size = Array.getLength(values); i < size; i++) {
+            //noinspection unchecked
+            NamedValuesHandler.this.apply(builder, name, (T) Array.get(values, i));
+          }
+        }
+      };
+    }
   }
 
   static class NamedParameterHandler<T> extends ParameterHandler<T> {

--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -401,100 +401,34 @@ final class ServiceMethod<T> {
       } else if (annotation instanceof Query) {
         Query query = (Query) annotation;
         String name = query.value();
-        boolean encoded = query.encoded();
-
-        Class<?> rawParameterType = Utils.getRawType(type);
         gotQuery = true;
-        if (Iterable.class.isAssignableFrom(rawParameterType)) {
-          if (!(type instanceof ParameterizedType)) {
-            throw parameterError(p, rawParameterType.getSimpleName()
-                + " must include generic type (e.g., "
-                + rawParameterType.getSimpleName()
-                + "<String>)");
-          }
-          ParameterizedType parameterizedType = (ParameterizedType) type;
-          Type iterableType = Utils.getParameterUpperBound(0, parameterizedType);
-          Converter<?, String> converter =
-              retrofit.stringConverter(iterableType, annotations);
-          return new ParameterHandler.Query<>(name, converter, encoded).iterable();
-        } else if (rawParameterType.isArray()) {
-          Class<?> arrayComponentType = boxIfPrimitive(rawParameterType.getComponentType());
-          Converter<?, String> converter =
-              retrofit.stringConverter(arrayComponentType, annotations);
-          return new ParameterHandler.Query<>(name, converter, encoded).array();
-        } else {
-          Converter<?, String> converter =
-              retrofit.stringConverter(type, annotations);
-          return new ParameterHandler.Query<>(name, converter, encoded);
-        }
+
+        Converter<?, String> converter =
+            retrofit.stringConverter(getItemType(type, p), annotations);
+        return wrapParameterHandler(type, new ParameterHandler.NamedParameterHandler<>(
+            name, new ParameterHandler.Query<>(converter, query.encoded())));
 
       } else if (annotation instanceof QueryMap) {
-        Class<?> rawParameterType = Utils.getRawType(type);
-        if (!Map.class.isAssignableFrom(rawParameterType)) {
-          throw parameterError(p, "@QueryMap parameter type must be Map.");
-        }
-        Type mapType = Utils.getSupertype(type, rawParameterType, Map.class);
-        if (!(mapType instanceof ParameterizedType)) {
-          throw parameterError(p, "Map must include generic types (e.g., Map<String, String>)");
-        }
-        ParameterizedType parameterizedType = (ParameterizedType) mapType;
-        Type keyType = Utils.getParameterUpperBound(0, parameterizedType);
-        if (String.class != keyType) {
-          throw parameterError(p, "@QueryMap keys must be of type String: " + keyType);
-        }
-        Type valueType = Utils.getParameterUpperBound(1, parameterizedType);
-        Converter<?, String> valueConverter =
-            retrofit.stringConverter(valueType, annotations);
-
-        return new ParameterHandler.QueryMap<>(valueConverter, ((QueryMap) annotation).encoded());
+        QueryMap queryMap = (QueryMap) annotation;
+        Converter<?, String> converter =
+            retrofit.stringConverter(getMapValueType(type, annotation, p), annotations);
+        return new ParameterHandler.MapParameterHandler<>(
+            new ParameterHandler.Query<>(converter, queryMap.encoded()), "Query");
 
       } else if (annotation instanceof Header) {
         Header header = (Header) annotation;
         String name = header.value();
 
-        Class<?> rawParameterType = Utils.getRawType(type);
-        if (Iterable.class.isAssignableFrom(rawParameterType)) {
-          if (!(type instanceof ParameterizedType)) {
-            throw parameterError(p, rawParameterType.getSimpleName()
-                + " must include generic type (e.g., "
-                + rawParameterType.getSimpleName()
-                + "<String>)");
-          }
-          ParameterizedType parameterizedType = (ParameterizedType) type;
-          Type iterableType = Utils.getParameterUpperBound(0, parameterizedType);
-          Converter<?, String> converter =
-              retrofit.stringConverter(iterableType, annotations);
-          return new ParameterHandler.Header<>(name, converter).iterable();
-        } else if (rawParameterType.isArray()) {
-          Class<?> arrayComponentType = boxIfPrimitive(rawParameterType.getComponentType());
-          Converter<?, String> converter =
-              retrofit.stringConverter(arrayComponentType, annotations);
-          return new ParameterHandler.Header<>(name, converter).array();
-        } else {
-          Converter<?, String> converter =
-              retrofit.stringConverter(type, annotations);
-          return new ParameterHandler.Header<>(name, converter);
-        }
+        Converter<?, String> converter =
+            retrofit.stringConverter(getItemType(type, p), annotations);
+        return wrapParameterHandler(type, new ParameterHandler.NamedParameterHandler<>(
+            name, new ParameterHandler.Header<>(converter)));
 
       } else if (annotation instanceof HeaderMap) {
-        Class<?> rawParameterType = Utils.getRawType(type);
-        if (!Map.class.isAssignableFrom(rawParameterType)) {
-          throw parameterError(p, "@HeaderMap parameter type must be Map.");
-        }
-        Type mapType = Utils.getSupertype(type, rawParameterType, Map.class);
-        if (!(mapType instanceof ParameterizedType)) {
-          throw parameterError(p, "Map must include generic types (e.g., Map<String, String>)");
-        }
-        ParameterizedType parameterizedType = (ParameterizedType) mapType;
-        Type keyType = Utils.getParameterUpperBound(0, parameterizedType);
-        if (String.class != keyType) {
-          throw parameterError(p, "@HeaderMap keys must be of type String: " + keyType);
-        }
-        Type valueType = Utils.getParameterUpperBound(1, parameterizedType);
-        Converter<?, String> valueConverter =
-            retrofit.stringConverter(valueType, annotations);
-
-        return new ParameterHandler.HeaderMap<>(valueConverter);
+        Converter<?, String> converter =
+            retrofit.stringConverter(getMapValueType(type, annotation, p), annotations);
+        return new ParameterHandler.MapParameterHandler<>(
+            new ParameterHandler.Header<>(converter), "Header");
 
       } else if (annotation instanceof Field) {
         if (!isFormEncoded) {
@@ -502,58 +436,24 @@ final class ServiceMethod<T> {
         }
         Field field = (Field) annotation;
         String name = field.value();
-        boolean encoded = field.encoded();
 
         gotField = true;
 
-        Class<?> rawParameterType = Utils.getRawType(type);
-        if (Iterable.class.isAssignableFrom(rawParameterType)) {
-          if (!(type instanceof ParameterizedType)) {
-            throw parameterError(p, rawParameterType.getSimpleName()
-                + " must include generic type (e.g., "
-                + rawParameterType.getSimpleName()
-                + "<String>)");
-          }
-          ParameterizedType parameterizedType = (ParameterizedType) type;
-          Type iterableType = Utils.getParameterUpperBound(0, parameterizedType);
-          Converter<?, String> converter =
-              retrofit.stringConverter(iterableType, annotations);
-          return new ParameterHandler.Field<>(name, converter, encoded).iterable();
-        } else if (rawParameterType.isArray()) {
-          Class<?> arrayComponentType = boxIfPrimitive(rawParameterType.getComponentType());
-          Converter<?, String> converter =
-              retrofit.stringConverter(arrayComponentType, annotations);
-          return new ParameterHandler.Field<>(name, converter, encoded).array();
-        } else {
-          Converter<?, String> converter =
-              retrofit.stringConverter(type, annotations);
-          return new ParameterHandler.Field<>(name, converter, encoded);
-        }
+        Converter<?, String> converter =
+            retrofit.stringConverter(getItemType(type, p), annotations);
+        return wrapParameterHandler(type, new ParameterHandler.NamedParameterHandler<>(
+            name, new ParameterHandler.Field<>(converter, field.encoded())));
 
       } else if (annotation instanceof FieldMap) {
         if (!isFormEncoded) {
           throw parameterError(p, "@FieldMap parameters can only be used with form encoding.");
         }
-        Class<?> rawParameterType = Utils.getRawType(type);
-        if (!Map.class.isAssignableFrom(rawParameterType)) {
-          throw parameterError(p, "@FieldMap parameter type must be Map.");
-        }
-        Type mapType = Utils.getSupertype(type, rawParameterType, Map.class);
-        if (!(mapType instanceof ParameterizedType)) {
-          throw parameterError(p,
-              "Map must include generic types (e.g., Map<String, String>)");
-        }
-        ParameterizedType parameterizedType = (ParameterizedType) mapType;
-        Type keyType = Utils.getParameterUpperBound(0, parameterizedType);
-        if (String.class != keyType) {
-          throw parameterError(p, "@FieldMap keys must be of type String: " + keyType);
-        }
-        Type valueType = Utils.getParameterUpperBound(1, parameterizedType);
-        Converter<?, String> valueConverter =
-            retrofit.stringConverter(valueType, annotations);
-
         gotField = true;
-        return new ParameterHandler.FieldMap<>(valueConverter, ((FieldMap) annotation).encoded());
+
+        Converter<?, String> converter =
+            retrofit.stringConverter(getMapValueType(type, annotation, p), annotations);
+        return new ParameterHandler.MapParameterHandler<>(
+            new ParameterHandler.Field<>(converter, ((FieldMap) annotation).encoded()), "Field");
 
       } else if (annotation instanceof Part) {
         if (!isMultipart) {
@@ -563,73 +463,25 @@ final class ServiceMethod<T> {
         gotPart = true;
 
         String partName = part.value();
-        Class<?> rawParameterType = Utils.getRawType(type);
-        if (partName.isEmpty()) {
-          if (Iterable.class.isAssignableFrom(rawParameterType)) {
-            if (!(type instanceof ParameterizedType)) {
-              throw parameterError(p, rawParameterType.getSimpleName()
-                  + " must include generic type (e.g., "
-                  + rawParameterType.getSimpleName()
-                  + "<String>)");
-            }
-            ParameterizedType parameterizedType = (ParameterizedType) type;
-            Type iterableType = Utils.getParameterUpperBound(0, parameterizedType);
-            if (!MultipartBody.Part.class.isAssignableFrom(Utils.getRawType(iterableType))) {
-              throw parameterError(p,
-                  "@Part annotation must supply a name or use MultipartBody.Part parameter type.");
-            }
-            return ParameterHandler.RawPart.INSTANCE.iterable();
-          } else if (rawParameterType.isArray()) {
-            Class<?> arrayComponentType = rawParameterType.getComponentType();
-            if (!MultipartBody.Part.class.isAssignableFrom(arrayComponentType)) {
-              throw parameterError(p,
-                  "@Part annotation must supply a name or use MultipartBody.Part parameter type.");
-            }
-            return ParameterHandler.RawPart.INSTANCE.array();
-          } else if (MultipartBody.Part.class.isAssignableFrom(rawParameterType)) {
-            return ParameterHandler.RawPart.INSTANCE;
-          } else {
+        Type itemType = getItemType(type, p);
+
+        if (MultipartBody.Part.class.isAssignableFrom((Class<?>) itemType)) {
+          if (!partName.isEmpty()) {
+            throw parameterError(p, "@Part parameters using the MultipartBody.Part must not "
+                    + "include a part name in the annotation.");
+          }
+          return wrapParameterHandler(type, new ParameterHandler.RawPart());
+        } else {
+          if (partName.isEmpty()) {
             throw parameterError(p,
                 "@Part annotation must supply a name or use MultipartBody.Part parameter type.");
           }
-        } else {
-          Headers headers =
-              Headers.of("Content-Disposition", "form-data; name=\"" + partName + "\"",
-                  "Content-Transfer-Encoding", part.encoding());
-
-          if (Iterable.class.isAssignableFrom(rawParameterType)) {
-            if (!(type instanceof ParameterizedType)) {
-              throw parameterError(p, rawParameterType.getSimpleName()
-                  + " must include generic type (e.g., "
-                  + rawParameterType.getSimpleName()
-                  + "<String>)");
-            }
-            ParameterizedType parameterizedType = (ParameterizedType) type;
-            Type iterableType = Utils.getParameterUpperBound(0, parameterizedType);
-            if (MultipartBody.Part.class.isAssignableFrom(Utils.getRawType(iterableType))) {
-              throw parameterError(p, "@Part parameters using the MultipartBody.Part must not "
-                  + "include a part name in the annotation.");
-            }
-            Converter<?, RequestBody> converter =
-                retrofit.requestBodyConverter(iterableType, annotations, methodAnnotations);
-            return new ParameterHandler.Part<>(headers, converter).iterable();
-          } else if (rawParameterType.isArray()) {
-            Class<?> arrayComponentType = boxIfPrimitive(rawParameterType.getComponentType());
-            if (MultipartBody.Part.class.isAssignableFrom(arrayComponentType)) {
-              throw parameterError(p, "@Part parameters using the MultipartBody.Part must not "
-                  + "include a part name in the annotation.");
-            }
-            Converter<?, RequestBody> converter =
-                retrofit.requestBodyConverter(arrayComponentType, annotations, methodAnnotations);
-            return new ParameterHandler.Part<>(headers, converter).array();
-          } else if (MultipartBody.Part.class.isAssignableFrom(rawParameterType)) {
-            throw parameterError(p, "@Part parameters using the MultipartBody.Part must not "
-                + "include a part name in the annotation.");
-          } else {
-            Converter<?, RequestBody> converter =
-                retrofit.requestBodyConverter(type, annotations, methodAnnotations);
-            return new ParameterHandler.Part<>(headers, converter);
-          }
+          String encoding = part.encoding();
+          Converter<?, RequestBody> converter =
+              retrofit.requestBodyConverter(itemType, annotations, methodAnnotations);
+          return wrapParameterHandler(type, new ParameterHandler.NamedParameterHandler<>(partName,
+              new ParameterHandler.Part<>(encoding, converter))
+          );
         }
 
       } else if (annotation instanceof PartMap) {
@@ -637,32 +489,17 @@ final class ServiceMethod<T> {
           throw parameterError(p, "@PartMap parameters can only be used with multipart encoding.");
         }
         gotPart = true;
-        Class<?> rawParameterType = Utils.getRawType(type);
-        if (!Map.class.isAssignableFrom(rawParameterType)) {
-          throw parameterError(p, "@PartMap parameter type must be Map.");
-        }
-        Type mapType = Utils.getSupertype(type, rawParameterType, Map.class);
-        if (!(mapType instanceof ParameterizedType)) {
-          throw parameterError(p, "Map must include generic types (e.g., Map<String, String>)");
-        }
-        ParameterizedType parameterizedType = (ParameterizedType) mapType;
-
-        Type keyType = Utils.getParameterUpperBound(0, parameterizedType);
-        if (String.class != keyType) {
-          throw parameterError(p, "@PartMap keys must be of type String: " + keyType);
-        }
-
-        Type valueType = Utils.getParameterUpperBound(1, parameterizedType);
+        Type valueType = getMapValueType(type, annotation, p);
         if (MultipartBody.Part.class.isAssignableFrom(Utils.getRawType(valueType))) {
           throw parameterError(p, "@PartMap values cannot be MultipartBody.Part. "
               + "Use @Part List<Part> or a different value type instead.");
         }
 
-        Converter<?, RequestBody> valueConverter =
+        Converter<?, RequestBody> converter =
             retrofit.requestBodyConverter(valueType, annotations, methodAnnotations);
 
-        PartMap partMap = (PartMap) annotation;
-        return new ParameterHandler.PartMap<>(valueConverter, partMap.encoding());
+        return new ParameterHandler.MapParameterHandler<>(
+            new ParameterHandler.Part<>(((PartMap) annotation).encoding(), converter), "Part");
 
       } else if (annotation instanceof Body) {
         if (isFormEncoded || isMultipart) {
@@ -685,6 +522,55 @@ final class ServiceMethod<T> {
       }
 
       return null; // Not a Retrofit annotation.
+    }
+
+    private Type getItemType(Type type, int p) {
+      Class<?> rawParameterType = Utils.getRawType(type);
+      if (Iterable.class.isAssignableFrom(rawParameterType)) {
+        if (!(type instanceof ParameterizedType)) {
+          throw parameterError(p, rawParameterType.getSimpleName()
+              + " must include generic type (e.g., "
+              + rawParameterType.getSimpleName()
+              + "<String>)");
+        }
+        ParameterizedType parameterizedType = (ParameterizedType) type;
+        return Utils.getParameterUpperBound(0, parameterizedType);
+      } else if (rawParameterType.isArray()) {
+        return boxIfPrimitive(rawParameterType.getComponentType());
+      } else {
+        return type;
+      }
+    }
+
+    private Type getMapValueType(Type type, Annotation annotation, int p) {
+      String annotationName = annotation.annotationType().getSimpleName();
+      Class<?> rawParameterType = Utils.getRawType(type);
+      if (!Map.class.isAssignableFrom(rawParameterType)) {
+        throw parameterError(p, String.format("@%1$s parameter type must be Map.",
+            annotationName));
+      }
+      Type mapType = Utils.getSupertype(type, rawParameterType, Map.class);
+      if (!(mapType instanceof ParameterizedType)) {
+        throw parameterError(p, "Map must include generic types (e.g., Map<String, String>)");
+      }
+      ParameterizedType parameterizedType = (ParameterizedType) mapType;
+      Type keyType = Utils.getParameterUpperBound(0, parameterizedType);
+      if (String.class != keyType) {
+        throw parameterError(p, String.format("@%1$s keys must be of type String: %2$s",
+            annotationName, keyType));
+      }
+      return Utils.getParameterUpperBound(1, parameterizedType);
+    }
+
+    private ParameterHandler<?> wrapParameterHandler(Type type, ParameterHandler<?> handler) {
+      Class<?> rawParameterType = Utils.getRawType(type);
+      if (Iterable.class.isAssignableFrom(rawParameterType)) {
+        return handler.iterable();
+      } else if (rawParameterType.isArray()) {
+        return handler.array();
+      } else {
+        return handler;
+      }
     }
 
     private void validatePathName(int p, String name) {

--- a/retrofit/src/main/java/retrofit2/http/FieldMap.java
+++ b/retrofit/src/main/java/retrofit2/http/FieldMap.java
@@ -45,4 +45,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface FieldMap {
   /** Specifies whether the names and values are already URL encoded. */
   boolean encoded() default false;
+
+  /**
+   * Specifies weather Iterable and Array values should be treated as multiple values.
+   * When {@code true}, separate field will be created for each item in the value collection.
+   **/
+  boolean multimap() default false;
 }

--- a/retrofit/src/main/java/retrofit2/http/HeaderMap.java
+++ b/retrofit/src/main/java/retrofit2/http/HeaderMap.java
@@ -47,5 +47,9 @@ import java.util.Map;
 @Target(PARAMETER)
 @Retention(RUNTIME)
 public @interface HeaderMap {
-
+  /**
+   * Specifies weather Iterable and Array values should be treated as multiple values.
+   * When {@code true}, separate header will be created for each item in the value collection.
+   **/
+  boolean multimap() default false;
 }

--- a/retrofit/src/main/java/retrofit2/http/PartMap.java
+++ b/retrofit/src/main/java/retrofit2/http/PartMap.java
@@ -53,4 +53,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface PartMap {
   /** The {@code Content-Transfer-Encoding} of the parts. */
   String encoding() default "binary";
+
+  /**
+   * Specifies weather Iterable and Array values should be treated as multiple values.
+   * When {@code true}, separate part will be created for each item in the value collection.
+   **/
+  boolean multimap() default false;
 }

--- a/retrofit/src/main/java/retrofit2/http/QueryMap.java
+++ b/retrofit/src/main/java/retrofit2/http/QueryMap.java
@@ -54,4 +54,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface QueryMap {
   /** Specifies whether parameter names and values are already URL encoded. */
   boolean encoded() default false;
+
+  /**
+   * Specifies weather Iterable and Array values should be treated as multiple values.
+   * When {@code true}, separate query parameter will be created for each item in the value
+   * collection.
+   **/
+  boolean multimap() default false;
 }


### PR DESCRIPTION
Implements support for multimaps requested in #1960, #1324 and numerous closed issues referenced from #626.

Multiple values are generated for map declared as `Map<String, Iterable<T>>` and `Map<String, T[]>`.

To maintain backward compatibility, this feature is disabled by default and needs to be enabled by setting `multimap` annotation argument to `true` (e.g. `@QueryMap(multimap = true) Map<String, List<String>> queries`).
