### PR TITLE
Replaced invocation of deprecated factory methods in JacksonConverterFactory

### DIFF
--- a/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonConverterFactory.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonConverterFactory.java
@@ -56,7 +56,7 @@ public final class JacksonConverterFactory extends Converter.Factory {
   public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
       Retrofit retrofit) {
     JavaType javaType = mapper.getTypeFactory().constructType(type);
-    ObjectReader reader = mapper.reader(javaType);
+    ObjectReader reader = mapper.readerFor(javaType);
     return new JacksonResponseBodyConverter<>(reader);
   }
 
@@ -64,7 +64,7 @@ public final class JacksonConverterFactory extends Converter.Factory {
   public Converter<?, RequestBody> requestBodyConverter(Type type,
       Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
     JavaType javaType = mapper.getTypeFactory().constructType(type);
-    ObjectWriter writer = mapper.writerWithType(javaType);
+    ObjectWriter writer = mapper.writerFor(javaType);
     return new JacksonRequestBodyConverter<>(writer);
   }
 }


### PR DESCRIPTION
Replaced invocation of deprecated factory methods in favor of newer counterparts in JacksonConverterFactory.