### PR TITLE
Promote adapter response body type parameter to class level.

### DIFF
--- a/retrofit-adapters/guava/src/test/java/retrofit2/adapter/guava/GuavaCallAdapterFactoryTest.java
+++ b/retrofit-adapters/guava/src/test/java/retrofit2/adapter/guava/GuavaCallAdapterFactoryTest.java
@@ -72,7 +72,7 @@ public final class GuavaCallAdapterFactoryTest {
   }
 
   @Test public void nonListenableFutureReturnsNull() {
-    CallAdapter<?> adapter = factory.get(String.class, NO_ANNOTATIONS, retrofit);
+    CallAdapter<?, ?> adapter = factory.get(String.class, NO_ANNOTATIONS, retrofit);
     assertThat(adapter).isNull();
   }
 

--- a/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/Java8CallAdapterFactoryTest.java
+++ b/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/Java8CallAdapterFactoryTest.java
@@ -72,7 +72,7 @@ public final class Java8CallAdapterFactoryTest {
   }
 
   @Test public void nonListenableFutureReturnsNull() {
-    CallAdapter<?> adapter = factory.get(String.class, NO_ANNOTATIONS, retrofit);
+    CallAdapter<?, ?> adapter = factory.get(String.class, NO_ANNOTATIONS, retrofit);
     assertThat(adapter).isNull();
   }
 

--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/RxJavaCallAdapter.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/RxJavaCallAdapter.java
@@ -23,7 +23,7 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Scheduler;
 
-final class RxJavaCallAdapter implements CallAdapter<Object> {
+final class RxJavaCallAdapter<R> implements CallAdapter<R, Object> {
   private final Type responseType;
   private final Scheduler scheduler;
   private final boolean isResult;
@@ -45,7 +45,7 @@ final class RxJavaCallAdapter implements CallAdapter<Object> {
     return responseType;
   }
 
-  @Override public <R> Object adapt(Call<R> call) {
+  @Override public Object adapt(Call<R> call) {
     OnSubscribe<Response<R>> callFunc = new CallOnSubscribe<>(call);
 
     OnSubscribe<?> func;

--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactory.java
@@ -80,7 +80,7 @@ public final class RxJavaCallAdapterFactory extends CallAdapter.Factory {
   }
 
   @Override
-  public CallAdapter<?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+  public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
     Class<?> rawType = getRawType(returnType);
     String canonicalName = rawType.getCanonicalName();
     boolean isSingle = "rx.Single".equals(canonicalName);

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactoryTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactoryTest.java
@@ -54,7 +54,7 @@ public final class RxJavaCallAdapterFactoryTest {
   }
 
   @Test public void nonRxJavaTypeReturnsNull() {
-    CallAdapter<?> adapter = factory.get(String.class, NO_ANNOTATIONS, retrofit);
+    CallAdapter<?, ?> adapter = factory.get(String.class, NO_ANNOTATIONS, retrofit);
     assertThat(adapter).isNull();
   }
 

--- a/retrofit-converters/scalars/src/test/java/retrofit2/converter/scalars/ScalarsConverterPrimitivesFactoryTest.java
+++ b/retrofit-converters/scalars/src/test/java/retrofit2/converter/scalars/ScalarsConverterPrimitivesFactoryTest.java
@@ -50,8 +50,8 @@ public final class ScalarsConverterPrimitivesFactoryTest {
 
   static class DirectCallAdapterFactory extends CallAdapter.Factory {
     @Override
-    public CallAdapter<?> get(final Type returnType, Annotation[] annotations, Retrofit retrofit) {
-      return new CallAdapter<Object>() {
+    public CallAdapter<?, ?> get(final Type returnType, Annotation[] annotations, Retrofit retrofit) {
+      return new CallAdapter<Object, Object>() {
         @Override public Type responseType() {
           return returnType;
         }

--- a/retrofit-mock/src/main/java/retrofit2/mock/BehaviorDelegate.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/BehaviorDelegate.java
@@ -51,15 +51,16 @@ public final class BehaviorDelegate<T> {
   }
 
   @SuppressWarnings("unchecked") // Single-interface proxy creation guarded by parameter safety.
-  public T returning(Call<?> call) {
-    final Call<?> behaviorCall = new BehaviorCall<>(behavior, executor, call);
+  public <R> T returning(Call<R> call) {
+    final Call<R> behaviorCall = new BehaviorCall<>(behavior, executor, call);
     return (T) Proxy.newProxyInstance(service.getClassLoader(), new Class[] { service },
         new InvocationHandler() {
           @Override
-          public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+          public T invoke(Object proxy, Method method, Object[] args) throws Throwable {
             Type returnType = method.getGenericReturnType();
             Annotation[] methodAnnotations = method.getAnnotations();
-            CallAdapter<?> callAdapter = retrofit.callAdapter(returnType, methodAnnotations);
+            CallAdapter<R, T> callAdapter =
+                (CallAdapter<R, T>) retrofit.callAdapter(returnType, methodAnnotations);
             return callAdapter.adapt(behaviorCall);
           }
         });

--- a/retrofit/src/main/java/retrofit2/CallAdapter.java
+++ b/retrofit/src/main/java/retrofit2/CallAdapter.java
@@ -20,11 +20,12 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
 /**
- * Adapts a {@link Call} into the type of {@code T}. Instances are created by {@linkplain Factory a
- * factory} which is {@linkplain Retrofit.Builder#addCallAdapterFactory(Factory) installed} into
- * the {@link Retrofit} instance.
+ * Adapts a {@link Call} with response type {@code R} into the type of {@code T}. Instances are
+ * created by {@linkplain Factory a factory} which is
+ * {@linkplain Retrofit.Builder#addCallAdapterFactory(Factory) installed} into the {@link Retrofit}
+ * instance.
  */
-public interface CallAdapter<T> {
+public interface CallAdapter<R, T> {
   /**
    * Returns the value type that this adapter uses when converting the HTTP response body to a Java
    * object. For example, the response type for {@code Call<Repo>} is {@code Repo}. This type
@@ -52,7 +53,7 @@ public interface CallAdapter<T> {
    * }
    * </code></pre>
    */
-  <R> T adapt(Call<R> call);
+  T adapt(Call<R> call);
 
   /**
    * Creates {@link CallAdapter} instances based on the return type of {@linkplain
@@ -63,7 +64,7 @@ public interface CallAdapter<T> {
      * Returns a call adapter for interface methods that return {@code returnType}, or null if it
      * cannot be handled by this factory.
      */
-    public abstract CallAdapter<?> get(Type returnType, Annotation[] annotations,
+    public abstract CallAdapter<?, ?> get(Type returnType, Annotation[] annotations,
         Retrofit retrofit);
 
     /**

--- a/retrofit/src/main/java/retrofit2/DefaultCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit2/DefaultCallAdapterFactory.java
@@ -27,18 +27,18 @@ final class DefaultCallAdapterFactory extends CallAdapter.Factory {
   static final CallAdapter.Factory INSTANCE = new DefaultCallAdapterFactory();
 
   @Override
-  public CallAdapter<?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+  public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
     if (getRawType(returnType) != Call.class) {
       return null;
     }
 
     final Type responseType = Utils.getCallResponseType(returnType);
-    return new CallAdapter<Call<?>>() {
+    return new CallAdapter<Object, Call<?>>() {
       @Override public Type responseType() {
         return responseType;
       }
 
-      @Override public <R> Call<R> adapt(Call<R> call) {
+      @Override public Call<Object> adapt(Call<Object> call) {
         return call;
       }
     };

--- a/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
@@ -29,17 +29,17 @@ final class ExecutorCallAdapterFactory extends CallAdapter.Factory {
   }
 
   @Override
-  public CallAdapter<Call<?>> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+  public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
     if (getRawType(returnType) != Call.class) {
       return null;
     }
     final Type responseType = Utils.getCallResponseType(returnType);
-    return new CallAdapter<Call<?>>() {
+    return new CallAdapter<Object, Call<?>>() {
       @Override public Type responseType() {
         return responseType;
       }
 
-      @Override public <R> Call<R> adapt(Call<R> call) {
+      @Override public Call<Object> adapt(Call<Object> call) {
         return new ExecutorCallbackCall<>(callbackExecutor, call);
       }
     };

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -25,7 +25,7 @@ import okio.ForwardingSource;
 import okio.Okio;
 
 final class OkHttpCall<T> implements Call<T> {
-  private final ServiceMethod<T> serviceMethod;
+  private final ServiceMethod<T, ?> serviceMethod;
   private final Object[] args;
 
   private volatile boolean canceled;
@@ -35,7 +35,7 @@ final class OkHttpCall<T> implements Call<T> {
   private Throwable creationFailure; // Either a RuntimeException or IOException.
   private boolean executed;
 
-  OkHttpCall(ServiceMethod<T> serviceMethod, Object[] args) {
+  OkHttpCall(ServiceMethod<T, ?> serviceMethod, Object[] args) {
     this.serviceMethod = serviceMethod;
     this.args = args;
   }

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -21,9 +21,9 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -57,7 +57,7 @@ import static retrofit2.Utils.checkNotNull;
  * @author Jake Wharton (jw@squareup.com)
  */
 public final class Retrofit {
-  private final Map<Method, ServiceMethod<?, ?>> serviceMethodCache = new LinkedHashMap<>();
+  private final Map<Method, ServiceMethod<?, ?>> serviceMethodCache = new ConcurrentHashMap<>();
 
   private final okhttp3.Call.Factory callFactory;
   private final HttpUrl baseUrl;
@@ -160,7 +160,9 @@ public final class Retrofit {
   }
 
   ServiceMethod<?, ?> loadServiceMethod(Method method) {
-    ServiceMethod<?, ?> result;
+    ServiceMethod<?, ?> result = serviceMethodCache.get(method);
+    if (result != null) return result;
+
     synchronized (serviceMethodCache) {
       result = serviceMethodCache.get(method);
       if (result == null) {

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -57,7 +57,7 @@ import static retrofit2.Utils.checkNotNull;
  * @author Jake Wharton (jw@squareup.com)
  */
 public final class Retrofit {
-  private final Map<Method, ServiceMethod> serviceMethodCache = new LinkedHashMap<>();
+  private final Map<Method, ServiceMethod<?, ?>> serviceMethodCache = new LinkedHashMap<>();
 
   private final okhttp3.Call.Factory callFactory;
   private final HttpUrl baseUrl;
@@ -142,8 +142,9 @@ public final class Retrofit {
             if (platform.isDefaultMethod(method)) {
               return platform.invokeDefaultMethod(method, service, proxy, args);
             }
-            ServiceMethod serviceMethod = loadServiceMethod(method);
-            OkHttpCall okHttpCall = new OkHttpCall<>(serviceMethod, args);
+            ServiceMethod<Object, Object> serviceMethod =
+                (ServiceMethod<Object, Object>) loadServiceMethod(method);
+            OkHttpCall<Object> okHttpCall = new OkHttpCall<>(serviceMethod, args);
             return serviceMethod.callAdapter.adapt(okHttpCall);
           }
         });
@@ -158,12 +159,12 @@ public final class Retrofit {
     }
   }
 
-  ServiceMethod loadServiceMethod(Method method) {
-    ServiceMethod result;
+  ServiceMethod<?, ?> loadServiceMethod(Method method) {
+    ServiceMethod<?, ?> result;
     synchronized (serviceMethodCache) {
       result = serviceMethodCache.get(method);
       if (result == null) {
-        result = new ServiceMethod.Builder(this, method).build();
+        result = new ServiceMethod.Builder<>(this, method).build();
         serviceMethodCache.put(method, result);
       }
     }
@@ -197,7 +198,7 @@ public final class Retrofit {
    *
    * @throws IllegalArgumentException if no call adapter available for {@code type}.
    */
-  public CallAdapter<?> callAdapter(Type returnType, Annotation[] annotations) {
+  public CallAdapter<?, ?> callAdapter(Type returnType, Annotation[] annotations) {
     return nextCallAdapter(null, returnType, annotations);
   }
 
@@ -207,14 +208,14 @@ public final class Retrofit {
    *
    * @throws IllegalArgumentException if no call adapter available for {@code type}.
    */
-  public CallAdapter<?> nextCallAdapter(CallAdapter.Factory skipPast, Type returnType,
+  public CallAdapter<?, ?> nextCallAdapter(CallAdapter.Factory skipPast, Type returnType,
       Annotation[] annotations) {
     checkNotNull(returnType, "returnType == null");
     checkNotNull(annotations, "annotations == null");
 
     int start = adapterFactories.indexOf(skipPast) + 1;
     for (int i = start, count = adapterFactories.size(); i < count; i++) {
-      CallAdapter<?> adapter = adapterFactories.get(i).get(returnType, annotations, this);
+      CallAdapter<?, ?> adapter = adapterFactories.get(i).get(returnType, annotations, this);
       if (adapter != null) {
         return adapter;
       }

--- a/retrofit/src/test/java/retrofit2/ExecutorCallAdapterFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/ExecutorCallAdapterFactoryTest.java
@@ -70,10 +70,10 @@ public final class ExecutorCallAdapterFactoryTest {
 
   @Test public void adaptedCallExecute() throws IOException {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
-    CallAdapter<Call<?>> adapter =
-        (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
+    CallAdapter<String, Call<String>> adapter =
+        (CallAdapter<String, Call<String>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
     final Response<String> response = Response.success("Hi");
-    Call<String> call = (Call<String>) adapter.adapt(new EmptyCall() {
+    Call<String> call = adapter.adapt(new EmptyCall() {
       @Override public Response<String> execute() throws IOException {
         return response;
       }
@@ -83,15 +83,15 @@ public final class ExecutorCallAdapterFactoryTest {
 
   @Test public void adaptedCallEnqueueUsesExecutorForSuccessCallback() {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
-    CallAdapter<Call<?>> adapter =
-        (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
+    CallAdapter<String, Call<String>> adapter =
+        (CallAdapter<String, Call<String>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
     final Response<String> response = Response.success("Hi");
     EmptyCall originalCall = new EmptyCall() {
       @Override public void enqueue(Callback<String> callback) {
         callback.onResponse(this, response);
       }
     };
-    Call<String> call = (Call<String>) adapter.adapt(originalCall);
+    Call<String> call = adapter.adapt(originalCall);
     call.enqueue(callback);
     verify(callbackExecutor).execute(any(Runnable.class));
     verify(callback).onResponse(call, response);
@@ -99,15 +99,15 @@ public final class ExecutorCallAdapterFactoryTest {
 
   @Test public void adaptedCallEnqueueUsesExecutorForFailureCallback() {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
-    CallAdapter<Call<?>> adapter =
-        (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
+    CallAdapter<String, Call<String>> adapter =
+        (CallAdapter<String, Call<String>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
     final Throwable throwable = new IOException();
     EmptyCall originalCall = new EmptyCall() {
       @Override public void enqueue(Callback<String> callback) {
         callback.onFailure(this, throwable);
       }
     };
-    Call<String> call = (Call<String>) adapter.adapt(originalCall);
+    Call<String> call = adapter.adapt(originalCall);
     call.enqueue(callback);
     verify(callbackExecutor).execute(any(Runnable.class));
     verifyNoMoreInteractions(callbackExecutor);
@@ -117,10 +117,10 @@ public final class ExecutorCallAdapterFactoryTest {
 
   @Test public void adaptedCallCloneDeepCopy() {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
-    CallAdapter<Call<?>> adapter =
-        (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
+    CallAdapter<String, Call<String>> adapter =
+        (CallAdapter<String, Call<String>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
     Call<String> delegate = mock(Call.class);
-    Call<String> call = (Call<String>) adapter.adapt(delegate);
+    Call<String> call = adapter.adapt(delegate);
     Call<String> cloned = call.clone();
     assertThat(cloned).isNotSameAs(call);
     verify(delegate).clone();
@@ -129,10 +129,10 @@ public final class ExecutorCallAdapterFactoryTest {
 
   @Test public void adaptedCallCancel() {
     Type returnType = new TypeToken<Call<String>>() {}.getType();
-    CallAdapter<Call<?>> adapter =
-        (CallAdapter<Call<?>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
+    CallAdapter<String, Call<String>> adapter =
+        (CallAdapter<String, Call<String>>) factory.get(returnType, NO_ANNOTATIONS, retrofit);
     Call<String> delegate = mock(Call.class);
-    Call<String> call = (Call<String>) adapter.adapt(delegate);
+    Call<String> call = adapter.adapt(delegate);
     call.cancel();
     verify(delegate).cancel();
     verifyNoMoreInteractions(delegate);

--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -2501,7 +2501,7 @@ public final class RequestBuilderTest {
     }
   }
 
-  static Request buildRequest(Class<?> cls, Object... args) {
+  static <T> Request buildRequest(Class<T> cls, Object... args) {
     final AtomicReference<Request> requestRef = new AtomicReference<>();
     okhttp3.Call.Factory callFactory = new okhttp3.Call.Factory() {
       @Override public okhttp3.Call newCall(Request request) {
@@ -2517,9 +2517,11 @@ public final class RequestBuilderTest {
         .build();
 
     Method method = TestingUtils.onlyMethod(cls);
-    ServiceMethod<?> serviceMethod = retrofit.loadServiceMethod(method);
-    OkHttpCall<?> okHttpCall = new OkHttpCall<>(serviceMethod, args);
-    Call<?> call = (Call<?>) serviceMethod.callAdapter.adapt(okHttpCall);
+    //noinspection unchecked
+    ServiceMethod<T, Call<T>> serviceMethod =
+        (ServiceMethod<T, Call<T>>) retrofit.loadServiceMethod(method);
+    Call<T> okHttpCall = new OkHttpCall<>(serviceMethod, args);
+    Call<T> call = serviceMethod.callAdapter.adapt(okHttpCall);
     try {
       call.execute();
       throw new AssertionError();

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -231,18 +231,18 @@ public final class RetrofitTest {
     final AtomicBoolean factoryCalled = new AtomicBoolean();
     final AtomicBoolean adapterCalled = new AtomicBoolean();
     class MyCallAdapterFactory extends CallAdapter.Factory {
-      @Override public CallAdapter<?> get(final Type returnType, Annotation[] annotations,
+      @Override public CallAdapter<?, ?> get(final Type returnType, Annotation[] annotations,
           Retrofit retrofit) {
         factoryCalled.set(true);
         if (getRawType(returnType) != Call.class) {
           return null;
         }
-        return new CallAdapter<Call<?>>() {
+        return new CallAdapter<Object, Call<?>>() {
           @Override public Type responseType() {
             return getParameterUpperBound(0, (ParameterizedType) returnType);
           }
 
-          @Override public <R> Call<R> adapt(Call<R> call) {
+          @Override public Call<Object> adapt(Call<Object> call) {
             adapterCalled.set(true);
             return call;
           }
@@ -262,17 +262,17 @@ public final class RetrofitTest {
 
   @Test public void customCallAdapter() {
     class GreetingCallAdapterFactory extends CallAdapter.Factory {
-      @Override public CallAdapter<String> get(Type returnType, Annotation[] annotations,
+      @Override public CallAdapter<Object, String> get(Type returnType, Annotation[] annotations,
           Retrofit retrofit) {
         if (getRawType(returnType) != String.class) {
           return null;
         }
-        return new CallAdapter<String>() {
+        return new CallAdapter<Object, String>() {
           @Override public Type responseType() {
             return String.class;
           }
 
-          @Override public <R> String adapt(Call<R> call) {
+          @Override public String adapt(Call<Object> call) {
             return "Hi!";
           }
         };
@@ -291,7 +291,7 @@ public final class RetrofitTest {
   @Test public void methodAnnotationsPassedToCallAdapter() {
     final AtomicReference<Annotation[]> annotationsRef = new AtomicReference<>();
     class MyCallAdapterFactory extends CallAdapter.Factory {
-      @Override public CallAdapter<?> get(Type returnType, Annotation[] annotations,
+      @Override public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations,
           Retrofit retrofit) {
         annotationsRef.set(annotations);
         return null;
@@ -1022,7 +1022,7 @@ public final class RetrofitTest {
     Type type = String.class;
     Annotation[] annotations = new Annotation[0];
 
-    CallAdapter<?> expectedAdapter = mock(CallAdapter.class);
+    CallAdapter<?, ?> expectedAdapter = mock(CallAdapter.class);
     CallAdapter.Factory factory = mock(CallAdapter.Factory.class);
 
     Retrofit retrofit = new Retrofit.Builder()
@@ -1032,7 +1032,7 @@ public final class RetrofitTest {
 
     doReturn(expectedAdapter).when(factory).get(type, annotations, retrofit);
 
-    CallAdapter<?> actualAdapter = retrofit.callAdapter(type, annotations);
+    CallAdapter<?, ?> actualAdapter = retrofit.callAdapter(type, annotations);
     assertThat(actualAdapter).isSameAs(expectedAdapter);
 
     verify(factory).get(type, annotations, retrofit);
@@ -1043,11 +1043,11 @@ public final class RetrofitTest {
     Type type = String.class;
     Annotation[] annotations = new Annotation[0];
 
-    CallAdapter<?> expectedAdapter = mock(CallAdapter.class);
+    CallAdapter<?, ?> expectedAdapter = mock(CallAdapter.class);
     CallAdapter.Factory factory2 = mock(CallAdapter.Factory.class);
     CallAdapter.Factory factory1 = spy(new CallAdapter.Factory() {
       @Override
-      public CallAdapter<?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+      public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
         return retrofit.nextCallAdapter(this, returnType, annotations);
       }
     });
@@ -1060,7 +1060,7 @@ public final class RetrofitTest {
 
     doReturn(expectedAdapter).when(factory2).get(type, annotations, retrofit);
 
-    CallAdapter<?> actualAdapter = retrofit.callAdapter(type, annotations);
+    CallAdapter<?, ?> actualAdapter = retrofit.callAdapter(type, annotations);
     assertThat(actualAdapter).isSameAs(expectedAdapter);
 
     verify(factory1).get(type, annotations, retrofit);
@@ -1073,17 +1073,17 @@ public final class RetrofitTest {
     Type type = String.class;
     Annotation[] annotations = new Annotation[0];
 
-    CallAdapter<?> expectedAdapter = mock(CallAdapter.class);
+    CallAdapter<?, ?> expectedAdapter = mock(CallAdapter.class);
     CallAdapter.Factory factory3 = mock(CallAdapter.Factory.class);
     CallAdapter.Factory factory2 = spy(new CallAdapter.Factory() {
       @Override
-      public CallAdapter<?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+      public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
         return retrofit.nextCallAdapter(this, returnType, annotations);
       }
     });
     CallAdapter.Factory factory1 = spy(new CallAdapter.Factory() {
       @Override
-      public CallAdapter<?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+      public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
         return retrofit.nextCallAdapter(this, returnType, annotations);
       }
     });
@@ -1097,7 +1097,7 @@ public final class RetrofitTest {
 
     doReturn(expectedAdapter).when(factory3).get(type, annotations, retrofit);
 
-    CallAdapter<?> actualAdapter = retrofit.callAdapter(type, annotations);
+    CallAdapter<?, ?> actualAdapter = retrofit.callAdapter(type, annotations);
     assertThat(actualAdapter).isSameAs(expectedAdapter);
 
     verify(factory1).get(type, annotations, retrofit);

--- a/retrofit/src/test/java/retrofit2/helpers/DelegatingCallAdapterFactory.java
+++ b/retrofit/src/test/java/retrofit2/helpers/DelegatingCallAdapterFactory.java
@@ -24,7 +24,7 @@ public final class DelegatingCallAdapterFactory extends CallAdapter.Factory {
   public boolean called;
 
   @Override
-  public CallAdapter<?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+  public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
     called = true;
     return retrofit.nextCallAdapter(this, returnType, annotations);
   }

--- a/retrofit/src/test/java/retrofit2/helpers/NonMatchingCallAdapterFactory.java
+++ b/retrofit/src/test/java/retrofit2/helpers/NonMatchingCallAdapterFactory.java
@@ -24,7 +24,7 @@ public final class NonMatchingCallAdapterFactory extends CallAdapter.Factory {
   public boolean called;
 
   @Override
-  public CallAdapter<?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+  public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
     called = true;
     return null;
   }


### PR DESCRIPTION
This is a source-incompatible but binary-compatible change. Since we don't expect a lot of third-party adapters, I think this is acceptable.

Closes #1985.