### PR TITLE
Close ResponseBody on 204/205 to avoid connection leak

### DIFF
--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -203,6 +203,7 @@ final class OkHttpCall<T> implements Call<T> {
     }
 
     if (code == 204 || code == 205) {
+      rawBody.close();
       return Response.success(null, rawResponse);
     }
 


### PR DESCRIPTION
I was getting "A connection to https://... was leaked. Did you forget to close a response body?" on all 204 responses.