### PR TITLE
Explicit usage of File objects in @Multipart methods

### DIFF
--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -15,10 +15,12 @@
  */
 package retrofit2;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.Map;
 import okhttp3.Headers;
+import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 
@@ -243,6 +245,22 @@ abstract class ParameterHandler<T> {
     @Override void apply(RequestBuilder builder, MultipartBody.Part value) throws IOException {
       if (value != null) { // Skip null values.
         builder.addPart(value);
+      }
+    }
+  }
+
+  static final class FilePart extends ParameterHandler<File> {
+    private final String name;
+
+    FilePart(String name) {
+      this.name = name;
+    }
+
+    @Override void apply(RequestBuilder builder, File value) throws IOException {
+      if (value != null) { // Skip null values.
+        builder.addPart(MultipartBody.Part.createFormData(name,
+                value.getName(),
+                RequestBody.create(MediaType.parse("multipart/form-data"), value)));
       }
     }
   }

--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -265,6 +265,31 @@ abstract class ParameterHandler<T> {
     }
   }
 
+  static final class FilePartMap extends ParameterHandler<Map<String, File>> {
+    static final FilePartMap INSTANCE = new FilePartMap();
+
+    @Override void apply(RequestBuilder builder, Map<String, File> value) throws IOException {
+      if (value == null) {
+        throw new IllegalArgumentException("Part map was null.");
+      }
+
+      for (Map.Entry<String, File> entry : value.entrySet()) {
+        String entryKey = entry.getKey();
+        if (entryKey == null) {
+          throw new IllegalArgumentException("Part map contained null key.");
+        }
+        File entryValue = entry.getValue();
+        if (entryValue == null) {
+          throw new IllegalArgumentException(
+              "Part map contained null value for key '" + entryKey + "'.");
+        }
+
+        FilePart singleFileHandler = new FilePart(entryKey);
+        singleFileHandler.apply(builder, entryValue);
+      }
+    }
+  }
+
   static final class PartMap<T> extends ParameterHandler<Map<String, T>> {
     private final Converter<T, RequestBody> valueConverter;
     private final String transferEncoding;

--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -284,17 +284,17 @@ abstract class ParameterHandler<T> {
           throw new IllegalArgumentException(
               "Part map contained null value for key '" + entryKey + "'.");
         }
-        applyElement(builder, entryKey, entryValue);
+        applyEntry(builder, entryKey, entryValue);
       }
     }
 
-    abstract void applyElement(RequestBuilder builder, String key, T value) throws IOException;
+    abstract void applyEntry(RequestBuilder builder, String key, T value) throws IOException;
   }
 
   static final class FilePartMap extends BasePartMap<File> {
     static final FilePartMap INSTANCE = new FilePartMap();
 
-    @Override void applyElement(RequestBuilder builder, String key, File value) throws IOException {
+    @Override void applyEntry(RequestBuilder builder, String key, File value) throws IOException {
       FilePart.apply(builder, key, value);
     }
   }
@@ -308,7 +308,7 @@ abstract class ParameterHandler<T> {
       this.transferEncoding = transferEncoding;
     }
 
-    @Override void applyElement(RequestBuilder builder, String key, T value) throws IOException {
+    @Override void applyEntry(RequestBuilder builder, String key, T value) throws IOException {
       Headers headers = Headers.of(
           "Content-Disposition", "form-data; name=\"" + key + "\"",
           "Content-Transfer-Encoding", transferEncoding);

--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.Map;
 import okhttp3.Headers;
-import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 
@@ -269,7 +268,7 @@ abstract class ParameterHandler<T> {
     }
   }
 
-  static abstract class BasePartMap<T> extends ParameterHandler<Map<String, T>> {
+  abstract static class BasePartMap<T> extends ParameterHandler<Map<String, T>> {
     @Override void apply(RequestBuilder builder, Map<String, T> value) throws IOException {
       if (value == null) {
         throw new IllegalArgumentException("Part map was null.");

--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -260,7 +260,7 @@ abstract class ParameterHandler<T> {
       if (value != null) { // Skip null values.
         builder.addPart(MultipartBody.Part.createFormData(name,
                 value.getName(),
-                RequestBody.create(MediaType.parse("multipart/form-data"), value)));
+                RequestBody.create(null, value)));
       }
     }
   }

--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -15,6 +15,7 @@
  */
 package retrofit2;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -626,6 +627,8 @@ final class ServiceMethod<R, T> {
           } else if (MultipartBody.Part.class.isAssignableFrom(rawParameterType)) {
             throw parameterError(p, "@Part parameters using the MultipartBody.Part must not "
                 + "include a part name in the annotation.");
+          } else if (File.class.isAssignableFrom(rawParameterType)) {
+            return new ParameterHandler.FilePart(partName);
           } else {
             Converter<?, RequestBody> converter =
                 retrofit.requestBodyConverter(type, annotations, methodAnnotations);

--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -663,6 +663,9 @@ final class ServiceMethod<R, T> {
           throw parameterError(p, "@PartMap values cannot be MultipartBody.Part. "
               + "Use @Part List<Part> or a different value type instead.");
         }
+        if (File.class.isAssignableFrom(Utils.getRawType(valueType))) {
+          return ParameterHandler.FilePartMap.INSTANCE;
+        }
 
         Converter<?, RequestBody> valueConverter =
             retrofit.requestBodyConverter(valueType, annotations, methodAnnotations);

--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -590,6 +590,8 @@ final class ServiceMethod<R, T> {
             return ParameterHandler.RawPart.INSTANCE.array();
           } else if (MultipartBody.Part.class.isAssignableFrom(rawParameterType)) {
             return ParameterHandler.RawPart.INSTANCE;
+          } else if (File.class.isAssignableFrom(rawParameterType)) {
+            throw parameterError(p, "File parts must have defined name.");
           } else {
             throw parameterError(p,
                 "@Part annotation must supply a name or use MultipartBody.Part parameter type.");

--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -15,6 +15,7 @@
  */
 package retrofit2;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
@@ -2069,6 +2070,26 @@ public final class RequestBuilderTest {
     } catch (IllegalStateException e) {
       assertThat(e.getMessage()).isEqualTo("Multipart body must have at least one part.");
     }
+  }
+
+  @Test public void multipartWithFile() throws IOException {
+    class Example {
+      @Multipart
+      @POST("/foo/bar/")
+      Call<ResponseBody> method(@Part("filepart") File contenxt) { return null; }
+    }
+
+    File multipartFile = File.createTempFile("multipartFileTest", ".txt");
+
+    Request request = buildRequest(Example.class, multipartFile);
+    RequestBody body = request.body();
+    Buffer buffer = new Buffer();
+    body.writeTo(buffer);
+    String bodyString = buffer.readUtf8();
+
+    assertThat(bodyString)
+            .contains("Content-Disposition: form-data;")
+            .contains("name=\"filepart\"; filename=\"" + multipartFile.getName() + "\"");
   }
 
   @Test public void simpleFormEncoded() {

--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -2091,6 +2091,30 @@ public final class RequestBuilderTest {
             .contains("name=\"filepart\"; filename=\"" + multipartFile.getName() + "\"");
   }
 
+  @Test public void multipartMapWithFiles() throws IOException {
+    class Example {
+      @Multipart
+      @POST("/foo/bar")
+      Call<ResponseBody> method(@PartMap Map<String, File> files) { return null; }
+    }
+
+    Map<String, File> fileMap = new HashMap<>(3);
+    fileMap.put("file[0]", File.createTempFile("multipartFileTest", ".txt"));
+    fileMap.put("file[1]", File.createTempFile("multipartFileTest", ".txt"));
+    fileMap.put("file[2]", File.createTempFile("multipartFileTest", ".txt"));
+
+    Request request = buildRequest(Example.class, fileMap);
+    RequestBody body = request.body();
+    Buffer buffer = new Buffer();
+    body.writeTo(buffer);
+    String bodyString = buffer.readUtf8();
+
+    assertThat(bodyString)
+        .contains("name=\"file[0]\"; filename=\"" + fileMap.get("file[0]").getName() + "\"")
+        .contains("name=\"file[1]\"; filename=\"" + fileMap.get("file[1]").getName() + "\"")
+        .contains("name=\"file[2]\"; filename=\"" + fileMap.get("file[2]").getName() + "\"");
+  }
+
   @Test public void multipartFileContentsNullValue() throws IOException {
     class Example {
       @Multipart

--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -2072,11 +2072,11 @@ public final class RequestBuilderTest {
     }
   }
 
-  @Test public void multipartWithFile() throws IOException {
+  @Test public void multipartWithFileContents() throws IOException {
     class Example {
       @Multipart
       @POST("/foo/bar/")
-      Call<ResponseBody> method(@Part("filepart") File contenxt) { return null; }
+      Call<ResponseBody> method(@Part("filepart") File content) { return null; }
     }
 
     File multipartFile = File.createTempFile("multipartFileTest", ".txt");

--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -2088,7 +2088,6 @@ public final class RequestBuilderTest {
     String bodyString = buffer.readUtf8();
 
     assertThat(bodyString)
-            .contains("Content-Disposition: form-data;")
             .contains("name=\"filepart\"; filename=\"" + multipartFile.getName() + "\"");
   }
 


### PR DESCRIPTION
This feature allow developers to explicitly use `File` objects in Retrofit services with `@Part("name")` and `@PartMap` (`Map<String, File>`) annotations - issue #2037

Provided implementation and tests.
