### PR TITLE
Add README docs for adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ License
 
 
  [1]: http://square.github.io/retrofit/
- [2]: https://search.maven.org/remote_content?g=com.squareup.retrofit&a=retrofit&v=LATEST
+ [2]: https://search.maven.org/remote_content?g=com.squareup.retrofit2&a=retrofit&v=LATEST
  [snap]: https://oss.sonatype.org/content/repositories/snapshots/

--- a/retrofit-adapters/guava/README.md
+++ b/retrofit-adapters/guava/README.md
@@ -6,17 +6,18 @@ A `CallAdapter.Factory` which converts Calls to [Guava][1]'s `ListenableFuture`.
 Download
 --------
 
-Via Maven:
+Download [the latest jar][2] or grab via Maven:
 ```xml
 <dependency>
   <groupId>com.squareup.retrofit2</groupId>
   <artifactId>adapter-guava</artifactId>
-  <version>latest.version.here</version>
+  <version>see.latest.version</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.squareup.retrofit2:adapter-guava:latest.version.here'
+compile 'com.squareup.retrofit2:adapter-guava:see.latest.version'
 ```
 
  [1]: https://github.com/google/guava
+ [2]: https://search.maven.org/remote_content?g=com.squareup.retrofit2&a=adapter-guava&v=LATEST

--- a/retrofit-adapters/guava/README.md
+++ b/retrofit-adapters/guava/README.md
@@ -1,0 +1,22 @@
+Guava Adapter
+==============
+
+A `CallAdapter.Factory` which converts Calls to [Guava][1]'s `ListenableFuture`.
+
+Download
+--------
+
+Via Maven:
+```xml
+<dependency>
+  <groupId>com.squareup.retrofit2</groupId>
+  <artifactId>adapter-guava</artifactId>
+  <version>latest.version.here</version>
+</dependency>
+```
+or Gradle:
+```groovy
+compile 'com.squareup.retrofit2:adapter-guava:latest.version.here'
+```
+
+ [1]: https://github.com/google/guava

--- a/retrofit-adapters/java8/README.md
+++ b/retrofit-adapters/java8/README.md
@@ -1,0 +1,20 @@
+Java 8 Adapter
+==============
+
+A `CallAdapter.Factory` which converts Calls to Java 8's `CompletableFuture`.
+
+Download
+--------
+
+Via Maven:
+```xml
+<dependency>
+  <groupId>com.squareup.retrofit2</groupId>
+  <artifactId>adapter-java8</artifactId>
+  <version>latest.version.here</version>
+</dependency>
+```
+or Gradle:
+```groovy
+compile 'com.squareup.retrofit2:adapter-java8:latest.version.here'
+```

--- a/retrofit-adapters/java8/README.md
+++ b/retrofit-adapters/java8/README.md
@@ -6,15 +6,16 @@ A `CallAdapter.Factory` which converts Calls to Java 8's `CompletableFuture`.
 Download
 --------
 
-Via Maven:
+Download [the latest jar][1] or grab via Maven:
 ```xml
 <dependency>
   <groupId>com.squareup.retrofit2</groupId>
   <artifactId>adapter-java8</artifactId>
-  <version>latest.version.here</version>
+  <version>see.latest.version</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.squareup.retrofit2:adapter-java8:latest.version.here'
+compile 'com.squareup.retrofit2:adapter-java8:see.latest.version'
 ```
+[1]: https://search.maven.org/remote_content?g=com.squareup.retrofit2&a=adapter-java8&v=LATEST

--- a/retrofit-adapters/rxjava/README.md
+++ b/retrofit-adapters/rxjava/README.md
@@ -1,0 +1,32 @@
+RxJava Adapter
+==============
+
+A `CallAdapter.Factory` which converts Calls to [RxJava][1] `Observable`s.
+
+```java
+@GET("user")
+Observable<User> getCurrentUser();
+```
+If you need both the deserialized object, as well as the Retrofit `Response`:
+```java
+@GET("user")
+Observable<Response<User>> getCurrentUser();
+```
+
+Download
+--------
+
+Via Maven:
+```xml
+<dependency>
+  <groupId>com.squareup.retrofit2</groupId>
+  <artifactId>adapter-rxjava</artifactId>
+  <version>latest.version.here</version>
+</dependency>
+```
+or Gradle:
+```groovy
+compile 'com.squareup.retrofit2:adapter-rxjava:latest.version.here'
+```
+
+ [1]: https://github.com/ReactiveX/RxJava

--- a/retrofit-adapters/rxjava/README.md
+++ b/retrofit-adapters/rxjava/README.md
@@ -16,17 +16,18 @@ Observable<Response<User>> getCurrentUser();
 Download
 --------
 
-Via Maven:
+Download [the latest jar][2] or grab via Maven:
 ```xml
 <dependency>
   <groupId>com.squareup.retrofit2</groupId>
   <artifactId>adapter-rxjava</artifactId>
-  <version>latest.version.here</version>
+  <version>see.latest.version</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.squareup.retrofit2:adapter-rxjava:latest.version.here'
+compile 'com.squareup.retrofit2:adapter-rxjava:see.latest.version'
 ```
 
  [1]: https://github.com/ReactiveX/RxJava
+ [2]: https://search.maven.org/remote_content?g=com.squareup.retrofit2&a=adapter-rxjava&v=LATEST

--- a/retrofit-adapters/rxjava2/README.md
+++ b/retrofit-adapters/rxjava2/README.md
@@ -1,0 +1,30 @@
+RxJava 2 Adapter
+==============
+
+A `CallAdapter.Factory` which converts Calls to [RxJava 2.X][1] types.
+
+Available types:
+
+ * `Observable<T>`, `Observable<Response<T>>`, and `Observable<Result<T>>` where `T` is the body type.
+ * `Flowable<T>`, `Flowable<Response<T>>` and `Flowable<Result<T>>` where `T` is the body type.
+ * `Single<T>`, `Single<Response<T>>`, and `Single<Result<T>>`  where `T` is the body type.
+ * `Maybe<T>`, `Maybe<Response<T>>`, and `Maybe<Result<T>>`  where `T` is the body type.
+ * `Completable` where response bodies are discarded.
+
+Download
+--------
+
+Via Maven:
+```xml
+<dependency>
+  <groupId>com.squareup.retrofit2</groupId>
+  <artifactId>adapter-rxjava2</artifactId>
+  <version>latest.version.here</version>
+</dependency>
+```
+or Gradle:
+```groovy
+compile 'com.squareup.retrofit2:adapter-rxjava2:latest.version.here'
+```
+
+ [1]: https://github.com/ReactiveX/RxJava

--- a/retrofit-adapters/rxjava2/README.md
+++ b/retrofit-adapters/rxjava2/README.md
@@ -14,17 +14,18 @@ Available types:
 Download
 --------
 
-Via Maven:
+Download [the latest JAR][2] or grab via Maven:
 ```xml
 <dependency>
   <groupId>com.squareup.retrofit2</groupId>
   <artifactId>adapter-rxjava2</artifactId>
-  <version>latest.version.here</version>
+  <version>see.latest.version</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.squareup.retrofit2:adapter-rxjava2:latest.version.here'
+compile 'com.squareup.retrofit2:adapter-rxjava2:see.latest.version'
 ```
 
  [1]: https://github.com/ReactiveX/RxJava
+ [2]: https://search.maven.org/remote_content?g=com.squareup.retrofit2&a=adapter-rxjava2&v=LATEST


### PR DESCRIPTION
It can be confusing or tricky to understand what the purpose is or what exactly a `CallAdapter.Factory` does. For instance, I spent quite a bit of time struggling and Googling before I realized you could get an `Observable<Response<Model>>` with an RxJava adapter. This adds some basic docs to each of the supported adapters, similar to how each `Converter` has its own docs. 

I am not super familiar with what all types are supported in the RxJava 1.X adapter, so that should be checked. I pulled most of the README for RxJava 2.X adapter from [Jake's project](https://github.com/JakeWharton/retrofit2-rxjava2-adapter)

Happy to make changes as needed!