### PR TITLE
proguard update

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -183,6 +183,7 @@ compile 'com.squareup.retrofit2:retrofit:<span class="version pln"><em>(insert l
 -keepattributes Signature
 # Retain declared checked exceptions for use by a Proxy instance.
 -keepattributes Exceptions
+-dontwarn okio.**
 </pre>
             </section>
 


### PR DESCRIPTION
Doesn't allow generate an apk when using proguard
- Warning:there were 14 unresolved references to classes or interfaces.
- Warning:Exception while processing task java.io.IOException: Please correct the above warnings first.
- Error:Execution failed for task ':app:transformClassesAndResourcesWithProguardForRelease'.
> java.io.IOException: Please correct the above warnings first.