### PR TITLE
Remove RoboVM support.

### DIFF
--- a/retrofit/src/main/java/retrofit2/Platform.java
+++ b/retrofit/src/main/java/retrofit2/Platform.java
@@ -20,7 +20,6 @@ import android.os.Handler;
 import android.os.Looper;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.Executor;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
@@ -43,11 +42,6 @@ class Platform {
     try {
       Class.forName("java.util.Optional");
       return new Java8();
-    } catch (ClassNotFoundException ignored) {
-    }
-    try {
-      Class.forName("org.robovm.apple.foundation.NSObject");
-      return new IOS();
     } catch (ClassNotFoundException ignored) {
     }
     return new Platform();
@@ -106,49 +100,6 @@ class Platform {
 
       @Override public void execute(Runnable r) {
         handler.post(r);
-      }
-    }
-  }
-
-  static class IOS extends Platform {
-    @Override public Executor defaultCallbackExecutor() {
-      return new MainThreadExecutor();
-    }
-
-    @Override CallAdapter.Factory defaultCallAdapterFactory(Executor callbackExecutor) {
-      return new ExecutorCallAdapterFactory(callbackExecutor);
-    }
-
-    static class MainThreadExecutor implements Executor {
-      private static Object queue;
-      private static Method addOperation;
-
-      static {
-        try {
-          // queue = NSOperationQueue.getMainQueue();
-          Class<?> operationQueue = Class.forName("org.robovm.apple.foundation.NSOperationQueue");
-          queue = operationQueue.getDeclaredMethod("getMainQueue").invoke(null);
-          addOperation = operationQueue.getDeclaredMethod("addOperation", Runnable.class);
-        } catch (Exception e) {
-          throw new AssertionError(e);
-        }
-      }
-
-      @Override public void execute(Runnable r) {
-        try {
-          // queue.addOperation(r);
-          addOperation.invoke(queue, r);
-        } catch (IllegalArgumentException | IllegalAccessException e) {
-          throw new AssertionError(e);
-        } catch (InvocationTargetException e) {
-          Throwable cause = e.getCause();
-          if (cause instanceof RuntimeException) {
-            throw (RuntimeException) cause;
-          } else if (cause instanceof Error) {
-            throw (Error) cause;
-          }
-          throw new RuntimeException(cause);
-        }
       }
     }
   }

--- a/website/index.html
+++ b/website/index.html
@@ -175,8 +175,6 @@ compile 'com.squareup.retrofit2:retrofit:<span class="version pln"><em>(insert l
               <pre class="prettyprint">
 # Platform calls Class.forName on types which do not exist on Android to determine platform.
 -dontnote retrofit2.Platform
-# Platform used when running on RoboVM on iOS. Will not be used at runtime.
--dontnote retrofit2.Platform$IOS$MainThreadExecutor
 # Platform used when running on Java 8 VMs. Will not be used at runtime.
 -dontwarn retrofit2.Platform$Java8
 # Retain generic type information for use by reflection by converters and adapters.


### PR DESCRIPTION
The project died quickly after we merged support, and I must have been high to let someone convince me this was a good idea to add.

If you still need RoboVM support supply your own callback executor to Retrofit.Builder.