### PR TITLE
Prevent NPE when retrofit is used by an IntelliJ plugin. The Android …

### DIFF
--- a/retrofit/src/main/java/retrofit2/Platform.java
+++ b/retrofit/src/main/java/retrofit2/Platform.java
@@ -32,12 +32,14 @@ class Platform {
   }
 
   private static Platform findPlatform() {
-    try {
-      Class.forName("android.os.Build");
-      if (Build.VERSION.SDK_INT != 0) {
-        return new Android();
+    if ("Dalvik".equals(System.getProperty("java.vm.name"))) {
+      try {
+        Class.forName("android.os.Build");
+        if (Build.VERSION.SDK_INT != 0) {
+          return new Android();
+        }
+      } catch (ClassNotFoundException ignored) {
       }
-    } catch (ClassNotFoundException ignored) {
     }
     try {
       Class.forName("java.util.Optional");


### PR DESCRIPTION
…Support plugin in IntelliJ IDEA Ultimate makes retrofit incorrectly think it is running in an Android environment. This is a fix for retrofit issue #2102.