### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ License
 
 
  [1]: http://square.github.io/retrofit/
- [2]: https://search.maven.org/remote_content?g=com.squareup.retrofit&a=retrofit&v=LATEST
+ [2]: https://search.maven.org/remote_content?g=com.squareup.retrofit2&a=retrofit&v=LATEST
  [snap]: https://oss.sonatype.org/content/repositories/snapshots/

--- a/retrofit-adapters/rxjava/README.md
+++ b/retrofit-adapters/rxjava/README.md
@@ -1,4 +1,4 @@
-Java8 Adapter
+RxJava Adapter
 ==============
 
 An `Adapter` for adapting [RxJava 1.x][1] types.

--- a/retrofit-adapters/rxjava2/README.md
+++ b/retrofit-adapters/rxjava2/README.md
@@ -1,4 +1,4 @@
-Java8 Adapter
+RxJava2 Adapter
 ==============
 
 An `Adapter` for adapting [RxJava 2.x][1] types.


### PR DESCRIPTION
This fixes the title of two of the converter adapter READMEs and also corrects the link to the jar on the main README. 