### PR TITLE
Okio proguard rules link

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -171,7 +171,7 @@ compile 'com.squareup.retrofit2:retrofit:<span class="version pln"><em>(insert l
               <p>Retrofit requires at minimum Java 7 or Android 2.3.</p>
 
               <h4>ProGuard</h4>
-              <p>If you are using Proguard in your project add the following lines to your configuration:</p>
+              <p>If you are using ProGuard in your project add the following lines to your configuration:</p>
               <pre class="prettyprint">
 # Platform calls Class.forName on types which do not exist on Android to determine platform.
 -dontnote retrofit2.Platform
@@ -182,6 +182,7 @@ compile 'com.squareup.retrofit2:retrofit:<span class="version pln"><em>(insert l
 # Retain declared checked exceptions for use by a Proxy instance.
 -keepattributes Exceptions
 </pre>
+            <p>Retrofit uses <a href="https://github.com/square/okio">Okio</a> under the hood, so you may want to look at its <a href="https://github.com/square/okio#proguard">ProGuard rules</a> as well.</p>
             </section>
 
             <section id="contributing">


### PR DESCRIPTION
As discussed in https://github.com/square/retrofit/pull/2090 this links out to Okio for its ProGuard rules. 

![capture](https://cloud.githubusercontent.com/assets/1459320/21040076/1be349f0-bda8-11e6-862b-e9e29cea9855.PNG)
