### PR TITLE
Add optional headers to @Part annotation

### DIFF
--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -594,9 +594,10 @@ final class ServiceMethod<R, T> {
                 "@Part annotation must supply a name or use MultipartBody.Part parameter type.");
           }
         } else {
-          Headers headers =
-              Headers.of("Content-Disposition", "form-data; name=\"" + partName + "\"",
-                  "Content-Transfer-Encoding", part.encoding());
+          Headers headers = parseHeaders(part.headers()).newBuilder()
+                .add("Content-Disposition", "form-data; name=\"" + partName + "\"")
+                .add("Content-Transfer-Encoding", part.encoding())
+                .build();
 
           if (Iterable.class.isAssignableFrom(rawParameterType)) {
             if (!(type instanceof ParameterizedType)) {

--- a/retrofit/src/main/java/retrofit2/http/Part.java
+++ b/retrofit/src/main/java/retrofit2/http/Part.java
@@ -40,6 +40,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>
  * Values may be {@code null} which will omit them from the request body.
  * <p>
+ * Headers can specified with {@link #headers() headers}. Usage mirrors
+ * {@link Headers Headers}.
+ * <p>
  * <pre><code>
  * &#64;Multipart
  * &#64;POST("/")
@@ -61,4 +64,5 @@ public @interface Part {
   String value() default "";
   /** The {@code Content-Transfer-Encoding} of this part. */
   String encoding() default "binary";
+  String[] headers() default {};
 }

--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -2071,6 +2071,59 @@ public final class RequestBuilderTest {
     }
   }
 
+  @Test public void multipartWithPartHeaders() throws IOException {
+    class Example {
+      @Multipart //
+      @POST("/foo/bar/") //
+      Call<ResponseBody> method(@Part(value = "ping", headers = "foo: bar") String ping,
+                                @Part(value = "kit", headers = {"tic: tock", "how: now"})
+                                RequestBody kit) {
+        return null;
+      }
+    }
+
+    Request request = buildRequest(Example.class, "pong", RequestBody.create(
+        MediaType.parse("text/plain"), "kat"));
+    assertThat(request.method()).isEqualTo("POST");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.url().toString()).isEqualTo("http://example.com/foo/bar/");
+
+    RequestBody body = request.body();
+    Buffer buffer = new Buffer();
+    body.writeTo(buffer);
+    String bodyString = buffer.readUtf8();
+
+    assertThat(bodyString)
+        .contains("foo: bar")
+        .contains("Content-Disposition: form-data;")
+        .contains("name=\"ping\"\r\n")
+        .contains("\r\npong\r\n--");
+
+    assertThat(bodyString)
+        .contains("tic: tock")
+        .contains("how: now")
+        .contains("Content-Disposition: form-data;")
+        .contains("name=\"kit\"")
+        .contains("\r\nkat\r\n--");
+  }
+
+  @Test public void multipartWithValidHeaders() throws IOException {
+    class Example {
+      @Multipart //
+      @POST("/foo/bar/") //
+      Call<ResponseBody> method(@Part(value = "ping", headers = "foo bar") String ping) {
+        return null;
+      }
+    }
+    try {
+      Request request = buildRequest(Example.class, "pong");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("@Headers value must be in the form \"Name: Value\". Found: \"foo bar\"\n" +
+          "    for method Example.method");
+    }
+  }
+
   @Test public void simpleFormEncoded() {
     class Example {
       @FormUrlEncoded //


### PR DESCRIPTION
Add a `headers` property to the `Part` annotation to allow for custom headers inside each part of the multipart body.

Inspired by this [SO question](http://stackoverflow.com/q/41164123/1904517).