### PR TITLE
Add createAsync() to RxJava 2.x CallAdapter.Factory.

### DIFF
--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/CallEnqueueObservable.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/CallEnqueueObservable.java
@@ -22,50 +22,67 @@ import io.reactivex.exceptions.CompositeException;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.plugins.RxJavaPlugins;
 import retrofit2.Call;
+import retrofit2.Callback;
 import retrofit2.Response;
 
-final class CallObservable<T> extends Observable<Response<T>> {
+final class CallEnqueueObservable<T> extends Observable<Response<T>> {
   private final Call<T> originalCall;
 
-  CallObservable(Call<T> originalCall) {
+  CallEnqueueObservable(Call<T> originalCall) {
     this.originalCall = originalCall;
   }
 
   @Override protected void subscribeActual(Observer<? super Response<T>> observer) {
     // Since Call is a one-shot type, clone it for each new observer.
     Call<T> call = originalCall.clone();
-    observer.onSubscribe(new CallDisposable(call));
+    CallCallback<T> callback = new CallCallback<>(call, observer);
+    observer.onSubscribe(callback);
+    call.enqueue(callback);
+  }
 
+  private static final class CallCallback<T> implements Disposable, Callback<T> {
+    private final Call<?> call;
+    private final Observer<? super Response<T>> observer;
     boolean terminated = false;
-    try {
-      Response<T> response = call.execute();
-      if (!call.isCanceled()) {
+
+    CallCallback(Call<?> call, Observer<? super Response<T>> observer) {
+      this.call = call;
+      this.observer = observer;
+    }
+
+    @Override public void onResponse(Call<T> call, Response<T> response) {
+      if (call.isCanceled()) return;
+
+      try {
         observer.onNext(response);
-      }
-      if (!call.isCanceled()) {
-        terminated = true;
-        observer.onComplete();
-      }
-    } catch (Throwable t) {
-      Exceptions.throwIfFatal(t);
-      if (terminated) {
-        RxJavaPlugins.onError(t);
-      } else if (!call.isCanceled()) {
-        try {
-          observer.onError(t);
-        } catch (Throwable inner) {
-          Exceptions.throwIfFatal(inner);
-          RxJavaPlugins.onError(new CompositeException(t, inner));
+
+        if (!call.isCanceled()) {
+          terminated = true;
+          observer.onComplete();
+        }
+      } catch (Throwable t) {
+        if (terminated) {
+          RxJavaPlugins.onError(t);
+        } else if (!call.isCanceled()) {
+          try {
+            observer.onError(t);
+          } catch (Throwable inner) {
+            Exceptions.throwIfFatal(inner);
+            RxJavaPlugins.onError(new CompositeException(t, inner));
+          }
         }
       }
     }
-  }
 
-  private static final class CallDisposable implements Disposable {
-    private final Call<?> call;
+    @Override public void onFailure(Call<T> call, Throwable t) {
+      if (call.isCanceled()) return;
 
-    CallDisposable(Call<?> call) {
-      this.call = call;
+      try {
+        observer.onError(t);
+      } catch (Throwable inner) {
+        Exceptions.throwIfFatal(inner);
+        RxJavaPlugins.onError(new CompositeException(t, inner));
+      }
     }
 
     @Override public void dispose() {

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/CallExecuteObservable.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/CallExecuteObservable.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016 Jake Wharton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.adapter.rxjava2;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.plugins.RxJavaPlugins;
+import retrofit2.Call;
+import retrofit2.Response;
+
+final class CallExecuteObservable<T> extends Observable<Response<T>> {
+  private final Call<T> originalCall;
+
+  CallExecuteObservable(Call<T> originalCall) {
+    this.originalCall = originalCall;
+  }
+
+  @Override protected void subscribeActual(Observer<? super Response<T>> observer) {
+    // Since Call is a one-shot type, clone it for each new observer.
+    Call<T> call = originalCall.clone();
+    observer.onSubscribe(new CallDisposable(call));
+
+    boolean terminated = false;
+    try {
+      Response<T> response = call.execute();
+      if (!call.isCanceled()) {
+        observer.onNext(response);
+      }
+      if (!call.isCanceled()) {
+        terminated = true;
+        observer.onComplete();
+      }
+    } catch (Throwable t) {
+      Exceptions.throwIfFatal(t);
+      if (terminated) {
+        RxJavaPlugins.onError(t);
+      } else if (!call.isCanceled()) {
+        try {
+          observer.onError(t);
+        } catch (Throwable inner) {
+          Exceptions.throwIfFatal(inner);
+          RxJavaPlugins.onError(new CompositeException(t, inner));
+        }
+      }
+    }
+  }
+
+  private static final class CallDisposable implements Disposable {
+    private final Call<?> call;
+
+    CallDisposable(Call<?> call) {
+      this.call = call;
+    }
+
+    @Override public void dispose() {
+      call.cancel();
+    }
+
+    @Override public boolean isDisposed() {
+      return call.isCanceled();
+    }
+  }
+}

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
@@ -26,6 +26,7 @@ import retrofit2.Response;
 final class RxJava2CallAdapter<R> implements CallAdapter<R, Object> {
   private final Type responseType;
   private final Scheduler scheduler;
+  private final boolean isAsync;
   private final boolean isResult;
   private final boolean isBody;
   private final boolean isFlowable;
@@ -33,10 +34,12 @@ final class RxJava2CallAdapter<R> implements CallAdapter<R, Object> {
   private final boolean isMaybe;
   private final boolean isCompletable;
 
-  RxJava2CallAdapter(Type responseType, Scheduler scheduler, boolean isResult, boolean isBody,
-      boolean isFlowable, boolean isSingle, boolean isMaybe, boolean isCompletable) {
+  RxJava2CallAdapter(Type responseType, Scheduler scheduler, boolean isAsync, boolean isResult,
+      boolean isBody, boolean isFlowable, boolean isSingle, boolean isMaybe,
+      boolean isCompletable) {
     this.responseType = responseType;
     this.scheduler = scheduler;
+    this.isAsync = isAsync;
     this.isResult = isResult;
     this.isBody = isBody;
     this.isFlowable = isFlowable;
@@ -50,7 +53,9 @@ final class RxJava2CallAdapter<R> implements CallAdapter<R, Object> {
   }
 
   @Override public Object adapt(Call<R> call) {
-    Observable<Response<R>> responseObservable = new CallObservable<>(call);
+    Observable<Response<R>> responseObservable = isAsync
+        ? new CallEnqueueObservable<>(call)
+        : new CallExecuteObservable<>(call);
 
     Observable<?> observable;
     if (isResult) {

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
@@ -59,7 +59,15 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
    * by default.
    */
   public static RxJava2CallAdapterFactory create() {
-    return new RxJava2CallAdapterFactory(null);
+    return new RxJava2CallAdapterFactory(null, false);
+  }
+
+  /**
+   * Returns an instance which creates asynchronous observables. Applying
+   * {@link Observable#subscribeOn} has no effect on stream types created by this factory.
+   */
+  public static RxJava2CallAdapterFactory createAsync() {
+    return new RxJava2CallAdapterFactory(null, true);
   }
 
   /**
@@ -68,13 +76,15 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
    */
   public static RxJava2CallAdapterFactory createWithScheduler(Scheduler scheduler) {
     if (scheduler == null) throw new NullPointerException("scheduler == null");
-    return new RxJava2CallAdapterFactory(scheduler);
+    return new RxJava2CallAdapterFactory(scheduler, false);
   }
 
   private final Scheduler scheduler;
+  private final boolean isAsync;
 
-  private RxJava2CallAdapterFactory(Scheduler scheduler) {
+  private RxJava2CallAdapterFactory(Scheduler scheduler, boolean isAsync) {
     this.scheduler = scheduler;
+    this.isAsync = isAsync;
   }
 
   @Override
@@ -84,7 +94,8 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
     if (rawType == Completable.class) {
       // Completable is not parameterized (which is what the rest of this method deals with) so it
       // can only be created with a single configuration.
-      return new RxJava2CallAdapter(Void.class, scheduler, false, true, false, false, false, true);
+      return new RxJava2CallAdapter(Void.class, scheduler, isAsync, false, true, false, false,
+          false, true);
     }
 
     boolean isFlowable = rawType == Flowable.class;
@@ -123,7 +134,7 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
       isBody = true;
     }
 
-    return new RxJava2CallAdapter(responseType, scheduler, isResult, isBody, isFlowable,
+    return new RxJava2CallAdapter(responseType, scheduler, isAsync, isResult, isBody, isFlowable,
         isSingle, isMaybe, false);
   }
 }


### PR DESCRIPTION
This uses Call.enqueue() instead of Call.execute() when invoking the underlying Call.

Refs #2132.