### PR TITLE
Make Calls more stateful and add deferring factory.

### DIFF
--- a/retrofit-mock/src/main/java/retrofit2/mock/Calls.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/Calls.java
@@ -16,6 +16,8 @@
 package retrofit2.mock;
 
 import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
 import okhttp3.Request;
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -23,75 +25,146 @@ import retrofit2.Response;
 
 /** Factory methods for creating {@link Call} instances which immediately respond or fail. */
 public final class Calls {
+  /**
+   * Invokes {@code callable} once for the returned {@link Call} and once for each instance that is
+   * obtained from {@linkplain Call#clone() cloning} the returned {@link Call}.
+   */
+  public static <T> Call<T> defer(Callable<Call<T>> callable) {
+    return new DeferredCall<>(callable);
+  }
+
   public static <T> Call<T> response(T successValue) {
-    return response(Response.success(successValue));
+    return new FakeCall<>(Response.success(successValue), null);
   }
 
-  public static <T> Call<T> response(final Response<T> response) {
-    return new Call<T>() {
-      @Override public Response<T> execute() throws IOException {
-        return response;
-      }
-
-      @Override public void enqueue(Callback<T> callback) {
-        callback.onResponse(this, response);
-      }
-
-      @Override public boolean isExecuted() {
-        return false;
-      }
-
-      @Override public void cancel() {
-      }
-
-      @Override public boolean isCanceled() {
-        return false;
-      }
-
-      @SuppressWarnings("CloneDoesntCallSuperClone") // Immutable object.
-      @Override public Call<T> clone() {
-        return this;
-      }
-
-      @Override public Request request() {
-        return response.raw().request();
-      }
-    };
+  public static <T> Call<T> response(Response<T> response) {
+    return new FakeCall<>(response, null);
   }
 
-  public static <T> Call<T> failure(final IOException failure) {
-    return new Call<T>() {
-      @Override public Response<T> execute() throws IOException {
-        throw failure;
-      }
-
-      @Override public void enqueue(Callback<T> callback) {
-        callback.onFailure(this, failure);
-      }
-
-      @Override public boolean isExecuted() {
-        return false;
-      }
-
-      @Override public void cancel() {
-      }
-
-      @Override public boolean isCanceled() {
-        return false;
-      }
-
-      @SuppressWarnings("CloneDoesntCallSuperClone") // Immutable object.
-      @Override public Call<T> clone() {
-        return this;
-      }
-
-      @Override public Request request() {
-        return new Request.Builder().url("http://localhost").build();
-      }
-    };
+  public static <T> Call<T> failure(IOException failure) {
+    return new FakeCall<>(null, failure);
   }
 
   private Calls() {
     throw new AssertionError("No instances.");
+  }
+
+  static final class FakeCall<T> implements Call<T> {
+    private final Response<T> response;
+    private final IOException error;
+    private final AtomicBoolean canceled = new AtomicBoolean();
+    private final AtomicBoolean executed = new AtomicBoolean();
+
+    FakeCall(Response<T> response, IOException error) {
+      if ((response == null) == (error == null)) {
+        throw new AssertionError("Only one of response or error can be set.");
+      }
+      this.response = response;
+      this.error = error;
+    }
+
+    @Override public Response<T> execute() throws IOException {
+      if (!executed.compareAndSet(false, true)) {
+        throw new IllegalStateException("Already executed");
+      }
+      if (canceled.get()) {
+        throw new IOException("canceled");
+      }
+      if (response != null) {
+        return response;
+      }
+      throw error;
+    }
+
+    @Override public void enqueue(Callback<T> callback) {
+      if (callback == null) {
+        throw new NullPointerException("callback == null");
+      }
+      if (!executed.compareAndSet(false, true)) {
+        throw new IllegalStateException("Already executed");
+      }
+      if (canceled.get()) {
+        callback.onFailure(this, new IOException("canceled"));
+      } else if (response != null) {
+        callback.onResponse(this, response);
+      } else {
+        callback.onFailure(this, error);
+      }
+    }
+
+    @Override public boolean isExecuted() {
+      return executed.get();
+    }
+
+    @Override public void cancel() {
+      canceled.set(true);
+    }
+
+    @Override public boolean isCanceled() {
+      return canceled.get();
+    }
+
+    @Override public Call<T> clone() {
+      return new FakeCall<>(response, error);
+    }
+
+    @Override public Request request() {
+      if (response != null) {
+        return response.raw().request();
+      }
+      return new Request.Builder().url("http://localhost").build();
+    }
+  }
+
+  static final class DeferredCall<T> implements Call<T> {
+    private final Callable<Call<T>> callable;
+    private Call<T> delegate;
+
+    DeferredCall(Callable<Call<T>> callable) {
+      this.callable = callable;
+    }
+
+    private synchronized Call<T> getDelegate() {
+      Call<T> delegate = this.delegate;
+      if (delegate == null) {
+        try {
+          delegate = callable.call();
+        } catch (IOException e) {
+          delegate = failure(e);
+        } catch (Exception e) {
+          throw new IllegalStateException("Callable threw unrecoverable exception", e);
+        }
+        this.delegate = delegate;
+      }
+      return delegate;
+    }
+
+    @Override public Response<T> execute() throws IOException {
+      return getDelegate().execute();
+    }
+
+    @Override public void enqueue(Callback<T> callback) {
+      getDelegate().enqueue(callback);
+    }
+
+    @Override public boolean isExecuted() {
+      return getDelegate().isExecuted();
+    }
+
+    @Override public void cancel() {
+      getDelegate().cancel();
+    }
+
+    @Override public boolean isCanceled() {
+      return getDelegate().isCanceled();
+    }
+
+    @Override public Call<T> clone() {
+      return new DeferredCall<>(callable);
+    }
+
+    @Override public Request request() {
+      return getDelegate().request();
+    }
   }
 }

--- a/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java
+++ b/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.mock;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public final class CallsTest {
+  @Test public void bodyExecute() throws IOException {
+    Call<String> taco = Calls.response("Taco");
+    assertEquals("Taco", taco.execute().body());
+  }
+
+  @Test public void bodyEnqueue() throws IOException {
+    Call<String> taco = Calls.response("Taco");
+    final AtomicReference<Response<String>> responseRef = new AtomicReference<>();
+    taco.enqueue(new Callback<String>() {
+      @Override public void onResponse(Call<String> call, Response<String> response) {
+        responseRef.set(response);
+      }
+
+      @Override public void onFailure(Call<String> call, Throwable t) {
+        fail();
+      }
+    });
+    assertThat(responseRef.get().body()).isEqualTo("Taco");
+  }
+
+  @Test public void responseExecute() throws IOException {
+    Response<String> response = Response.success("Taco");
+    Call<String> taco = Calls.response(response);
+    assertFalse(taco.isExecuted());
+    assertSame(response, taco.execute());
+    assertTrue(taco.isExecuted());
+    try {
+      taco.execute();
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Already executed");
+    }
+  }
+
+  @Test public void responseEnqueue() {
+    Response<String> response = Response.success("Taco");
+    Call<String> taco = Calls.response(response);
+    assertFalse(taco.isExecuted());
+
+    final AtomicReference<Response<String>> responseRef = new AtomicReference<>();
+    taco.enqueue(new Callback<String>() {
+      @Override public void onResponse(Call<String> call, Response<String> response) {
+        responseRef.set(response);
+      }
+
+      @Override public void onFailure(Call<String> call, Throwable t) {
+        fail();
+      }
+    });
+    assertSame(response, responseRef.get());
+    assertTrue(taco.isExecuted());
+
+    try {
+      taco.enqueue(new Callback<String>() {
+        @Override public void onResponse(Call<String> call, Response<String> response) {
+          fail();
+        }
+
+        @Override public void onFailure(Call<String> call, Throwable t) {
+          fail();
+        }
+      });
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Already executed");
+    }
+  }
+
+  @Test public void enqueueNullThrows() {
+    Call<String> taco = Calls.response("Taco");
+    try {
+      taco.enqueue(null);
+      fail();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("callback == null");
+    }
+  }
+
+  @Test public void responseCancelExecute() {
+    Call<String> taco = Calls.response(Response.success("Taco"));
+    assertFalse(taco.isCanceled());
+    taco.cancel();
+    assertTrue(taco.isCanceled());
+
+    try {
+      taco.execute();
+      fail();
+    } catch (IOException e) {
+      assertThat(e).hasMessage("canceled");
+    }
+  }
+
+  @Test public void responseCancelEnqueue() throws IOException {
+    Call<String> taco = Calls.response(Response.success("Taco"));
+    assertFalse(taco.isCanceled());
+    taco.cancel();
+    assertTrue(taco.isCanceled());
+
+    final AtomicReference<Throwable> failureRef = new AtomicReference<>();
+    taco.enqueue(new Callback<String>() {
+      @Override public void onResponse(Call<String> call, Response<String> response) {
+        fail();
+      }
+
+      @Override public void onFailure(Call<String> call, Throwable t) {
+        failureRef.set(t);
+      }
+    });
+    assertThat(failureRef.get()).isInstanceOf(IOException.class).hasMessage("canceled");
+  }
+
+  @Test public void failureExecute() {
+    IOException failure = new IOException("Hey");
+    Call<Object> taco = Calls.failure(failure);
+    assertFalse(taco.isExecuted());
+    try {
+      taco.execute();
+      fail();
+    } catch (IOException e) {
+      assertSame(failure, e);
+    }
+    assertTrue(taco.isExecuted());
+  }
+
+  @Test public void failureEnqueue() {
+    IOException failure = new IOException("Hey");
+    Call<Object> taco = Calls.failure(failure);
+    assertFalse(taco.isExecuted());
+
+    final AtomicReference<Throwable> failureRef = new AtomicReference<>();
+    taco.enqueue(new Callback<Object>() {
+      @Override public void onResponse(Call<Object> call, Response<Object> response) {
+        fail();
+      }
+
+      @Override public void onFailure(Call<Object> call, Throwable t) {
+        failureRef.set(t);
+      }
+    });
+    assertSame(failure, failureRef.get());
+    assertTrue(taco.isExecuted());
+  }
+
+  @Test public void cloneHasOwnState() throws IOException {
+    Call<String> taco = Calls.response("Taco");
+    assertEquals("Taco", taco.execute().body());
+    Call<String> anotherTaco = taco.clone();
+    assertFalse(anotherTaco.isExecuted());
+    assertEquals("Taco", anotherTaco.execute().body());
+    assertTrue(anotherTaco.isExecuted());
+  }
+
+  @Test public void deferredReturnExecute() throws IOException {
+    Call<Integer> counts = Calls.defer(new Callable<Call<Integer>>() {
+      private int count = 0;
+
+      @Override public Call<Integer> call() throws Exception {
+        return Calls.response(++count);
+      }
+    });
+    Call<Integer> a = counts.clone();
+    Call<Integer> b = counts.clone();
+
+    assertEquals(1, b.execute().body().intValue());
+    assertEquals(2, a.execute().body().intValue());
+  }
+
+  @Test public void deferredReturnEnqueue() {
+    Call<Integer> counts = Calls.defer(new Callable<Call<Integer>>() {
+      private int count = 0;
+
+      @Override public Call<Integer> call() throws Exception {
+        return Calls.response(++count);
+      }
+    });
+    Call<Integer> a = counts.clone();
+    Call<Integer> b = counts.clone();
+
+    final AtomicReference<Response<Integer>> responseRef = new AtomicReference<>();
+    Callback<Integer> callback = new Callback<Integer>() {
+      @Override public void onResponse(Call<Integer> call, Response<Integer> response) {
+        responseRef.set(response);
+      }
+
+      @Override public void onFailure(Call<Integer> call, Throwable t) {
+        fail();
+      }
+    };
+    b.enqueue(callback);
+    assertEquals(1, responseRef.get().body().intValue());
+
+    a.enqueue(callback);
+    assertEquals(2, responseRef.get().body().intValue());
+  }
+
+  @Test public void deferredThrowExecute() throws IOException {
+    final IOException failure = new IOException("Hey");
+    Call<Object> failing = Calls.defer(new Callable<Call<Object>>() {
+      @Override public Call<Object> call() throws Exception {
+        throw failure;
+      }
+    });
+    try {
+      failing.execute();
+      fail();
+    } catch (IOException e) {
+      assertSame(failure, e);
+    }
+  }
+
+  @Test public void deferredThrowEnqueue() {
+    final IOException failure = new IOException("Hey");
+    Call<Object> failing = Calls.defer(new Callable<Call<Object>>() {
+      @Override public Call<Object> call() throws Exception {
+        throw failure;
+      }
+    });
+    final AtomicReference<Throwable> failureRef = new AtomicReference<>();
+    failing.enqueue(new Callback<Object>() {
+      @Override public void onResponse(Call<Object> call, Response<Object> response) {
+        fail();
+      }
+
+      @Override public void onFailure(Call<Object> call, Throwable t) {
+        failureRef.set(t);
+      }
+    });
+    assertSame(failure, failureRef.get());
+  }
+}


### PR DESCRIPTION
The deferring factory allows you to provide functionality that can change when Call.clone() is being used.

Closes #1838.