### PR TITLE
Removal of Unnecessary Creation of String Builder

### DIFF
--- a/retrofit/src/main/java/retrofit2/Utils.java
+++ b/retrofit/src/main/java/retrofit2/Utils.java
@@ -407,9 +407,9 @@ final class Utils {
     }
 
     @Override public String toString() {
+      if (typeArguments.length == 0) return typeToString(rawType);
       StringBuilder result = new StringBuilder(30 * (typeArguments.length + 1));
       result.append(typeToString(rawType));
-      if (typeArguments.length == 0) return result.toString();
       result.append("<").append(typeToString(typeArguments[0]));
       for (int i = 1; i < typeArguments.length; i++) {
         result.append(", ").append(typeToString(typeArguments[i]));


### PR DESCRIPTION
if typeArguments has length 0 there is no point to create stringBuilder for that. that condition check needs to happen before stringBuilder creation.