### PR TITLE
Removal of unnecessary http method parsing

### DIFF
--- a/retrofit-mock/src/main/java/retrofit2/mock/NetworkBehavior.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/NetworkBehavior.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-
 import okhttp3.ResponseBody;
 import retrofit2.Response;
 
@@ -202,7 +201,7 @@ public final class NetworkBehavior {
     return MILLISECONDS.convert(callDelayMs, unit);
   }
 
-  private void checkPercentageValidity(int percentage,String message) {
+  private void checkPercentageValidity(int percentage, String message) {
     if (percentage < 0 || percentage > 100) {
       throw new IllegalArgumentException(message);
     }

--- a/retrofit-mock/src/main/java/retrofit2/mock/NetworkBehavior.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/NetworkBehavior.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+
 import okhttp3.ResponseBody;
 import retrofit2.Response;
 
@@ -94,9 +95,7 @@ public final class NetworkBehavior {
 
   /** Set the plus-or-minus variance percentage of the network round trip delay. */
   public void setVariancePercent(int variancePercent) {
-    if (variancePercent < 0 || variancePercent > 100) {
-      throw new IllegalArgumentException("Variance percentage must be between 0 and 100.");
-    }
+    checkPercentageValidity(variancePercent, "Variance percentage must be between 0 and 100.");
     this.variancePercent = variancePercent;
   }
 
@@ -107,9 +106,7 @@ public final class NetworkBehavior {
 
   /** Set the percentage of calls to {@link #calculateIsFailure()} that return {@code true}. */
   public void setFailurePercent(int failurePercent) {
-    if (failurePercent < 0 || failurePercent > 100) {
-      throw new IllegalArgumentException("Failure percentage must be between 0 and 100.");
-    }
+    checkPercentageValidity(failurePercent, "Failure percentage must be between 0 and 100.");
     this.failurePercent = failurePercent;
   }
 
@@ -143,9 +140,7 @@ public final class NetworkBehavior {
 
   /** Set the percentage of calls to {@link #calculateIsError()} that return {@code true}. */
   public void setErrorPercent(int errorPercent) {
-    if (errorPercent < 0 || errorPercent > 100) {
-      throw new IllegalArgumentException("Error percentage must be between 0 and 100.");
-    }
+    checkPercentageValidity(errorPercent, "Error percentage must be between 0 and 100.");
     this.errorPercent = errorPercent;
   }
 
@@ -205,5 +200,11 @@ public final class NetworkBehavior {
     float delayPercent = lowerBound + (random.nextFloat() * bound); // 0.8 + (rnd * 0.4)
     long callDelayMs = (long) (delayMs * delayPercent);
     return MILLISECONDS.convert(callDelayMs, unit);
+  }
+
+  private void checkPercentageValidity(int percentage,String message) {
+    if (percentage < 0 || percentage > 100) {
+      throw new IllegalArgumentException(message);
+    }
   }
 }

--- a/retrofit-mock/src/main/java/retrofit2/mock/NetworkBehavior.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/NetworkBehavior.java
@@ -201,7 +201,7 @@ public final class NetworkBehavior {
     return MILLISECONDS.convert(callDelayMs, unit);
   }
 
-  private void checkPercentageValidity(int percentage, String message) {
+  private static void checkPercentageValidity(int percentage, String message) {
     if (percentage < 0 || percentage > 100) {
       throw new IllegalArgumentException(message);
     }

--- a/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
@@ -19,7 +19,10 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.concurrent.Executor;
+
 import okhttp3.Request;
+
+import static retrofit2.Utils.checkNotNull;
 
 final class ExecutorCallAdapterFactory extends CallAdapter.Factory {
   final Executor callbackExecutor;
@@ -55,7 +58,7 @@ final class ExecutorCallAdapterFactory extends CallAdapter.Factory {
     }
 
     @Override public void enqueue(final Callback<T> callback) {
-      if (callback == null) throw new NullPointerException("callback == null");
+      checkNotNull(callback, "callback == null");
 
       delegate.enqueue(new Callback<T>() {
         @Override public void onResponse(Call<T> call, final Response<T> response) {

--- a/retrofit/src/main/java/retrofit2/HttpException.java
+++ b/retrofit/src/main/java/retrofit2/HttpException.java
@@ -15,10 +15,12 @@
  */
 package retrofit2;
 
+import static retrofit2.Utils.checkNotNull;
+
 /** Exception for an unexpected, non-2xx HTTP response. */
 public class HttpException extends Exception {
   private static String getMessage(Response<?> response) {
-    if (response == null) throw new NullPointerException("response == null");
+    checkNotNull(response, "response == null");
     return "HTTP " + response.code() + " " + response.message();
   }
 

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -200,7 +200,8 @@ final class OkHttpCall<T> implements Call<T> {
       } finally {
         rawBody.close();
       }
-    } else if (code == 204 || code == 205) {
+    }
+    if (code == 204 || code == 205) {
       rawBody.close();
       return Response.success(null, rawResponse);
     }

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -16,6 +16,7 @@
 package retrofit2;
 
 import java.io.IOException;
+
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.ResponseBody;
@@ -23,6 +24,8 @@ import okio.Buffer;
 import okio.BufferedSource;
 import okio.ForwardingSource;
 import okio.Okio;
+
+import static retrofit2.Utils.checkNotNull;
 
 final class OkHttpCall<T> implements Call<T> {
   private final ServiceMethod<T, ?> serviceMethod;
@@ -177,9 +180,7 @@ final class OkHttpCall<T> implements Call<T> {
   private okhttp3.Call createRawCall() throws IOException {
     Request request = serviceMethod.toRequest(args);
     okhttp3.Call call = serviceMethod.callFactory.newCall(request);
-    if (call == null) {
-      throw new NullPointerException("Call.Factory returned null.");
-    }
+    checkNotNull(call, "Call.Factory returned null.");
     return call;
   }
 

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -200,9 +200,7 @@ final class OkHttpCall<T> implements Call<T> {
       } finally {
         rawBody.close();
       }
-    }
-
-    if (code == 204 || code == 205) {
+    } else if (code == 204 || code == 205) {
       rawBody.close();
       return Response.success(null, rawResponse);
     }

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -16,7 +16,6 @@
 package retrofit2;
 
 import java.io.IOException;
-
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.ResponseBody;

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -16,6 +16,7 @@
 package retrofit2;
 
 import java.io.IOException;
+
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.ResponseBody;

--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -282,6 +282,8 @@ final class ServiceMethod<R, T> {
         throw methodError("Only one HTTP method is allowed. Found: %s and %s.",
             this.httpMethod, httpMethod);
       }
+      if (null == httpMethod) return;
+
       this.httpMethod = httpMethod;
       this.hasBody = hasBody;
 

--- a/retrofit/src/main/java/retrofit2/Utils.java
+++ b/retrofit/src/main/java/retrofit2/Utils.java
@@ -26,7 +26,6 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
-
 import okhttp3.ResponseBody;
 import okio.Buffer;
 

--- a/retrofit/src/main/java/retrofit2/Utils.java
+++ b/retrofit/src/main/java/retrofit2/Utils.java
@@ -26,6 +26,7 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
+
 import okhttp3.ResponseBody;
 import okio.Buffer;
 

--- a/retrofit/src/main/java/retrofit2/Utils.java
+++ b/retrofit/src/main/java/retrofit2/Utils.java
@@ -381,7 +381,7 @@ final class Utils {
       this.typeArguments = typeArguments.clone();
 
       for (Type typeArgument : this.typeArguments) {
-        if (typeArgument == null) throw new NullPointerException();
+        checkNotNull(typeArgument, "typeArgument == null");
         checkNotPrimitive(typeArgument);
       }
     }


### PR DESCRIPTION
If httpMethod is null then we don't need to parse and set the other values.

