### PR TITLE
removal of unnecssary parsing if httpMethod is null

### DIFF
--- a/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit2/ExecutorCallAdapterFactory.java
@@ -19,7 +19,10 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.concurrent.Executor;
+
 import okhttp3.Request;
+
+import static retrofit2.Utils.checkNotNull;
 
 final class ExecutorCallAdapterFactory extends CallAdapter.Factory {
   final Executor callbackExecutor;
@@ -55,7 +58,7 @@ final class ExecutorCallAdapterFactory extends CallAdapter.Factory {
     }
 
     @Override public void enqueue(final Callback<T> callback) {
-      if (callback == null) throw new NullPointerException("callback == null");
+      checkNotNull(callback, "callback == null");
 
       delegate.enqueue(new Callback<T>() {
         @Override public void onResponse(Call<T> call, final Response<T> response) {

--- a/retrofit/src/main/java/retrofit2/HttpException.java
+++ b/retrofit/src/main/java/retrofit2/HttpException.java
@@ -15,10 +15,12 @@
  */
 package retrofit2;
 
+import static retrofit2.Utils.checkNotNull;
+
 /** Exception for an unexpected, non-2xx HTTP response. */
 public class HttpException extends Exception {
   private static String getMessage(Response<?> response) {
-    if (response == null) throw new NullPointerException("response == null");
+    checkNotNull(response, "response == null");
     return "HTTP " + response.code() + " " + response.message();
   }
 

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -16,6 +16,7 @@
 package retrofit2;
 
 import java.io.IOException;
+
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.ResponseBody;
@@ -23,6 +24,8 @@ import okio.Buffer;
 import okio.BufferedSource;
 import okio.ForwardingSource;
 import okio.Okio;
+
+import static retrofit2.Utils.checkNotNull;
 
 final class OkHttpCall<T> implements Call<T> {
   private final ServiceMethod<T, ?> serviceMethod;
@@ -177,9 +180,7 @@ final class OkHttpCall<T> implements Call<T> {
   private okhttp3.Call createRawCall() throws IOException {
     Request request = serviceMethod.toRequest(args);
     okhttp3.Call call = serviceMethod.callFactory.newCall(request);
-    if (call == null) {
-      throw new NullPointerException("Call.Factory returned null.");
-    }
+    checkNotNull(call, "Call.Factory returned null.");
     return call;
   }
 

--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -282,6 +282,8 @@ final class ServiceMethod<R, T> {
         throw methodError("Only one HTTP method is allowed. Found: %s and %s.",
             this.httpMethod, httpMethod);
       }
+      if (null == httpMethod) return;
+
       this.httpMethod = httpMethod;
       this.hasBody = hasBody;
 

--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -282,7 +282,6 @@ final class ServiceMethod<R, T> {
         throw methodError("Only one HTTP method is allowed. Found: %s and %s.",
             this.httpMethod, httpMethod);
       }
-      
       this.httpMethod = httpMethod;
       this.hasBody = hasBody;
 

--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -282,8 +282,7 @@ final class ServiceMethod<R, T> {
         throw methodError("Only one HTTP method is allowed. Found: %s and %s.",
             this.httpMethod, httpMethod);
       }
-      if (null == httpMethod) return;
-
+      
       this.httpMethod = httpMethod;
       this.hasBody = hasBody;
 


### PR DESCRIPTION
If httpMethod is null then we don't need to parse and set the other values