### PR TITLE
Make HttpException unchecked

### DIFF
--- a/retrofit/src/main/java/retrofit2/HttpException.java
+++ b/retrofit/src/main/java/retrofit2/HttpException.java
@@ -16,7 +16,7 @@
 package retrofit2;
 
 /** Exception for an unexpected, non-2xx HTTP response. */
-public class HttpException extends Exception {
+public class HttpException extends RuntimeException {
   private static String getMessage(Response<?> response) {
     if (response == null) throw new NullPointerException("response == null");
     return "HTTP " + response.code() + " " + response.message();


### PR DESCRIPTION
@JakeWharton Make `HttpException` unchecked to allow the `Exception` to be thrown in custom `CallAdapters`.