### PR TITLE
Allowing skipping of query params if the conveters converted to a null

### DIFF
--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -69,7 +69,12 @@ abstract class ParameterHandler<T> {
 
     @Override void apply(RequestBuilder builder, T value) throws IOException {
       if (value == null) return; // Skip null values.
-      builder.addHeader(name, valueConverter.convert(value));
+
+      String headerValue = valueConverter.convert(value);
+
+      if (headerValue == null) return; // Skip converted but null values
+
+      builder.addHeader(name, headerValue);
     }
   }
 
@@ -106,7 +111,12 @@ abstract class ParameterHandler<T> {
 
     @Override void apply(RequestBuilder builder, T value) throws IOException {
       if (value == null) return; // Skip null values.
-      builder.addQueryParam(name, valueConverter.convert(value), encoded);
+
+      String queryValue = valueConverter.convert(value);
+
+      if (queryValue == null) return; // Skip converted but null values
+
+      builder.addQueryParam(name, queryValue, encoded);
     }
   }
 
@@ -149,7 +159,15 @@ abstract class ParameterHandler<T> {
           throw new IllegalArgumentException(
               "Query map contained null value for key '" + entryKey + "'.");
         }
-        builder.addQueryParam(entryKey, valueConverter.convert(entryValue), encoded);
+
+        String convertedEntryValue = valueConverter.convert(entryValue);
+
+        if (convertedEntryValue == null) {
+          throw new IllegalArgumentException(
+              "Query map contained null value for key '" + entryKey + "'.");
+        }
+
+        builder.addQueryParam(entryKey, convertedEntryValue, encoded);
       }
     }
   }
@@ -194,7 +212,12 @@ abstract class ParameterHandler<T> {
 
     @Override void apply(RequestBuilder builder, T value) throws IOException {
       if (value == null) return; // Skip null values.
-      builder.addFormField(name, valueConverter.convert(value), encoded);
+
+      String fieldValue = valueConverter.convert(value);
+
+      if (fieldValue == null) return; // Skip null converted values
+
+      builder.addFormField(name, fieldValue, encoded);
     }
   }
 
@@ -222,7 +245,15 @@ abstract class ParameterHandler<T> {
           throw new IllegalArgumentException(
               "Field map contained null value for key '" + entryKey + "'.");
         }
-        builder.addFormField(entryKey, valueConverter.convert(entryValue), encoded);
+
+        String fieldEntry = valueConverter.convert(entryValue);
+
+        if (fieldEntry == null) {
+          throw new IllegalArgumentException(
+              "Field map contained null value for key '" + entryKey + "'.");
+        }
+
+        builder.addFormField(entryKey, fieldEntry, encoded);
       }
     }
   }

--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -72,7 +72,7 @@ abstract class ParameterHandler<T> {
 
       String headerValue = valueConverter.convert(value);
 
-      if (headerValue == null) return; // Skip converted but null values
+      if (headerValue == null) return; // Skip converted but null values.
 
       builder.addHeader(name, headerValue);
     }

--- a/retrofit/src/test/java/retrofit2/CallTest.java
+++ b/retrofit/src/test/java/retrofit2/CallTest.java
@@ -18,7 +18,6 @@ package retrofit2;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -40,8 +39,6 @@ import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
-import retrofit2.http.Query;
-import retrofit2.http.QueryMap;
 import retrofit2.http.Streaming;
 
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/retrofit/src/test/java/retrofit2/CallTest.java
+++ b/retrofit/src/test/java/retrofit2/CallTest.java
@@ -18,7 +18,6 @@ package retrofit2;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,7 +35,6 @@ import okio.ForwardingSource;
 import okio.Okio;
 import org.junit.Rule;
 import org.junit.Test;
-import retrofit2.helpers.NullObjectConverterFactory;
 import retrofit2.helpers.ToStringConverterFactory;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
@@ -63,8 +61,6 @@ public final class CallTest {
     @GET("/") @Streaming Call<ResponseBody> getStreamingBody();
     @POST("/") Call<String> postString(@Body String body);
     @POST("/{a}") Call<String> postRequestBody(@Path("a") Object a);
-    @POST("/query") Call<String> queryPath(@Query("a") Object a);
-    @POST("/query") Call<String> queryPathMap(@QueryMap Map<String, String> a);
   }
 
   @Test public void http200Sync() throws IOException {
@@ -984,67 +980,5 @@ public final class CallTest {
       assertThat(e).hasMessage("Broken!");
     }
     assertThat(writeCount.get()).isEqualTo(1);
-  }
-
-  @Test public void queryParamsSkippedIfConvertedToNull() throws IOException, InterruptedException {
-    Retrofit retrofit = new Retrofit.Builder()
-            .baseUrl(server.url("/"))
-            .addConverterFactory(new NullObjectConverterFactory())
-            .build();
-    Service example = retrofit.create(Service.class);
-
-    server.enqueue(new MockResponse().setBody("Hi"));
-
-    final AtomicReference<Response<String>> responseRef = new AtomicReference<>();
-
-    final CountDownLatch latch = new CountDownLatch(1);
-    example.queryPath("Ignored").enqueue(new Callback<String>() {
-      @Override public void onResponse(final Call<String> call, final Response<String> response) {
-        if(call.request().url().toString().contains("Ignored")){
-          fail();
-        }
-
-        responseRef.set(response);
-        latch.countDown();
-      }
-
-      @Override public void onFailure(final Call<String> call, final Throwable t) {
-        latch.countDown();
-      }
-    });
-
-    assertTrue(latch.await(10, SECONDS));
-    assertThat(responseRef.get().isSuccessful()).isTrue();
-  }
-
-  @Test public void queryParamMapsConvertedToNullShouldError() throws IOException, InterruptedException {
-    Retrofit retrofit = new Retrofit.Builder()
-            .baseUrl(server.url("/"))
-            .addConverterFactory(new NullObjectConverterFactory())
-            .build();
-    Service example = retrofit.create(Service.class);
-
-    server.enqueue(new MockResponse().setBody("Hi"));
-
-    final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
-
-    final HashMap<String, String> queryMap = new HashMap<String, String>() {{
-      put("Ignored", "Always Null");
-    }};
-
-    final CountDownLatch latch = new CountDownLatch(1);
-    example.queryPathMap(queryMap).enqueue(new Callback<String>() {
-      @Override public void onResponse(final Call<String> call, final Response<String> response) {
-        latch.countDown();
-      }
-
-      @Override public void onFailure(final Call<String> call, final Throwable t) {
-        throwableRef.set(t);
-        latch.countDown();
-      }
-    });
-
-    assertTrue(latch.await(10, SECONDS));
-    assertThat(throwableRef.get()).isNotNull();
   }
 }

--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -35,6 +35,7 @@ import okhttp3.ResponseBody;
 import okio.Buffer;
 import org.junit.Ignore;
 import org.junit.Test;
+import retrofit2.helpers.NullObjectConverterFactory;
 import retrofit2.helpers.ToStringConverterFactory;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
@@ -2578,6 +2579,44 @@ public final class RequestBuilderTest {
     assertThat(readBody.indexOf("secondParam")).isLessThan(readBody.indexOf("thirdParam"));
   }
 
+
+  @Test public void queryParamsSkippedIfConvertedToNull() throws IOException, InterruptedException {
+    class Example {
+      @POST("/query") Call<String> queryPath(@Query("a") Object a) { return null; }
+    }
+
+    Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
+            .baseUrl("http://example.com")
+            .addConverterFactory(new NullObjectConverterFactory());
+
+    Request request = buildRequest(Example.class, retrofitBuilder, "Ignored");
+
+    if(request.url().toString().contains("Ignored")){
+      fail();
+    }
+  }
+
+  @Test public void queryParamMapsConvertedToNullShouldError() throws IOException, InterruptedException {
+    class Example {
+      @POST("/query") Call<String> queryPath(@QueryMap HashMap<String, String> a) { return null; }
+    }
+
+    Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
+            .baseUrl("http://example.com")
+            .addConverterFactory(new NullObjectConverterFactory());
+
+    final HashMap<String, String> queryMap = new HashMap<String, String>() {{
+      put("Ignored", "Always Null");
+    }};
+
+    try {
+      buildRequest(Example.class, retrofitBuilder, queryMap);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageContaining("Query map contained null value for key");
+    }
+  }
+
   private static void assertBody(RequestBody body, String expected) {
     assertThat(body).isNotNull();
     Buffer buffer = new Buffer();
@@ -2589,7 +2628,7 @@ public final class RequestBuilderTest {
     }
   }
 
-  static <T> Request buildRequest(Class<T> cls, Object... args) {
+  static <T> Request buildRequest(Class<T> cls, Retrofit.Builder builder, Object... args) {
     final AtomicReference<Request> requestRef = new AtomicReference<>();
     okhttp3.Call.Factory callFactory = new okhttp3.Call.Factory() {
       @Override public okhttp3.Call newCall(Request request) {
@@ -2598,16 +2637,12 @@ public final class RequestBuilderTest {
       }
     };
 
-    Retrofit retrofit = new Retrofit.Builder()
-        .baseUrl("http://example.com/")
-        .addConverterFactory(new ToStringConverterFactory())
-        .callFactory(callFactory)
-        .build();
+    Retrofit retrofit = builder.callFactory(callFactory).build();
 
     Method method = TestingUtils.onlyMethod(cls);
     //noinspection unchecked
     ServiceMethod<T, Call<T>> serviceMethod =
-        (ServiceMethod<T, Call<T>>) retrofit.loadServiceMethod(method);
+            (ServiceMethod<T, Call<T>>) retrofit.loadServiceMethod(method);
     Call<T> okHttpCall = new OkHttpCall<>(serviceMethod, args);
     Call<T> call = serviceMethod.callAdapter.adapt(okHttpCall);
     try {
@@ -2620,5 +2655,13 @@ public final class RequestBuilderTest {
     } catch (Exception e) {
       throw new AssertionError(e);
     }
+  }
+
+  static <T> Request buildRequest(Class<T> cls, Object... args) {
+    Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
+        .baseUrl("http://example.com/")
+        .addConverterFactory(new ToStringConverterFactory());
+
+    return buildRequest(cls, retrofitBuilder, args);
   }
 }

--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -2591,9 +2591,7 @@ public final class RequestBuilderTest {
 
     Request request = buildRequest(Example.class, retrofitBuilder, "Ignored");
 
-    if(request.url().toString().contains("Ignored")){
-      fail();
-    }
+    assertThat(request.url().toString()).doesNotContain("Ignored");
   }
 
   @Test public void queryParamMapsConvertedToNullShouldError() throws IOException, InterruptedException {
@@ -2605,7 +2603,7 @@ public final class RequestBuilderTest {
             .baseUrl("http://example.com")
             .addConverterFactory(new NullObjectConverterFactory());
 
-    final HashMap<String, String> queryMap = new HashMap<String, String>() {{
+    final Map<String, String> queryMap = new LinkedHashMap<String, String>() {{
       put("Ignored", "Always Null");
     }};
 
@@ -2613,7 +2611,7 @@ public final class RequestBuilderTest {
       buildRequest(Example.class, retrofitBuilder, queryMap);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageContaining("Query map contained null value for key");
+      assertThat(e).hasMessageContaining("Query map contained null value for key 'Ignored'");
     }
   }
 

--- a/retrofit/src/test/java/retrofit2/helpers/NullObjectConverterFactory.java
+++ b/retrofit/src/test/java/retrofit2/helpers/NullObjectConverterFactory.java
@@ -1,0 +1,23 @@
+package retrofit2.helpers;
+
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * Always converts strings to null
+ */
+public class NullObjectConverterFactory extends ToStringConverterFactory {
+    @Override
+    public Converter<?, String> stringConverter(final Type type, final Annotation[] annotations, final Retrofit retrofit) {
+        return new Converter<Object, String>() {
+            @Override
+            public String convert(final Object value) throws IOException {
+                return null;
+            }
+        };
+    }
+}

--- a/retrofit/src/test/java/retrofit2/helpers/NullObjectConverterFactory.java
+++ b/retrofit/src/test/java/retrofit2/helpers/NullObjectConverterFactory.java
@@ -10,7 +10,7 @@ import java.lang.reflect.Type;
 /**
  * Always converts strings to null
  */
-public class NullObjectConverterFactory extends ToStringConverterFactory {
+public final class NullObjectConverterFactory extends ToStringConverterFactory {
     @Override
     public Converter<?, String> stringConverter(final Type type, final Annotation[] annotations, final Retrofit retrofit) {
         return new Converter<Object, String>() {


### PR DESCRIPTION
First let me say, love retrofit. It's a wonderfully written library.  

We're using retrofit with a custom adapter to use with scala.  So far things work swimmingly, we have our own jackson converter factory that lets us use scala types for request and response bodies. However, we ran into an issue with optional query parameters using the scala None object.  There doesn't seem to be a way to properly indicate "do not use this query param" other than passing in a null object. While this works in java land, its very anti scala.  

Given that parameters can be converted, this PR submits that if a string converter returns a valid converter who _then_ returns a null object, that this indicates that the object should not be used as a query/header/etc param.  This lets us hook into the conversion factory and delegate all type resolution of scala wonkery to the converter.

