### PR TITLE
Fix NoSuchElementException when using Rx 1.x Singles.

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/CallArbiter.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/CallArbiter.java
@@ -140,9 +140,7 @@ final class CallArbiter<T> extends AtomicInteger implements Subscription, Produc
 
     if (!isUnsubscribed()) {
       try {
-        if (!isUnsubscribed()) {
-          subscriber.onError(t);
-        }
+        subscriber.onError(t);
       } catch (Throwable inner) {
         Exceptions.throwIfFatal(inner);
         CompositeException composite = new CompositeException(t, inner);

--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/CallArbiter.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/CallArbiter.java
@@ -126,7 +126,9 @@ final class CallArbiter<T> extends AtomicInteger implements Subscription, Produc
       return;
     }
     try {
-      subscriber.onCompleted();
+      if (!isUnsubscribed()) {
+        subscriber.onCompleted();
+      }
     } catch (Throwable t) {
       Exceptions.throwIfFatal(t);
       RxJavaPlugins.getInstance().getErrorHandler().handleError(t);
@@ -138,7 +140,9 @@ final class CallArbiter<T> extends AtomicInteger implements Subscription, Produc
 
     if (!isUnsubscribed()) {
       try {
-        subscriber.onError(t);
+        if (!isUnsubscribed()) {
+          subscriber.onError(t);
+        }
       } catch (Throwable inner) {
         Exceptions.throwIfFatal(inner);
         CompositeException composite = new CompositeException(t, inner);


### PR DESCRIPTION
We're seeing quite a few `NoSuchElementException` errors in our apps and I think I've narrowed it down to this issue.

It looks like `CallArbiter` checks if the subscriber is still subscribed when calling onNext, but not when calling onCompleted. This can lead to `NoSuchElementException` when a subscriber unsubscribes during a `deliverResponse` call.

**Repro steps:**
I can't 100% reproduce this in the wild, but I can trigger it via the debugger. If you run this [snippet](https://gist.github.com/tonycosentini/d22f05431af34123ef725a5d4cf08e59), add a breakpoint to `deliverResponse`, and manually unsubscribe via the debugger, it will crash.

There is also a test in `AsyncTest` that will reproduce this by failing when the fix is removed.

**TODO:**
* [x] Tests? If this is a valid bug, some guidance on where / how to test this would be super appreciated.