### PR TITLE
[WIP] Add nullability annotations to public APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <android.version>4.1.1.4</android.version>
     <okhttp.version>3.6.0</okhttp.version>
     <animal.sniffer.version>1.14</animal.sniffer.version>
+    <annotations.version>15.0</annotations.version>
 
     <!-- Adapter Dependencies -->
     <rxjava.version>1.2.0</rxjava.version>
@@ -155,6 +156,11 @@
         <groupId>com.squareup.moshi</groupId>
         <artifactId>moshi</artifactId>
         <version>${moshi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations-java5</artifactId>
+        <version>${annotations.version}</version>
       </dependency>
 
       <dependency>

--- a/retrofit-adapters/guava/pom.xml
+++ b/retrofit-adapters/guava/pom.xml
@@ -23,6 +23,11 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations-java5</artifactId>
+      <version>${annotations.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/retrofit-adapters/guava/src/main/java/retrofit2/adapter/guava/GuavaCallAdapterFactory.java
+++ b/retrofit-adapters/guava/src/main/java/retrofit2/adapter/guava/GuavaCallAdapterFactory.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import retrofit2.Call;
 import retrofit2.CallAdapter;
 import retrofit2.Callback;
@@ -49,7 +52,7 @@ import retrofit2.Retrofit;
  * </ul>
  */
 public final class GuavaCallAdapterFactory extends CallAdapter.Factory {
-  public static GuavaCallAdapterFactory create() {
+  public static @NotNull GuavaCallAdapterFactory create() {
     return new GuavaCallAdapterFactory();
   }
 
@@ -57,7 +60,8 @@ public final class GuavaCallAdapterFactory extends CallAdapter.Factory {
   }
 
   @Override
-  public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+  public @Nullable CallAdapter<?, ?> get(Type returnType, Annotation[] annotations,
+      Retrofit retrofit) {
     if (getRawType(returnType) != ListenableFuture.class) {
       return null;
     }
@@ -92,7 +96,7 @@ public final class GuavaCallAdapterFactory extends CallAdapter.Factory {
       return responseType;
     }
 
-    @Override public ListenableFuture<R> adapt(final Call<R> call) {
+    @Override public ListenableFuture<R> adapt(final @NotNull Call<R> call) {
       return new AbstractFuture<R>() {
         {
           call.enqueue(new Callback<R>() {

--- a/retrofit-adapters/java8/pom.xml
+++ b/retrofit-adapters/java8/pom.xml
@@ -23,6 +23,11 @@
       <artifactId>retrofit</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations-java5</artifactId>
+      <version>${annotations.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/retrofit-adapters/java8/src/main/java/retrofit2/adapter/java8/Java8CallAdapterFactory.java
+++ b/retrofit-adapters/java8/src/main/java/retrofit2/adapter/java8/Java8CallAdapterFactory.java
@@ -20,6 +20,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.concurrent.CompletableFuture;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import retrofit2.Call;
 import retrofit2.CallAdapter;
 import retrofit2.Callback;
@@ -48,7 +51,7 @@ import retrofit2.Retrofit;
  * </ul>
  */
 public final class Java8CallAdapterFactory extends CallAdapter.Factory {
-  public static Java8CallAdapterFactory create() {
+  public static @NotNull Java8CallAdapterFactory create() {
     return new Java8CallAdapterFactory();
   }
 
@@ -56,7 +59,8 @@ public final class Java8CallAdapterFactory extends CallAdapter.Factory {
   }
 
   @Override
-  public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+  public @Nullable CallAdapter<?, ?> get(Type returnType, Annotation[] annotations,
+      Retrofit retrofit) {
     if (getRawType(returnType) != CompletableFuture.class) {
       return null;
     }

--- a/retrofit-adapters/rxjava/pom.xml
+++ b/retrofit-adapters/rxjava/pom.xml
@@ -23,6 +23,11 @@
       <groupId>io.reactivex</groupId>
       <artifactId>rxjava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations-java5</artifactId>
+      <version>${annotations.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/Result.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/Result.java
@@ -16,16 +16,19 @@
 package retrofit2.adapter.rxjava;
 
 import java.io.IOException;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import retrofit2.Response;
 
 /** The result of executing an HTTP request. */
 public final class Result<T> {
-  public static <T> Result<T> error(Throwable error) {
+  public static @NotNull <T> Result<T> error(@NotNull Throwable error) {
     if (error == null) throw new NullPointerException("error == null");
     return new Result<>(null, error);
   }
 
-  public static <T> Result<T> response(Response<T> response) {
+  public static @NotNull <T> Result<T> response(@NotNull Response<T> response) {
     if (response == null) throw new NullPointerException("response == null");
     return new Result<>(response, null);
   }
@@ -42,7 +45,7 @@ public final class Result<T> {
    * The response received from executing an HTTP request. Only present when {@link #isError()} is
    * false, null otherwise.
    */
-  public Response<T> response() {
+  public @Nullable Response<T> response() {
     return response;
   }
 
@@ -54,7 +57,7 @@ public final class Result<T> {
    * remote server. Any other exception type indicates an unexpected failure and should be
    * considered fatal (configuration error, programming error, etc.).
    */
-  public Throwable error() {
+  public @Nullable Throwable error() {
     return error;
   }
 

--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactory.java
@@ -19,6 +19,9 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import retrofit2.CallAdapter;
 import retrofit2.HttpException;
 import retrofit2.Response;
@@ -61,7 +64,7 @@ public final class RxJavaCallAdapterFactory extends CallAdapter.Factory {
    * Returns an instance which creates synchronous observables that do not operate on any scheduler
    * by default.
    */
-  public static RxJavaCallAdapterFactory create() {
+  public static @NotNull RxJavaCallAdapterFactory create() {
     return new RxJavaCallAdapterFactory(null, false);
   }
 
@@ -69,7 +72,7 @@ public final class RxJavaCallAdapterFactory extends CallAdapter.Factory {
    * Returns an instance which creates asynchronous observables. Applying
    * {@link Observable#subscribeOn} has no effect on stream types created by this factory.
    */
-  public static RxJavaCallAdapterFactory createAsync() {
+  public static @NotNull RxJavaCallAdapterFactory createAsync() {
     return new RxJavaCallAdapterFactory(null, true);
   }
 
@@ -77,7 +80,8 @@ public final class RxJavaCallAdapterFactory extends CallAdapter.Factory {
    * Returns an instance which creates synchronous observables that
    * {@linkplain Observable#subscribeOn(Scheduler) subscribe on} {@code scheduler} by default.
    */
-  public static RxJavaCallAdapterFactory createWithScheduler(Scheduler scheduler) {
+  public static @NotNull RxJavaCallAdapterFactory createWithScheduler(
+      @NotNull Scheduler scheduler) {
     if (scheduler == null) throw new NullPointerException("scheduler == null");
     return new RxJavaCallAdapterFactory(scheduler, false);
   }
@@ -91,7 +95,8 @@ public final class RxJavaCallAdapterFactory extends CallAdapter.Factory {
   }
 
   @Override
-  public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+  public @Nullable CallAdapter<?, ?> get(Type returnType, Annotation[] annotations,
+      Retrofit retrofit) {
     Class<?> rawType = getRawType(returnType);
     boolean isSingle = rawType == Single.class;
     boolean isCompletable = "rx.Completable".equals(rawType.getCanonicalName());

--- a/retrofit-adapters/rxjava2/pom.xml
+++ b/retrofit-adapters/rxjava2/pom.xml
@@ -23,6 +23,11 @@
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations-java5</artifactId>
+      <version>${annotations.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/Result.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/Result.java
@@ -16,16 +16,19 @@
 package retrofit2.adapter.rxjava2;
 
 import java.io.IOException;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import retrofit2.Response;
 
 /** The result of executing an HTTP request. */
 public final class Result<T> {
-  public static <T> Result<T> error(Throwable error) {
+  public static @NotNull <T> Result<T> error(@Nullable Throwable error) {
     if (error == null) throw new NullPointerException("error == null");
     return new Result<>(null, error);
   }
 
-  public static <T> Result<T> response(Response<T> response) {
+  public static @NotNull <T> Result<T> response(@NotNull Response<T> response) {
     if (response == null) throw new NullPointerException("response == null");
     return new Result<>(response, null);
   }
@@ -42,7 +45,7 @@ public final class Result<T> {
    * The response received from executing an HTTP request. Only present when {@link #isError()} is
    * false, null otherwise.
    */
-  public Response<T> response() {
+  public @Nullable Response<T> response() {
     return response;
   }
 
@@ -54,7 +57,7 @@ public final class Result<T> {
    * remote server. Any other exception type indicates an unexpected failure and should be
    * considered fatal (configuration error, programming error, etc.).
    */
-  public Throwable error() {
+  public @Nullable Throwable error() {
     return error;
   }
 

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
@@ -25,6 +25,9 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import retrofit2.CallAdapter;
 import retrofit2.HttpException;
 import retrofit2.Response;
@@ -59,7 +62,7 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
    * Returns an instance which creates synchronous observables that do not operate on any scheduler
    * by default.
    */
-  public static RxJava2CallAdapterFactory create() {
+  public static @NotNull RxJava2CallAdapterFactory create() {
     return new RxJava2CallAdapterFactory(null, false);
   }
 
@@ -67,7 +70,7 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
    * Returns an instance which creates asynchronous observables. Applying
    * {@link Observable#subscribeOn} has no effect on stream types created by this factory.
    */
-  public static RxJava2CallAdapterFactory createAsync() {
+  public static @NotNull RxJava2CallAdapterFactory createAsync() {
     return new RxJava2CallAdapterFactory(null, true);
   }
 
@@ -75,7 +78,8 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
    * Returns an instance which creates synchronous observables that
    * {@linkplain Observable#subscribeOn(Scheduler) subscribe on} {@code scheduler} by default.
    */
-  public static RxJava2CallAdapterFactory createWithScheduler(Scheduler scheduler) {
+  public static @NotNull RxJava2CallAdapterFactory createWithScheduler(
+      @NotNull Scheduler scheduler) {
     if (scheduler == null) throw new NullPointerException("scheduler == null");
     return new RxJava2CallAdapterFactory(scheduler, false);
   }
@@ -89,7 +93,8 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
   }
 
   @Override
-  public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+  public @Nullable CallAdapter<?, ?> get(Type returnType, Annotation[] annotations,
+      Retrofit retrofit) {
     Class<?> rawType = getRawType(returnType);
 
     if (rawType == Completable.class) {

--- a/retrofit-converters/moshi/pom.xml
+++ b/retrofit-converters/moshi/pom.xml
@@ -23,6 +23,11 @@
       <groupId>com.squareup.moshi</groupId>
       <artifactId>moshi</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations-java5</artifactId>
+      <version>${annotations.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/retrofit-converters/moshi/src/main/java/retrofit2/converter/moshi/MoshiConverterFactory.java
+++ b/retrofit-converters/moshi/src/main/java/retrofit2/converter/moshi/MoshiConverterFactory.java
@@ -25,6 +25,8 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
@@ -44,12 +46,12 @@ import static java.util.Collections.unmodifiableSet;
  */
 public final class MoshiConverterFactory extends Converter.Factory {
   /** Create an instance using a default {@link Moshi} instance for conversion. */
-  public static MoshiConverterFactory create() {
+  public static @NotNull MoshiConverterFactory create() {
     return create(new Moshi.Builder().build());
   }
 
   /** Create an instance using {@code moshi} for conversion. */
-  public static MoshiConverterFactory create(Moshi moshi) {
+  public static @NotNull MoshiConverterFactory create(@NotNull Moshi moshi) {
     if (moshi == null) throw new NullPointerException("moshi == null");
     return new MoshiConverterFactory(moshi, false, false, false);
   }
@@ -68,25 +70,25 @@ public final class MoshiConverterFactory extends Converter.Factory {
   }
 
   /** Return a new factory which uses {@linkplain JsonAdapter#lenient() lenient} adapters. */
-  public MoshiConverterFactory asLenient() {
+  public @NotNull MoshiConverterFactory asLenient() {
     return new MoshiConverterFactory(moshi, true, failOnUnknown, serializeNulls);
   }
 
   /**
    * Return a new factory which uses {@link JsonAdapter#failOnUnknown()} adapters.
    */
-  public MoshiConverterFactory failOnUnknown() {
+  public @NotNull MoshiConverterFactory failOnUnknown() {
     return new MoshiConverterFactory(moshi, lenient, true, serializeNulls);
   }
 
   /** Return a new factory which includes null values into the serialized JSON. */
-  public MoshiConverterFactory withNullSerialization() {
+  public @NotNull MoshiConverterFactory withNullSerialization() {
     return new MoshiConverterFactory(moshi, lenient, failOnUnknown, true);
   }
 
   @Override
-  public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
-      Retrofit retrofit) {
+  public @Nullable Converter<ResponseBody, ?> responseBodyConverter(@NotNull Type type,
+      @NotNull Annotation[] annotations, Retrofit retrofit) {
     JsonAdapter<?> adapter = moshi.adapter(type, jsonAnnotations(annotations));
     if (lenient) {
       adapter = adapter.lenient();
@@ -100,8 +102,9 @@ public final class MoshiConverterFactory extends Converter.Factory {
     return new MoshiResponseBodyConverter<>(adapter);
   }
 
-  @Override public Converter<?, RequestBody> requestBodyConverter(Type type,
-      Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
+  @Override public @Nullable Converter<?, RequestBody> requestBodyConverter(@NotNull Type type,
+      @NotNull Annotation[] parameterAnnotations, @NotNull Annotation[] methodAnnotations,
+      Retrofit retrofit) {
     JsonAdapter<?> adapter = moshi.adapter(type, jsonAnnotations(parameterAnnotations));
     if (lenient) {
       adapter = adapter.lenient();

--- a/retrofit-mock/src/main/java/retrofit2/mock/BehaviorCall.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/BehaviorCall.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import okhttp3.Request;
+import org.jetbrains.annotations.NotNull;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -43,15 +44,15 @@ final class BehaviorCall<T> implements Call<T> {
   }
 
   @SuppressWarnings("CloneDoesntCallSuperClone") // We are a final type & this saves clearing state.
-  @Override public Call<T> clone() {
+  @Override public @NotNull Call<T> clone() {
     return new BehaviorCall<>(behavior, backgroundExecutor, delegate.clone());
   }
 
-  @Override public Request request() {
+  @Override public @NotNull Request request() {
     return delegate.request();
   }
 
-  @Override public void enqueue(final Callback<T> callback) {
+  @Override public void enqueue(final @NotNull Callback<T> callback) {
     if (callback == null) throw new NullPointerException("callback == null");
 
     synchronized (this) {
@@ -107,7 +108,7 @@ final class BehaviorCall<T> implements Call<T> {
     return executed;
   }
 
-  @Override public Response<T> execute() throws IOException {
+  @Override public @NotNull Response<T> execute() throws IOException {
     final AtomicReference<Response<T>> responseRef = new AtomicReference<>();
     final AtomicReference<Throwable> failureRef = new AtomicReference<>();
     final CountDownLatch latch = new CountDownLatch(1);

--- a/retrofit-mock/src/main/java/retrofit2/mock/Calls.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/Calls.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import okhttp3.Request;
+import org.jetbrains.annotations.NotNull;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -29,19 +30,19 @@ public final class Calls {
    * Invokes {@code callable} once for the returned {@link Call} and once for each instance that is
    * obtained from {@linkplain Call#clone() cloning} the returned {@link Call}.
    */
-  public static <T> Call<T> defer(Callable<Call<T>> callable) {
+  public static @NotNull <T> Call<T> defer(@NotNull Callable<Call<T>> callable) {
     return new DeferredCall<>(callable);
   }
 
-  public static <T> Call<T> response(T successValue) {
+  public static @NotNull <T> Call<T> response(T successValue) {
     return new FakeCall<>(Response.success(successValue), null);
   }
 
-  public static <T> Call<T> response(Response<T> response) {
+  public static @NotNull <T> Call<T> response(@NotNull Response<T> response) {
     return new FakeCall<>(response, null);
   }
 
-  public static <T> Call<T> failure(IOException failure) {
+  public static @NotNull <T> Call<T> failure(@NotNull IOException failure) {
     return new FakeCall<>(null, failure);
   }
 
@@ -63,7 +64,7 @@ public final class Calls {
       this.error = error;
     }
 
-    @Override public Response<T> execute() throws IOException {
+    @Override public @NotNull Response<T> execute() throws IOException {
       if (!executed.compareAndSet(false, true)) {
         throw new IllegalStateException("Already executed");
       }
@@ -76,7 +77,7 @@ public final class Calls {
       throw error;
     }
 
-    @Override public void enqueue(Callback<T> callback) {
+    @Override public void enqueue(@NotNull Callback<T> callback) {
       if (callback == null) {
         throw new NullPointerException("callback == null");
       }
@@ -104,11 +105,11 @@ public final class Calls {
       return canceled.get();
     }
 
-    @Override public Call<T> clone() {
+    @Override public @NotNull Call<T> clone() {
       return new FakeCall<>(response, error);
     }
 
-    @Override public Request request() {
+    @Override public @NotNull Request request() {
       if (response != null) {
         return response.raw().request();
       }
@@ -124,7 +125,7 @@ public final class Calls {
       this.callable = callable;
     }
 
-    private synchronized Call<T> getDelegate() {
+    private synchronized @NotNull Call<T> getDelegate() {
       Call<T> delegate = this.delegate;
       if (delegate == null) {
         try {
@@ -139,11 +140,11 @@ public final class Calls {
       return delegate;
     }
 
-    @Override public Response<T> execute() throws IOException {
+    @Override public @NotNull Response<T> execute() throws IOException {
       return getDelegate().execute();
     }
 
-    @Override public void enqueue(Callback<T> callback) {
+    @Override public void enqueue(@NotNull Callback<T> callback) {
       getDelegate().enqueue(callback);
     }
 
@@ -159,11 +160,11 @@ public final class Calls {
       return getDelegate().isCanceled();
     }
 
-    @Override public Call<T> clone() {
+    @Override public @NotNull Call<T> clone() {
       return new DeferredCall<>(callable);
     }
 
-    @Override public Request request() {
+    @Override public @NotNull Request request() {
       return getDelegate().request();
     }
   }

--- a/retrofit/pom.xml
+++ b/retrofit/pom.xml
@@ -18,6 +18,11 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations-java5</artifactId>
+      <version>${annotations.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>com.google.android</groupId>

--- a/retrofit/src/main/java/retrofit2/Call.java
+++ b/retrofit/src/main/java/retrofit2/Call.java
@@ -17,6 +17,7 @@ package retrofit2;
 
 import java.io.IOException;
 import okhttp3.Request;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An invocation of a Retrofit method that sends a request to a webserver and returns a response.
@@ -39,13 +40,13 @@ public interface Call<T> extends Cloneable {
    * @throws RuntimeException (and subclasses) if an unexpected error occurs creating the request
    * or decoding the response.
    */
-  Response<T> execute() throws IOException;
+  @NotNull Response<T> execute() throws IOException;
 
   /**
    * Asynchronously send the request and notify {@code callback} of its response or if an error
    * occurred talking to the server, creating the request, or processing the response.
    */
-  void enqueue(Callback<T> callback);
+  void enqueue(@NotNull Callback<T> callback);
 
   /**
    * Returns true if this call has been either {@linkplain #execute() executed} or {@linkplain
@@ -66,8 +67,8 @@ public interface Call<T> extends Cloneable {
    * Create a new, identical call to this one which can be enqueued or executed even if this call
    * has already been.
    */
-  Call<T> clone();
+  @NotNull Call<T> clone();
 
   /** The original HTTP request. */
-  Request request();
+  @NotNull Request request();
 }

--- a/retrofit/src/main/java/retrofit2/CallAdapter.java
+++ b/retrofit/src/main/java/retrofit2/CallAdapter.java
@@ -15,6 +15,9 @@
  */
 package retrofit2;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -34,7 +37,7 @@ public interface CallAdapter<R, T> {
    * Note: This is typically not the same type as the {@code returnType} provided to this call
    * adapter's factory.
    */
-  Type responseType();
+  @NotNull Type responseType();
 
   /**
    * Returns an instance of {@code T} which delegates to {@code call}.
@@ -53,7 +56,7 @@ public interface CallAdapter<R, T> {
    * }
    * </code></pre>
    */
-  T adapt(Call<R> call);
+  @NotNull T adapt(@NotNull Call<R> call);
 
   /**
    * Creates {@link CallAdapter} instances based on the return type of {@linkplain
@@ -64,14 +67,14 @@ public interface CallAdapter<R, T> {
      * Returns a call adapter for interface methods that return {@code returnType}, or null if it
      * cannot be handled by this factory.
      */
-    public abstract CallAdapter<?, ?> get(Type returnType, Annotation[] annotations,
+    public abstract @Nullable CallAdapter<?, ?> get(Type returnType, Annotation[] annotations,
         Retrofit retrofit);
 
     /**
      * Extract the upper bound of the generic parameter at {@code index} from {@code type}. For
      * example, index 1 of {@code Map<String, ? extends Runnable>} returns {@code Runnable}.
      */
-    protected static Type getParameterUpperBound(int index, ParameterizedType type) {
+    protected static @NotNull Type getParameterUpperBound(int index, ParameterizedType type) {
       return Utils.getParameterUpperBound(index, type);
     }
 
@@ -79,7 +82,7 @@ public interface CallAdapter<R, T> {
      * Extract the raw class type from {@code type}. For example, the type representing
      * {@code List<? extends Runnable>} returns {@code List.class}.
      */
-    protected static Class<?> getRawType(Type type) {
+    protected static @NotNull Class<?> getRawType(Type type) {
       return Utils.getRawType(type);
     }
   }

--- a/retrofit/src/main/java/retrofit2/Callback.java
+++ b/retrofit/src/main/java/retrofit2/Callback.java
@@ -15,6 +15,8 @@
  */
 package retrofit2;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Communicates responses from a server or offline requests. One and only one method will be
  * invoked in response to a given request.
@@ -35,11 +37,11 @@ public interface Callback<T> {
    * Note: An HTTP response may still indicate an application-level failure such as a 404 or 500.
    * Call {@link Response#isSuccessful()} to determine if the response indicates success.
    */
-  void onResponse(Call<T> call, Response<T> response);
+  void onResponse(@NotNull Call<T> call, @NotNull Response<T> response);
 
   /**
    * Invoked when a network exception occurred talking to the server or when an unexpected
    * exception occurred creating the request or processing the response.
    */
-  void onFailure(Call<T> call, Throwable t);
+  void onFailure(@NotNull Call<T> call, @NotNull Throwable t);
 }

--- a/retrofit/src/main/java/retrofit2/Converter.java
+++ b/retrofit/src/main/java/retrofit2/Converter.java
@@ -20,6 +20,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import retrofit2.http.Body;
 import retrofit2.http.Field;
 import retrofit2.http.FieldMap;
@@ -37,7 +39,7 @@ import retrofit2.http.QueryMap;
  * into the {@link Retrofit} instance.
  */
 public interface Converter<F, T> {
-  T convert(F value) throws IOException;
+  @Nullable T convert(F value) throws IOException;
 
   /** Creates {@link Converter} instances based on a type and target usage. */
   abstract class Factory {
@@ -47,8 +49,8 @@ public interface Converter<F, T> {
      * response types such as {@code SimpleResponse} from a {@code Call<SimpleResponse>}
      * declaration.
      */
-    public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
-        Retrofit retrofit) {
+    public @Nullable Converter<ResponseBody, ?> responseBodyConverter(@NotNull Type type,
+        @NotNull Annotation[] annotations, @Nullable Retrofit retrofit) {
       return null;
     }
 
@@ -58,8 +60,9 @@ public interface Converter<F, T> {
      * specified by {@link Body @Body}, {@link Part @Part}, and {@link PartMap @PartMap}
      * values.
      */
-    public Converter<?, RequestBody> requestBodyConverter(Type type,
-        Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
+    public @Nullable Converter<?, RequestBody> requestBodyConverter(@NotNull Type type,
+        @NotNull Annotation[] parameterAnnotations, @NotNull Annotation[] methodAnnotations,
+        @Nullable Retrofit retrofit) {
       return null;
     }
 
@@ -70,8 +73,8 @@ public interface Converter<F, T> {
      * {@link Header @Header}, {@link HeaderMap @HeaderMap}, {@link Path @Path},
      * {@link Query @Query}, and {@link QueryMap @QueryMap} values.
      */
-    public Converter<?, String> stringConverter(Type type, Annotation[] annotations,
-        Retrofit retrofit) {
+    public @Nullable Converter<?, String> stringConverter(@NotNull Type type,
+        @NotNull Annotation[] annotations, @Nullable Retrofit retrofit) {
       return null;
     }
   }

--- a/retrofit/src/main/java/retrofit2/HttpException.java
+++ b/retrofit/src/main/java/retrofit2/HttpException.java
@@ -15,6 +15,9 @@
  */
 package retrofit2;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import static retrofit2.Utils.checkNotNull;
 
 /** Exception for an unexpected, non-2xx HTTP response. */
@@ -28,7 +31,7 @@ public class HttpException extends RuntimeException {
   private final String message;
   private final transient Response<?> response;
 
-  public HttpException(Response<?> response) {
+  public HttpException(@NotNull Response<?> response) {
     super(getMessage(response));
     this.code = response.code();
     this.message = response.message();
@@ -41,14 +44,14 @@ public class HttpException extends RuntimeException {
   }
 
   /** HTTP status message. */
-  public String message() {
+  public @NotNull String message() {
     return message;
   }
 
   /**
    * The full HTTP response. This may be null if the exception was serialized.
    */
-  public Response<?> response() {
+  public @Nullable Response<?> response() {
     return response;
   }
 }

--- a/retrofit/src/main/java/retrofit2/Response.java
+++ b/retrofit/src/main/java/retrofit2/Response.java
@@ -19,13 +19,15 @@ import okhttp3.Headers;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.ResponseBody;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static retrofit2.Utils.checkNotNull;
 
 /** An HTTP response. */
 public final class Response<T> {
   /** Create a synthetic successful response with {@code body} as the deserialized body. */
-  public static <T> Response<T> success(T body) {
+  public static @NotNull <T> Response<T> success(@Nullable T body) {
     return success(body, new okhttp3.Response.Builder() //
         .code(200)
         .message("OK")
@@ -38,7 +40,7 @@ public final class Response<T> {
    * Create a synthetic successful response using {@code headers} with {@code body} as the
    * deserialized body.
    */
-  public static <T> Response<T> success(T body, Headers headers) {
+  public static @NotNull <T> Response<T> success(@Nullable T body, @NotNull Headers headers) {
     checkNotNull(headers, "headers == null");
     return success(body, new okhttp3.Response.Builder() //
         .code(200)
@@ -53,7 +55,8 @@ public final class Response<T> {
    * Create a successful response from {@code rawResponse} with {@code body} as the deserialized
    * body.
    */
-  public static <T> Response<T> success(T body, okhttp3.Response rawResponse) {
+  public static @NotNull <T> Response<T> success(@Nullable T body,
+      @NotNull okhttp3.Response rawResponse) {
     checkNotNull(rawResponse, "rawResponse == null");
     if (!rawResponse.isSuccessful()) {
       throw new IllegalArgumentException("rawResponse must be successful response");
@@ -65,7 +68,7 @@ public final class Response<T> {
    * Create a synthetic error response with an HTTP status code of {@code code} and {@code body}
    * as the error body.
    */
-  public static <T> Response<T> error(int code, ResponseBody body) {
+  public static @NotNull <T> Response<T> error(int code, @NotNull ResponseBody body) {
     if (code < 400) throw new IllegalArgumentException("code < 400: " + code);
     return error(body, new okhttp3.Response.Builder() //
         .code(code)
@@ -75,7 +78,8 @@ public final class Response<T> {
   }
 
   /** Create an error response from {@code rawResponse} with {@code body} as the error body. */
-  public static <T> Response<T> error(ResponseBody body, okhttp3.Response rawResponse) {
+  public static @NotNull <T> Response<T> error(@Nullable ResponseBody body,
+      @NotNull okhttp3.Response rawResponse) {
     checkNotNull(body, "body == null");
     checkNotNull(rawResponse, "rawResponse == null");
     if (rawResponse.isSuccessful()) {
@@ -95,7 +99,7 @@ public final class Response<T> {
   }
 
   /** The raw response from the HTTP client. */
-  public okhttp3.Response raw() {
+  public @NotNull okhttp3.Response raw() {
     return rawResponse;
   }
 
@@ -105,12 +109,12 @@ public final class Response<T> {
   }
 
   /** HTTP status message or null if unknown. */
-  public String message() {
+  public @Nullable String message() {
     return rawResponse.message();
   }
 
   /** HTTP headers. */
-  public Headers headers() {
+  public @NotNull Headers headers() {
     return rawResponse.headers();
   }
 
@@ -120,12 +124,12 @@ public final class Response<T> {
   }
 
   /** The deserialized response body of a {@linkplain #isSuccessful() successful} response. */
-  public T body() {
+  public @Nullable T body() {
     return body;
   }
 
   /** The raw response body of an {@linkplain #isSuccessful() unsuccessful} response. */
-  public ResponseBody errorBody() {
+  public @Nullable ResponseBody errorBody() {
     return errorBody;
   }
 

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -29,6 +29,8 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import retrofit2.http.GET;
 import retrofit2.http.HTTP;
 import retrofit2.http.Header;
@@ -124,7 +126,7 @@ public final class Retrofit {
    * </pre>
    */
   @SuppressWarnings("unchecked") // Single-interface proxy creation guarded by parameter safety.
-  public <T> T create(final Class<T> service) {
+  public @NotNull <T> T create(final @NotNull Class<T> service) {
     Utils.validateServiceInterface(service);
     if (validateEagerly) {
       eagerlyValidateMethods(service);
@@ -177,12 +179,12 @@ public final class Retrofit {
    * The factory used to create {@linkplain okhttp3.Call OkHttp calls} for sending a HTTP requests.
    * Typically an instance of {@link OkHttpClient}.
    */
-  public okhttp3.Call.Factory callFactory() {
+  public @NotNull okhttp3.Call.Factory callFactory() {
     return callFactory;
   }
 
   /** The API base URL. */
-  public HttpUrl baseUrl() {
+  public @NotNull HttpUrl baseUrl() {
     return baseUrl;
   }
 
@@ -190,7 +192,7 @@ public final class Retrofit {
    * Returns a list of the factories tried when creating a
    * {@linkplain #callAdapter(Type, Annotation[])} call adapter}.
    */
-  public List<CallAdapter.Factory> callAdapterFactories() {
+  public @NotNull List<CallAdapter.Factory> callAdapterFactories() {
     return adapterFactories;
   }
 
@@ -200,7 +202,8 @@ public final class Retrofit {
    *
    * @throws IllegalArgumentException if no call adapter available for {@code type}.
    */
-  public CallAdapter<?, ?> callAdapter(Type returnType, Annotation[] annotations) {
+  public @NotNull CallAdapter<?, ?> callAdapter(@NotNull Type returnType,
+      @NotNull Annotation[] annotations) {
     return nextCallAdapter(null, returnType, annotations);
   }
 
@@ -210,8 +213,8 @@ public final class Retrofit {
    *
    * @throws IllegalArgumentException if no call adapter available for {@code type}.
    */
-  public CallAdapter<?, ?> nextCallAdapter(CallAdapter.Factory skipPast, Type returnType,
-      Annotation[] annotations) {
+  public @NotNull CallAdapter<?, ?> nextCallAdapter(@Nullable CallAdapter.Factory skipPast,
+      @NotNull Type returnType, @NotNull Annotation[] annotations) {
     checkNotNull(returnType, "returnType == null");
     checkNotNull(annotations, "annotations == null");
 
@@ -246,7 +249,7 @@ public final class Retrofit {
    * {@linkplain #responseBodyConverter(Type, Annotation[]) response body converter}, or a
    * {@linkplain #stringConverter(Type, Annotation[]) string converter}.
    */
-  public List<Converter.Factory> converterFactories() {
+  public @NotNull List<Converter.Factory> converterFactories() {
     return converterFactories;
   }
 
@@ -256,8 +259,8 @@ public final class Retrofit {
    *
    * @throws IllegalArgumentException if no converter available for {@code type}.
    */
-  public <T> Converter<T, RequestBody> requestBodyConverter(Type type,
-      Annotation[] parameterAnnotations, Annotation[] methodAnnotations) {
+  public @NotNull <T> Converter<T, RequestBody> requestBodyConverter(@NotNull Type type,
+      @NotNull Annotation[] parameterAnnotations, @NotNull Annotation[] methodAnnotations) {
     return nextRequestBodyConverter(null, type, parameterAnnotations, methodAnnotations);
   }
 
@@ -267,8 +270,10 @@ public final class Retrofit {
    *
    * @throws IllegalArgumentException if no converter available for {@code type}.
    */
-  public <T> Converter<T, RequestBody> nextRequestBodyConverter(Converter.Factory skipPast,
-      Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations) {
+  public @NotNull <T> Converter<T, RequestBody> nextRequestBodyConverter(
+      @Nullable Converter.Factory skipPast,
+      @NotNull Type type, @NotNull Annotation[] parameterAnnotations,
+      @NotNull Annotation[] methodAnnotations) {
     checkNotNull(type, "type == null");
     checkNotNull(parameterAnnotations, "parameterAnnotations == null");
     checkNotNull(methodAnnotations, "methodAnnotations == null");
@@ -307,7 +312,8 @@ public final class Retrofit {
    *
    * @throws IllegalArgumentException if no converter available for {@code type}.
    */
-  public <T> Converter<ResponseBody, T> responseBodyConverter(Type type, Annotation[] annotations) {
+  public @NotNull <T> Converter<ResponseBody, T> responseBodyConverter(@NotNull Type type,
+      @NotNull Annotation[] annotations) {
     return nextResponseBodyConverter(null, type, annotations);
   }
 
@@ -317,8 +323,9 @@ public final class Retrofit {
    *
    * @throws IllegalArgumentException if no converter available for {@code type}.
    */
-  public <T> Converter<ResponseBody, T> nextResponseBodyConverter(Converter.Factory skipPast,
-      Type type, Annotation[] annotations) {
+  public @NotNull <T> Converter<ResponseBody, T> nextResponseBodyConverter(
+      @Nullable Converter.Factory skipPast,
+      @NotNull Type type, @NotNull Annotation[] annotations) {
     checkNotNull(type, "type == null");
     checkNotNull(annotations, "annotations == null");
 
@@ -353,7 +360,8 @@ public final class Retrofit {
    * Returns a {@link Converter} for {@code type} to {@link String} from the available
    * {@linkplain #converterFactories() factories}.
    */
-  public <T> Converter<T, String> stringConverter(Type type, Annotation[] annotations) {
+  public @NotNull <T> Converter<T, String> stringConverter(@NotNull Type type,
+      @NotNull Annotation[] annotations) {
     checkNotNull(type, "type == null");
     checkNotNull(annotations, "annotations == null");
 
@@ -375,11 +383,11 @@ public final class Retrofit {
    * The executor used for {@link Callback} methods on a {@link Call}. This may be {@code null},
    * in which case callbacks should be made synchronously on the background thread.
    */
-  public Executor callbackExecutor() {
+  public @NotNull Executor callbackExecutor() {
     return callbackExecutor;
   }
 
-  public Builder newBuilder() {
+  public @NotNull Builder newBuilder() {
     return new Builder(this);
   }
 
@@ -426,7 +434,7 @@ public final class Retrofit {
      * <p>
      * This is a convenience method for calling {@link #callFactory}.
      */
-    public Builder client(OkHttpClient client) {
+    public @NotNull Builder client(@NotNull OkHttpClient client) {
       return callFactory(checkNotNull(client, "client == null"));
     }
 
@@ -435,7 +443,7 @@ public final class Retrofit {
      * <p>
      * Note: Calling {@link #client} automatically sets this value.
      */
-    public Builder callFactory(okhttp3.Call.Factory factory) {
+    public @NotNull Builder callFactory(@NotNull okhttp3.Call.Factory factory) {
       this.callFactory = checkNotNull(factory, "factory == null");
       return this;
     }
@@ -445,7 +453,7 @@ public final class Retrofit {
      *
      * @see #baseUrl(HttpUrl)
      */
-    public Builder baseUrl(String baseUrl) {
+    public @NotNull Builder baseUrl(@NotNull String baseUrl) {
       checkNotNull(baseUrl, "baseUrl == null");
       HttpUrl httpUrl = HttpUrl.parse(baseUrl);
       if (httpUrl == null) {
@@ -504,7 +512,7 @@ public final class Retrofit {
      * Endpoint: //github.com/square/retrofit/<br>
      * Result: http://github.com/square/retrofit/ (note the scheme stays 'http')
      */
-    public Builder baseUrl(HttpUrl baseUrl) {
+    public @NotNull Builder baseUrl(@NotNull HttpUrl baseUrl) {
       checkNotNull(baseUrl, "baseUrl == null");
       List<String> pathSegments = baseUrl.pathSegments();
       if (!"".equals(pathSegments.get(pathSegments.size() - 1))) {
@@ -515,7 +523,7 @@ public final class Retrofit {
     }
 
     /** Add converter factory for serialization and deserialization of objects. */
-    public Builder addConverterFactory(Converter.Factory factory) {
+    public @NotNull Builder addConverterFactory(@NotNull Converter.Factory factory) {
       converterFactories.add(checkNotNull(factory, "factory == null"));
       return this;
     }
@@ -524,7 +532,7 @@ public final class Retrofit {
      * Add a call adapter factory for supporting service method return types other than {@link
      * Call}.
      */
-    public Builder addCallAdapterFactory(CallAdapter.Factory factory) {
+    public @NotNull Builder addCallAdapterFactory(@NotNull CallAdapter.Factory factory) {
       adapterFactories.add(checkNotNull(factory, "factory == null"));
       return this;
     }
@@ -536,7 +544,7 @@ public final class Retrofit {
      * Note: {@code executor} is not used for {@linkplain #addCallAdapterFactory custom method
      * return types}.
      */
-    public Builder callbackExecutor(Executor executor) {
+    public @NotNull Builder callbackExecutor(@NotNull Executor executor) {
       this.callbackExecutor = checkNotNull(executor, "executor == null");
       return this;
     }
@@ -545,7 +553,7 @@ public final class Retrofit {
      * When calling {@link #create} on the resulting {@link Retrofit} instance, eagerly validate
      * the configuration of all methods in the supplied interface.
      */
-    public Builder validateEagerly(boolean validateEagerly) {
+    public @NotNull Builder validateEagerly(boolean validateEagerly) {
       this.validateEagerly = validateEagerly;
       return this;
     }
@@ -556,7 +564,7 @@ public final class Retrofit {
      * Note: If neither {@link #client} nor {@link #callFactory} is called a default {@link
      * OkHttpClient} will be created and used.
      */
-    public Retrofit build() {
+    public @NotNull Retrofit build() {
       if (baseUrl == null) {
         throw new IllegalStateException("Base URL required.");
       }


### PR DESCRIPTION
WIP implementation of #624

What I think I've covered:

* [x] Retrofit public APIs
* [x] Retrofit Adapters
* [ ] Retrofit Converters

It also turns out that `org.jetbrains:annotations-java5` contains _only_ `@Nullable` and `@NotNull`.