### PR TITLE
Allow Crawler to crawl urls that aren't present in the fetched urls set

### DIFF
--- a/samples/src/main/java/com/example/retrofit/Crawler.java
+++ b/samples/src/main/java/com/example/retrofit/Crawler.java
@@ -77,7 +77,7 @@ public final class Crawler {
         // Enqueue its links for visiting.
         for (String link : page.links) {
           HttpUrl linkUrl = base.resolve(link);
-          if (linkUrl != null && !fetchedUrls.add(linkUrl)) {
+          if (linkUrl != null && fetchedUrls.add(linkUrl)) {
             crawlPage(linkUrl);
           }
         }


### PR DESCRIPTION
The subsequent calls of `crawlPage` was only occurring if the url that is being iterated is already in the fetched urls set.

With this modification, `crawlPage`  only occurs in the first time that the url is being added to the set