### PR TITLE
Explicitly handle wrapped, re-thrown exceptions from onComplete, onError.

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/BodyOnSubscribe.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/BodyOnSubscribe.java
@@ -20,6 +20,9 @@ import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.exceptions.CompositeException;
 import rx.exceptions.Exceptions;
+import rx.exceptions.OnCompletedFailedException;
+import rx.exceptions.OnErrorFailedException;
+import rx.exceptions.OnErrorNotImplementedException;
 import rx.plugins.RxJavaPlugins;
 
 final class BodyOnSubscribe<T> implements OnSubscribe<T> {
@@ -51,6 +54,10 @@ final class BodyOnSubscribe<T> implements OnSubscribe<T> {
         Throwable t = new HttpException(response);
         try {
           subscriber.onError(t);
+        } catch (OnCompletedFailedException
+            | OnErrorFailedException
+            | OnErrorNotImplementedException e) {
+          RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
         } catch (Throwable inner) {
           Exceptions.throwIfFatal(inner);
           CompositeException composite = new CompositeException(t, inner);

--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/CallArbiter.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/CallArbiter.java
@@ -23,6 +23,9 @@ import rx.Subscriber;
 import rx.Subscription;
 import rx.exceptions.CompositeException;
 import rx.exceptions.Exceptions;
+import rx.exceptions.OnCompletedFailedException;
+import rx.exceptions.OnErrorFailedException;
+import rx.exceptions.OnErrorNotImplementedException;
 import rx.plugins.RxJavaPlugins;
 
 final class CallArbiter<T> extends AtomicInteger implements Subscription, Producer {
@@ -114,10 +117,19 @@ final class CallArbiter<T> extends AtomicInteger implements Subscription, Produc
       if (!isUnsubscribed()) {
         subscriber.onNext(response);
       }
+    } catch (OnCompletedFailedException
+        | OnErrorFailedException
+        | OnErrorNotImplementedException e) {
+      RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
+      return;
     } catch (Throwable t) {
       Exceptions.throwIfFatal(t);
       try {
         subscriber.onError(t);
+      } catch (OnCompletedFailedException
+          | OnErrorFailedException
+          | OnErrorNotImplementedException e) {
+        RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
       } catch (Throwable inner) {
         Exceptions.throwIfFatal(inner);
         CompositeException composite = new CompositeException(t, inner);
@@ -129,6 +141,10 @@ final class CallArbiter<T> extends AtomicInteger implements Subscription, Produc
       if (!isUnsubscribed()) {
         subscriber.onCompleted();
       }
+    } catch (OnCompletedFailedException
+        | OnErrorFailedException
+        | OnErrorNotImplementedException e) {
+      RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
     } catch (Throwable t) {
       Exceptions.throwIfFatal(t);
       RxJavaPlugins.getInstance().getErrorHandler().handleError(t);
@@ -141,6 +157,10 @@ final class CallArbiter<T> extends AtomicInteger implements Subscription, Produc
     if (!isUnsubscribed()) {
       try {
         subscriber.onError(t);
+      } catch (OnCompletedFailedException
+          | OnErrorFailedException
+          | OnErrorNotImplementedException e) {
+        RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
       } catch (Throwable inner) {
         Exceptions.throwIfFatal(inner);
         CompositeException composite = new CompositeException(t, inner);

--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/ResultOnSubscribe.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/ResultOnSubscribe.java
@@ -20,6 +20,9 @@ import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.exceptions.CompositeException;
 import rx.exceptions.Exceptions;
+import rx.exceptions.OnCompletedFailedException;
+import rx.exceptions.OnErrorFailedException;
+import rx.exceptions.OnErrorNotImplementedException;
 import rx.plugins.RxJavaPlugins;
 
 final class ResultOnSubscribe<T> implements OnSubscribe<Result<T>> {
@@ -51,6 +54,10 @@ final class ResultOnSubscribe<T> implements OnSubscribe<Result<T>> {
       } catch (Throwable t) {
         try {
           subscriber.onError(t);
+        } catch (OnCompletedFailedException
+            | OnErrorFailedException
+            | OnErrorNotImplementedException e) {
+          RxJavaPlugins.getInstance().getErrorHandler().handleError(e);
         } catch (Throwable inner) {
           Exceptions.throwIfFatal(inner);
           CompositeException composite = new CompositeException(t, inner);

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableThrowingSafeSubscriberTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableThrowingSafeSubscriberTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.adapter.rxjava;
+
+import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import retrofit2.Retrofit;
+import retrofit2.http.GET;
+import rx.Completable;
+import rx.CompletableSubscriber;
+import rx.Subscription;
+import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
+import rx.exceptions.OnCompletedFailedException;
+import rx.exceptions.OnErrorFailedException;
+import rx.plugins.RxJavaErrorHandler;
+import rx.plugins.RxJavaPlugins;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class CompletableThrowingSafeSubscriberTest {
+  @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final TestRule resetRule = new RxJavaPluginsResetRule();
+  @Rule public final RecordingSubscriber.Rule subscriberRule = new RecordingSubscriber.Rule();
+
+  interface Service {
+    @GET("/") Completable completable();
+  }
+
+  private Service service;
+
+  @Before public void setUp() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+        .build();
+    service = retrofit.create(Service.class);
+  }
+
+  @Test public void throwingInOnCompleteDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (throwable instanceof OnCompletedFailedException) {
+          if (!pluginRef.compareAndSet(null, throwable)) {
+            throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+          }
+        }
+      }
+    });
+
+    RecordingSubscriber<Void> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.completable().subscribe(new ForwardingCompletableObserver(observer) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    assertThat(pluginRef.get().getCause()).isSameAs(e);
+  }
+
+  @Test public void bodyThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (throwable instanceof OnErrorFailedException) {
+          if (!pluginRef.compareAndSet(null, throwable)) {
+            throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+          }
+        }
+      }
+    });
+
+    RecordingSubscriber<Void> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    service.completable().subscribe(new ForwardingCompletableObserver(observer) {
+      @Override public void onError(Throwable throwable) {
+        errorRef.set(throwable);
+        throw e;
+      }
+    });
+
+    CompositeException composite = (CompositeException) pluginRef.get().getCause();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
+  }
+
+  static abstract class ForwardingCompletableObserver implements CompletableSubscriber {
+    private final RecordingSubscriber<Void> delegate;
+
+    ForwardingCompletableObserver(RecordingSubscriber<Void> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override public void onSubscribe(Subscription d) {
+    }
+
+    @Override public void onCompleted() {
+      delegate.onCompleted();
+    }
+
+    @Override public void onError(Throwable throwable) {
+      delegate.onError(throwable);
+    }
+  }
+}

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableThrowingTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableThrowingTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.adapter.rxjava;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import retrofit2.Retrofit;
+import retrofit2.http.GET;
+import rx.Completable;
+import rx.CompletableSubscriber;
+import rx.Subscription;
+import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
+import rx.plugins.RxJavaErrorHandler;
+import rx.plugins.RxJavaPlugins;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class CompletableThrowingTest {
+  @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final TestRule resetRule = new RxJavaPluginsResetRule();
+  @Rule public final RecordingSubscriber.Rule subscriberRule = new RecordingSubscriber.Rule();
+
+  interface Service {
+    @GET("/") Completable completable();
+  }
+
+  private Service service;
+
+  @Before public void setUp() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+        .build();
+    service = retrofit.create(Service.class);
+  }
+
+  @Test public void throwingInOnCompleteDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<Void> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.completable().unsafeSubscribe(new ForwardingCompletableObserver(observer) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    assertThat(pluginRef.get()).isSameAs(e);
+  }
+
+  @Test public void bodyThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<Void> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    service.completable().unsafeSubscribe(new ForwardingCompletableObserver(observer) {
+      @Override public void onError(Throwable throwable) {
+        errorRef.set(throwable);
+        throw e;
+      }
+    });
+
+    CompositeException composite = (CompositeException) pluginRef.get();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
+  }
+
+  static abstract class ForwardingCompletableObserver implements CompletableSubscriber {
+    private final RecordingSubscriber<Void> delegate;
+
+    ForwardingCompletableObserver(RecordingSubscriber<Void> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override public void onSubscribe(Subscription d) {
+    }
+
+    @Override public void onCompleted() {
+      delegate.onCompleted();
+    }
+
+    @Override public void onError(Throwable throwable) {
+      delegate.onError(throwable);
+    }
+  }
+}

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/ObservableThrowingSafeSubscriberTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/ObservableThrowingSafeSubscriberTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.adapter.rxjava;
+
+import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.http.GET;
+import rx.Observable;
+import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
+import rx.exceptions.OnCompletedFailedException;
+import rx.exceptions.OnErrorFailedException;
+import rx.plugins.RxJavaErrorHandler;
+import rx.plugins.RxJavaPlugins;
+
+import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class ObservableThrowingSafeSubscriberTest {
+  @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final TestRule resetRule = new RxJavaPluginsResetRule();
+  @Rule public final RecordingSubscriber.Rule subscriberRule = new RecordingSubscriber.Rule();
+
+  interface Service {
+    @GET("/") Observable<String> body();
+    @GET("/") Observable<Response<String>> response();
+    @GET("/") Observable<Result<String>> result();
+  }
+
+  private Service service;
+
+  @Before public void setUp() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(new StringConverterFactory())
+        .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+        .build();
+    service = retrofit.create(Service.class);
+  }
+
+  @Test public void bodyThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse());
+
+    RecordingSubscriber<String> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.body().subscribe(new ForwardingSubscriber<String>(observer) {
+      @Override public void onNext(String value) {
+        throw e;
+      }
+    });
+
+    observer.assertError(e);
+  }
+
+  @Test public void bodyThrowingInOnCompleteDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (throwable instanceof OnCompletedFailedException) {
+          if (!pluginRef.compareAndSet(null, throwable)) {
+            throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+          }
+        }
+      }
+    });
+
+    RecordingSubscriber<String> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.body().subscribe(new ForwardingSubscriber<String>(observer) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    observer.assertAnyValue();
+    assertThat(pluginRef.get().getCause()).isSameAs(e);
+  }
+
+  @Test public void bodyThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (throwable instanceof OnErrorFailedException) {
+          if (!pluginRef.compareAndSet(null, throwable)) {
+            throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+          }
+        }
+      }
+    });
+
+    RecordingSubscriber<String> observer = subscriberRule.create();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final RuntimeException e = new RuntimeException();
+    service.body().subscribe(new ForwardingSubscriber<String>(observer) {
+      @Override public void onError(Throwable throwable) {
+        if (!errorRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+        throw e;
+      }
+    });
+
+    CompositeException composite = (CompositeException) pluginRef.get().getCause();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
+  }
+
+  @Test public void responseThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse());
+
+    RecordingSubscriber<Response<String>> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.response().subscribe(new ForwardingSubscriber<Response<String>>(observer) {
+      @Override public void onNext(Response<String> value) {
+        throw e;
+      }
+    });
+
+    observer.assertError(e);
+  }
+
+  @Test public void responseThrowingInOnCompleteDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (throwable instanceof OnCompletedFailedException) {
+          if (!pluginRef.compareAndSet(null, throwable)) {
+            throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+          }
+        }
+      }
+    });
+
+    RecordingSubscriber<Response<String>> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.response().subscribe(new ForwardingSubscriber<Response<String>>(observer) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    observer.assertAnyValue();
+    assertThat(pluginRef.get().getCause()).isSameAs(e);
+  }
+
+  @Test public void responseThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST));
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (throwable instanceof OnErrorFailedException) {
+          if (!pluginRef.compareAndSet(null, throwable)) {
+            throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+          }
+        }
+      }
+    });
+
+    RecordingSubscriber<Response<String>> observer = subscriberRule.create();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final RuntimeException e = new RuntimeException();
+    service.response().subscribe(new ForwardingSubscriber<Response<String>>(observer) {
+      @Override public void onError(Throwable throwable) {
+        if (!errorRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+        throw e;
+      }
+    });
+
+    CompositeException composite = (CompositeException) pluginRef.get().getCause();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
+  }
+
+  @Test public void resultThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse());
+
+    RecordingSubscriber<Result<String>> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.result().subscribe(new ForwardingSubscriber<Result<String>>(observer) {
+      @Override public void onNext(Result<String> value) {
+        throw e;
+      }
+    });
+
+    observer.assertError(e);
+  }
+
+  @Test public void resultThrowingInOnCompletedDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (throwable instanceof OnCompletedFailedException) {
+          if (!pluginRef.compareAndSet(null, throwable)) {
+            throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+          }
+        }
+      }
+    });
+
+    RecordingSubscriber<Result<String>> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.result().subscribe(new ForwardingSubscriber<Result<String>>(observer) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    observer.assertAnyValue();
+    assertThat(pluginRef.get().getCause()).isSameAs(e);
+  }
+
+  @Test public void resultThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (throwable instanceof OnErrorFailedException) {
+          if (!pluginRef.compareAndSet(null, throwable)) {
+            throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+          }
+        }
+      }
+    });
+
+    RecordingSubscriber<Result<String>> observer = subscriberRule.create();
+    final RuntimeException first = new RuntimeException();
+    final RuntimeException second = new RuntimeException();
+    service.result().subscribe(new ForwardingSubscriber<Result<String>>(observer) {
+      @Override public void onNext(Result<String> value) {
+        // The only way to trigger onError for a result is if onNext throws.
+        throw first;
+      }
+
+      @Override public void onError(Throwable throwable) {
+        throw second;
+      }
+    });
+
+    CompositeException composite = (CompositeException) pluginRef.get().getCause();
+    assertThat(composite.getExceptions()).containsExactly(first, second);
+  }
+}

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/ObservableThrowingTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/ObservableThrowingTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.adapter.rxjava;
+
+import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.http.GET;
+import rx.Observable;
+import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
+import rx.plugins.RxJavaErrorHandler;
+import rx.plugins.RxJavaPlugins;
+
+import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class ObservableThrowingTest {
+  @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final TestRule resetRule = new RxJavaPluginsResetRule();
+  @Rule public final RecordingSubscriber.Rule subscriberRule = new RecordingSubscriber.Rule();
+
+  interface Service {
+    @GET("/") Observable<String> body();
+    @GET("/") Observable<Response<String>> response();
+    @GET("/") Observable<Result<String>> result();
+  }
+
+  private Service service;
+
+  @Before public void setUp() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(new StringConverterFactory())
+        .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+        .build();
+    service = retrofit.create(Service.class);
+  }
+
+  @Test public void bodyThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse());
+
+    RecordingSubscriber<String> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.body().unsafeSubscribe(new ForwardingSubscriber<String>(observer) {
+      @Override public void onNext(String value) {
+        throw e;
+      }
+    });
+
+    observer.assertError(e);
+  }
+
+  @Test public void bodyThrowingInOnCompleteDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<String> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.body().unsafeSubscribe(new ForwardingSubscriber<String>(observer) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    observer.assertAnyValue();
+    assertThat(pluginRef.get()).isSameAs(e);
+  }
+
+  @Test public void bodyThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<String> observer = subscriberRule.create();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final RuntimeException e = new RuntimeException();
+    service.body().unsafeSubscribe(new ForwardingSubscriber<String>(observer) {
+      @Override public void onError(Throwable throwable) {
+        if (!errorRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+        throw e;
+      }
+    });
+
+    CompositeException composite = (CompositeException) pluginRef.get();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
+  }
+
+  @Test public void responseThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse());
+
+    RecordingSubscriber<Response<String>> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.response().unsafeSubscribe(new ForwardingSubscriber<Response<String>>(observer) {
+      @Override public void onNext(Response<String> value) {
+        throw e;
+      }
+    });
+
+    observer.assertError(e);
+  }
+
+  @Test public void responseThrowingInOnCompleteDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<Response<String>> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.response().unsafeSubscribe(new ForwardingSubscriber<Response<String>>(observer) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    observer.assertAnyValue();
+    assertThat(pluginRef.get()).isSameAs(e);
+  }
+
+  @Test public void responseThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST));
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<Response<String>> observer = subscriberRule.create();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final RuntimeException e = new RuntimeException();
+    service.response().unsafeSubscribe(new ForwardingSubscriber<Response<String>>(observer) {
+      @Override public void onError(Throwable throwable) {
+        if (!errorRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+        throw e;
+      }
+    });
+
+    CompositeException composite = (CompositeException) pluginRef.get();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
+  }
+
+  @Test public void resultThrowingInOnNextDeliveredToError() {
+    server.enqueue(new MockResponse());
+
+    RecordingSubscriber<Result<String>> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.result().unsafeSubscribe(new ForwardingSubscriber<Result<String>>(observer) {
+      @Override public void onNext(Result<String> value) {
+        throw e;
+      }
+    });
+
+    observer.assertError(e);
+  }
+
+  @Test public void resultThrowingInOnCompletedDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<Result<String>> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.result().unsafeSubscribe(new ForwardingSubscriber<Result<String>>(observer) {
+      @Override public void onCompleted() {
+        throw e;
+      }
+    });
+
+    observer.assertAnyValue();
+    assertThat(pluginRef.get()).isSameAs(e);
+  }
+
+  @Test public void resultThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<Result<String>> observer = subscriberRule.create();
+    final RuntimeException first = new RuntimeException();
+    final RuntimeException second = new RuntimeException();
+    service.result().unsafeSubscribe(new ForwardingSubscriber<Result<String>>(observer) {
+      @Override public void onNext(Result<String> value) {
+        // The only way to trigger onError for a result is if onNext throws.
+        throw first;
+      }
+
+      @Override public void onError(Throwable throwable) {
+        throw second;
+      }
+    });
+
+    CompositeException composite = (CompositeException) pluginRef.get();
+    assertThat(composite.getExceptions()).containsExactly(first, second);
+  }
+}

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleThrowingTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleThrowingTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.adapter.rxjava;
+
+import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.http.GET;
+import rx.Single;
+import rx.SingleSubscriber;
+import rx.Subscriber;
+import rx.exceptions.CompositeException;
+import rx.exceptions.Exceptions;
+import rx.plugins.RxJavaErrorHandler;
+import rx.plugins.RxJavaPlugins;
+
+import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class SingleThrowingTest {
+  @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final TestRule resetRule = new RxJavaPluginsResetRule();
+  @Rule public final RecordingSubscriber.Rule subscriberRule = new RecordingSubscriber.Rule();
+
+  interface Service {
+    @GET("/") Single<String> body();
+    @GET("/") Single<Response<String>> response();
+    @GET("/") Single<Result<String>> result();
+  }
+
+  private Service service;
+
+  @Before public void setUp() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(new StringConverterFactory())
+        .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+        .build();
+    service = retrofit.create(Service.class);
+  }
+
+  @Test public void bodyThrowingInOnSuccessDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<String> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.body().subscribe(new ForwardingObserver<String>(observer) {
+      @Override public void onSuccess(String value) {
+        throw e;
+      }
+    });
+
+    assertThat(pluginRef.get()).isSameAs(e);
+  }
+
+  @Test public void bodyThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<String> observer = subscriberRule.create();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final RuntimeException e = new RuntimeException();
+    service.body().subscribe(new ForwardingObserver<String>(observer) {
+      @Override public void onError(Throwable throwable) {
+        if (!errorRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+        throw e;
+      }
+    });
+
+    CompositeException composite = (CompositeException) pluginRef.get();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
+  }
+
+  @Test public void responseThrowingInOnSuccessDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<Response<String>> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.response().subscribe(new ForwardingObserver<Response<String>>(observer) {
+      @Override public void onSuccess(Response<String> value) {
+        throw e;
+      }
+    });
+
+    assertThat(pluginRef.get()).isSameAs(e);
+  }
+
+  @Test public void responseThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST));
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<Response<String>> observer = subscriberRule.create();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    final RuntimeException e = new RuntimeException();
+    service.response().subscribe(new ForwardingObserver<Response<String>>(observer) {
+      @Override public void onError(Throwable throwable) {
+        if (!errorRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable);
+        }
+        throw e;
+      }
+    });
+
+    CompositeException composite = (CompositeException) pluginRef.get();
+    assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
+  }
+
+  @Test public void resultThrowingInOnSuccessDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<Result<String>> observer = subscriberRule.create();
+    final RuntimeException e = new RuntimeException();
+    service.result().subscribe(new ForwardingObserver<Result<String>>(observer) {
+      @Override public void onSuccess(Result<String> value) {
+        throw e;
+      }
+    });
+
+    assertThat(pluginRef.get()).isSameAs(e);
+  }
+
+  @Ignore("Single's contract is onNext|onError so we have no way of triggering this case")
+  @Test public void resultThrowingInOnErrorDeliveredToPlugin() {
+    server.enqueue(new MockResponse());
+
+    final AtomicReference<Throwable> pluginRef = new AtomicReference<>();
+    RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
+      @Override public void handleError(Throwable throwable) {
+        if (!pluginRef.compareAndSet(null, throwable)) {
+          throw Exceptions.propagate(throwable); // Don't swallow secondary errors!
+        }
+      }
+    });
+
+    RecordingSubscriber<Result<String>> observer = subscriberRule.create();
+    final RuntimeException first = new RuntimeException();
+    final RuntimeException second = new RuntimeException();
+    service.result().subscribe(new ForwardingObserver<Result<String>>(observer) {
+      @Override public void onSuccess(Result<String> value) {
+        // The only way to trigger onError for Result is if onSuccess throws.
+        throw first;
+      }
+
+      @Override public void onError(Throwable throwable) {
+        throw second;
+      }
+    });
+
+    CompositeException composite = (CompositeException) pluginRef.get();
+    assertThat(composite.getExceptions()).containsExactly(first, second);
+  }
+
+  private static abstract class ForwardingObserver<T> extends SingleSubscriber<T> {
+    private final Subscriber<T> delegate;
+
+    ForwardingObserver(Subscriber<T> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override public void onSuccess(T value) {
+      delegate.onNext(value);
+      delegate.onCompleted();
+    }
+
+    @Override public void onError(Throwable throwable) {
+      delegate.onError(throwable);
+    }
+  }
+}


### PR DESCRIPTION
Because `Exceptions.throwIfFatal` treats these as fatal, prior to this they would bubble up to the caller. This is either the thread uncaught exception handler which is fine, but in the case of async sources it would go to the library code invoking the async callback (like OkHttp's `Call`) which might swallow them.

Tests are just copy/paste from RxJava 2 adapter.

Closes #2285.