### PR TITLE
clarify random network failure message

### DIFF
--- a/retrofit-mock/src/main/java/retrofit2/mock/NetworkBehavior.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/NetworkBehavior.java
@@ -76,7 +76,7 @@ public final class NetworkBehavior {
   private NetworkBehavior(Random random) {
     this.random = random;
 
-    failureException = new IOException("Mock failure!");
+    failureException = new IOException("Mock random network failure!");
     failureException.setStackTrace(new StackTraceElement[0]);
   }
 

--- a/retrofit-mock/src/test/java/retrofit2/mock/NetworkBehaviorTest.java
+++ b/retrofit-mock/src/test/java/retrofit2/mock/NetworkBehaviorTest.java
@@ -33,7 +33,7 @@ public final class NetworkBehaviorTest {
 
   @Test public void defaultThrowable() {
     Throwable t = behavior.failureException();
-    assertThat(t).isExactlyInstanceOf(IOException.class).hasMessage("Mock failure!");
+    assertThat(t).isExactlyInstanceOf(IOException.class).hasMessage("Mock random network failure!");
     assertThat(t.getStackTrace()).isEmpty();
   }
 


### PR DESCRIPTION
Small change, but this one bit us when someone copy/pasted an example usage into our project and we weren't aware of the new behavior.  Having a less ambiguous error message will help track down the problem more quickly IMO.