### PR TITLE
Use custom exception type when triggering mock failure.

### DIFF
--- a/retrofit-mock/src/main/java/retrofit2/mock/MockRetrofitIOException.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/MockRetrofitIOException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.mock;
+
+import java.io.IOException;
+
+final class MockRetrofitIOException extends IOException {
+  MockRetrofitIOException() {
+    super("Failure triggered by MockRetrofit's NetworkBehavior");
+  }
+}

--- a/retrofit-mock/src/main/java/retrofit2/mock/NetworkBehavior.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/NetworkBehavior.java
@@ -76,7 +76,7 @@ public final class NetworkBehavior {
   private NetworkBehavior(Random random) {
     this.random = random;
 
-    failureException = new IOException("Mock failure!");
+    failureException = new MockRetrofitIOException();
     failureException.setStackTrace(new StackTraceElement[0]);
   }
 

--- a/retrofit-mock/src/test/java/retrofit2/mock/NetworkBehaviorTest.java
+++ b/retrofit-mock/src/test/java/retrofit2/mock/NetworkBehaviorTest.java
@@ -33,7 +33,8 @@ public final class NetworkBehaviorTest {
 
   @Test public void defaultThrowable() {
     Throwable t = behavior.failureException();
-    assertThat(t).isExactlyInstanceOf(IOException.class).hasMessage("Mock failure!");
+    assertThat(t).isInstanceOf(IOException.class)
+        .isExactlyInstanceOf(MockRetrofitIOException.class);
     assertThat(t.getStackTrace()).isEmpty();
   }
 


### PR DESCRIPTION
Since we omit the stack trace, this more clearly indicates the source being from Retrofit's mock behavior.

Closes #2325.