### PR TITLE
Upgrade to OkHttp 3.8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
     <!-- Dependencies -->
     <android.version>4.1.1.4</android.version>
-    <okhttp.version>3.6.0</okhttp.version>
+    <okhttp.version>3.8.0</okhttp.version>
     <animal.sniffer.version>1.14</animal.sniffer.version>
 
     <!-- Adapter Dependencies -->

--- a/retrofit/src/main/java/retrofit2/Response.java
+++ b/retrofit/src/main/java/retrofit2/Response.java
@@ -70,6 +70,7 @@ public final class Response<T> {
     if (code < 400) throw new IllegalArgumentException("code < 400: " + code);
     return error(body, new okhttp3.Response.Builder() //
         .code(code)
+        .message("Response.error()")
         .protocol(Protocol.HTTP_1_1)
         .request(new Request.Builder().url("http://localhost/").build())
         .build());

--- a/retrofit/src/test/java/retrofit2/ResponseTest.java
+++ b/retrofit/src/test/java/retrofit2/ResponseTest.java
@@ -112,7 +112,7 @@ public final class ResponseTest {
     Response<?> response = Response.error(400, errorBody);
     assertThat(response.raw()).isNotNull();
     assertThat(response.code()).isEqualTo(400);
-    assertThat(response.message()).isNull();
+    assertThat(response.message()).isEqualTo("Response.error()");
     assertThat(response.headers().size()).isZero();
     assertThat(response.isSuccessful()).isFalse();
     assertThat(response.body()).isNull();


### PR DESCRIPTION
Quite disappointingly OkHttp 3.8's new requirement for a non-null message
ends up breaking Retrofit. Good excuse to get this release out at the
same time.