### PR TITLE
Add SimpleJSON body support

### DIFF
--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -360,4 +360,23 @@ abstract class ParameterHandler<T> {
       builder.setBody(body);
     }
   }
+
+  static final class SimpleJSONField<T> extends ParameterHandler<T> {
+    private final String name;
+    private final Converter<T, String> valueConverter;
+
+    SimpleJSONField(String name, Converter<T, String> valueConverter) {
+      this.name = checkNotNull(name, "name == null");
+      this.valueConverter = valueConverter;
+    }
+
+    @Override void apply(RequestBuilder builder, @Nullable T value) throws IOException {
+      if (value == null) return; // Skip null values.
+
+      String strValue = valueConverter.convert(value);
+      if (strValue == null) return; // Skip converted but null values
+
+      builder.addJSONField(name, strValue);
+    }
+  }
 }

--- a/retrofit/src/main/java/retrofit2/Utils.java
+++ b/retrofit/src/main/java/retrofit2/Utils.java
@@ -25,7 +25,9 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import javax.annotation.Nullable;
 import okhttp3.ResponseBody;
 import okio.Buffer;
@@ -493,5 +495,49 @@ final class Utils {
       if (upperBound == Object.class) return "?";
       return "? extends " + typeToString(upperBound);
     }
+  }
+
+  /**
+   * convert Map to JSON string
+   */
+  public static String toJSONString(Map<String, Object> map) {
+    if (null == map || map.isEmpty()) {
+      return "{}";
+    }
+
+    StringBuilder jsonStringBuilder = new StringBuilder("{");
+
+    Set<String> keys = map.keySet();
+
+    for (String key : keys) {
+      if ("".equals(key) || null == key) {
+        continue;
+      }
+
+      Object value = map.get(key);
+      if (null == value) {
+        continue;
+      }
+
+      jsonStringBuilder.append("\"").append(key).append("\":");
+
+      Class clazz = value.getClass();
+      if (clazz == Integer.class
+              || clazz == Float.class
+              || clazz == Double.class
+              || clazz == Long.class
+              || clazz == Short.class
+              || clazz == Boolean.class) {
+        jsonStringBuilder.append(value).append(",");
+      } else {
+        jsonStringBuilder.append("\"").append(value).append("\"").append(",");
+      }
+    }
+    String result = jsonStringBuilder.toString();
+    if (result.endsWith(",")) {
+      result = result.substring(0, result.length() - 1);
+    }
+    result += "}";
+    return result;
   }
 }

--- a/retrofit/src/main/java/retrofit2/http/SimpleJSON.java
+++ b/retrofit/src/main/java/retrofit2/http/SimpleJSON.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.http;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Denotes that the request body is SimpleJSON.
+ * SimpleJSON is like {'gender':'M'}、{'username':'github', 'password':'123456'},
+ * only has raw type fields.
+ * Fileds should be declared as parameters and annotated with
+ * {@link SimpleJSONField @SimpleJSONField}.
+ */
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface SimpleJSON {
+}

--- a/retrofit/src/main/java/retrofit2/http/SimpleJSONField.java
+++ b/retrofit/src/main/java/retrofit2/http/SimpleJSONField.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.http;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.Type;
+import retrofit2.Retrofit;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Named pair for a SimpleJSON request.
+ * <p>
+ * Values are converted to strings using {@link Retrofit#stringConverter(Type, Annotation[])}
+ * (or {@link Object#toString()}, if no matching string converter is installed)
+ * and then form URL encoded.
+ * {@code null} values are ignored. value's type can only be raw type.
+ * <p>
+ * Simple Example:
+ * <pre><code>
+ * &#64;SimpleJSON
+ * &#64;POST("/login")
+ * Call&lt;ResponseBody&gt; login(
+ *     &#64;SimpleJSONField("username") String username,
+ *     &#64;SimpleJSONField("password") String password);
+ * </code></pre>
+ * Calling with {@code foo.example("Bob Smith", "President")} yields a request body of
+ * {@code {'password':'Bob Smith','password':'President'}}.
+ * <p>
+ *
+ * @see SimpleJSON
+ */
+@Documented
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface SimpleJSONField {
+    /** The SimpleJSON filed name. */
+    String value();
+}

--- a/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestBuilderTest.java
@@ -37,29 +37,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import retrofit2.helpers.NullObjectConverterFactory;
 import retrofit2.helpers.ToStringConverterFactory;
-import retrofit2.http.Body;
-import retrofit2.http.DELETE;
-import retrofit2.http.Field;
-import retrofit2.http.FieldMap;
-import retrofit2.http.FormUrlEncoded;
-import retrofit2.http.GET;
-import retrofit2.http.HEAD;
-import retrofit2.http.HTTP;
-import retrofit2.http.Header;
-import retrofit2.http.HeaderMap;
-import retrofit2.http.Headers;
-import retrofit2.http.Multipart;
-import retrofit2.http.OPTIONS;
-import retrofit2.http.PATCH;
-import retrofit2.http.POST;
-import retrofit2.http.PUT;
-import retrofit2.http.Part;
-import retrofit2.http.PartMap;
-import retrofit2.http.Path;
-import retrofit2.http.Query;
-import retrofit2.http.QueryMap;
-import retrofit2.http.QueryName;
-import retrofit2.http.Url;
+import retrofit2.http.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
@@ -132,6 +110,24 @@ public final class RequestBuilderTest {
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage(
           "Only one encoding annotation is allowed.\n    for method Example.method");
+    }
+  }
+
+  @Test public void onlyOneEncodingIsAllowedSimpleJSONFirst() {
+    class Example {
+      @SimpleJSON //
+      @Multipart //
+      @POST("/") //
+      Call<ResponseBody> method() {
+        return null;
+      }
+    }
+    try {
+      buildRequest(Example.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(
+              "Only one encoding annotation is allowed.\n    for method Example.method");
     }
   }
 
@@ -677,7 +673,7 @@ public final class RequestBuilderTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage(
-          "@Body parameters cannot be used with form or multi-part encoding. (parameter #2)\n    for method Example.method");
+          "@Body parameters cannot be used with form or SimpleJSON or multi-part encoding. (parameter #2)\n    for method Example.method");
     }
   }
 

--- a/retrofit/src/test/java/retrofit2/UtilsTest.java
+++ b/retrofit/src/test/java/retrofit2/UtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class UtilsTest {
+
+    @Test
+    public void toJSONString1() throws Exception {
+        String json = Utils.toJSONString(null);
+        Assert.assertEquals("{}", json);
+    }
+
+    @Test
+    public void toJSONString2() throws Exception {
+        HashMap<String, Object> map = new HashMap<String, Object>();
+        String json = Utils.toJSONString(map);
+        Assert.assertEquals("{}", json);
+    }
+
+    @Test
+    public void toJSONString3() throws Exception {
+        HashMap<String, Object> map = new HashMap<String, Object>();
+        map.put("1", 1);
+        map.put("2", null);
+        map.put("3", 2.0f);
+        map.put("4", 2L);
+        map.put("5", "5");
+        map.put("5", true);
+
+        String json = Utils.toJSONString(map);
+        Assert.assertEquals("{\"1\":1,\"3\":2.0,\"4\":2,\"5\":true}", json);
+    }
+
+    @Test
+    public void toJSONString4() throws Exception {
+        HashMap<String, Object> map = new HashMap<String, Object>();
+        map.put("1", 1);
+        map.put("2", 2.0);
+        map.put(null, 2.0f);
+        map.put("4", 2L);
+        map.put("5", "5");
+        map.put("5", true);
+
+        String json = Utils.toJSONString(map);
+        Assert.assertEquals("{\"1\":1,\"2\":2.0,\"4\":2,\"5\":true}", json);
+    }
+
+
+    @Test
+    public void toJSONString5() throws Exception {
+        HashMap<String, Object> map = new HashMap<String, Object>();
+        map.put("1", 1);
+        map.put("2", 2.0);
+        map.put("3", 2.0f);
+        map.put("4", 2L);
+        map.put("5", "5");
+        map.put("5", true);
+
+        String json = Utils.toJSONString(map);
+        Assert.assertEquals("{\"1\":1,\"2\":2.0,\"3\":2.0,\"4\":2,\"5\":true}", json);
+    }
+}


### PR DESCRIPTION
We always Post some simple JSON to server,  simple JSON means its fields only has raw type, for example {'age':18}、 {'username':'xxxx', 'password':'yyyyy'}. If we use @Body annotation, we need New a Java class，it seems not simple, you might suggest me to design my API with Restful API, but some old programmers not like Restful API，they only use POST method. so, I add this support.

the usage as follow:
-----------------------------------------------------
public interface HttpAPI {
        @POST("/user-login")
        @SimpleJSON
        Observable<ResponseEntity> changeHeight(@SimpleJSONField("username") String username, @SimpleJSONField("password") String password);
}
-----------------------------------------------------
the usage is similar to @FormUrlEncoded and @Field
-----------------------------------------------------
HTTP Request like as follows:
-----------------------------------------------------
POST /user-change-gender HTTP/1.1
Host: http://192.168.1.100
Content-Type: application/json;charset=UTF-8
Content-Length: 16
{'username':'fpliu','password':'SHA256--------'}
-----------------------------------------------------
add this support, we don't need to new a class，if we have a large number of similar HTTP interfaces，it will save us much time.
