### PR TITLE
Create ResponseObservable

### DIFF
--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/ResponseObservable.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/ResponseObservable.java
@@ -1,0 +1,72 @@
+package retrofit2.adapter.rxjava2;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.plugins.RxJavaPlugins;
+import retrofit2.Response;
+
+
+/**
+ * Created by jspiner on 2017. 7. 12..
+ */
+public class ResponseObservable<T> extends Observable<T> {
+    private final Observable<Response<T>> upstream;
+
+    ResponseObservable(Observable<Response<T>> upstream) {
+        this.upstream = upstream;
+    }
+
+    @Override protected void subscribeActual(Observer<? super T> observer) {
+        upstream.subscribe(new ResponseObservable.BodyObserver<T>(observer));
+    }
+
+    private static class BodyObserver<R> implements Observer<Response<R>> {
+        private final Observer<? super R> observer;
+        private boolean terminated;
+
+        BodyObserver(Observer<? super R> observer) {
+            this.observer = observer;
+        }
+
+        @Override public void onSubscribe(Disposable disposable) {
+            observer.onSubscribe(disposable);
+        }
+
+        @Override public void onNext(Response<R> response) {
+            if (response.isSuccessful()) {
+                observer.onNext(response.body());
+            } else {
+                terminated = true;
+                Throwable t = new HttpException(response);
+                try {
+                    observer.onError(t);
+                } catch (Throwable inner) {
+                    Exceptions.throwIfFatal(inner);
+                    RxJavaPlugins.onError(new CompositeException(t, inner));
+                }
+            }
+        }
+
+        @Override public void onComplete() {
+            if (!terminated) {
+                observer.onComplete();
+            }
+        }
+
+        @Override public void onError(Throwable throwable) {
+            if (!terminated) {
+                observer.onError(throwable);
+            } else {
+                // This should never happen! onNext handles and forwards errors automatically.
+                Throwable broken = new AssertionError(
+                        "This should never happen! Report as a bug with the full stacktrace.");
+                //noinspection UnnecessaryInitCause Two-arg AssertionError constructor is 1.7+ only.
+                broken.initCause(throwable);
+                RxJavaPlugins.onError(broken);
+            }
+        }
+    }
+}

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/ResponseObservable.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/ResponseObservable.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package retrofit2.adapter.rxjava2;
 
 import io.reactivex.Observable;
@@ -12,44 +27,43 @@ import retrofit2.Response;
 /**
  * @author JSpiner (jspiner@naver.com)
  */
-public class ResponseObservable<T> extends Observable<Response<T>> {
-    private final Observable<Response<T>> upstream;
+final class ResponseObservable<T> extends Observable<Response<T>> {
+  private final Observable<Response<T>> upstream;
+  ResponseObservable(Observable<Response<T>> upstream) {
+    this.upstream = upstream;
+  }
 
-    ResponseObservable(Observable<Response<T>> upstream) {
-        this.upstream = upstream;
+  @Override protected void subscribeActual(Observer<? super Response<T>> observer) {
+    upstream.subscribe(new ResponseObservable.ResponseObserver<T>(observer));
+  }
+
+  private static class ResponseObserver<R> implements Observer<Response<R>> {
+    private final Observer<? super Response<R>> observer;
+
+    ResponseObserver(Observer<? super Response<R>> observer) {
+      this.observer = observer;
     }
 
-    @Override protected void subscribeActual(Observer<? super Response<T>> observer) {
-        upstream.subscribe(new ResponseObservable.ResponseObserver<T>(observer));
+    @Override public void onSubscribe(Disposable disposable) {
+      observer.onSubscribe(disposable);
     }
 
-    private static class ResponseObserver<R> implements Observer<Response<R>> {
-        private final Observer<? super Response<R>> observer;
-
-        ResponseObserver(Observer<? super Response<R>> observer) {
-            this.observer = observer;
-        }
-
-        @Override public void onSubscribe(Disposable disposable) {
-            observer.onSubscribe(disposable);
-        }
-
-        @Override public void onNext(Response<R> response) {
-            observer.onNext(response);
-        }
-
-        @Override public void onComplete() {
-            observer.onComplete();
-        }
-
-        @Override public void onError(Throwable throwable) {
-            try {
-                observer.onError(throwable);
-            } catch (Throwable inner) {
-                Exceptions.throwIfFatal(inner);
-                RxJavaPlugins.onError(new CompositeException(throwable, inner));
-            }
-            return;
-        }
+    @Override public void onNext(Response<R> response) {
+      observer.onNext(response);
     }
+
+    @Override public void onComplete() {
+      observer.onComplete();
+    }
+
+    @Override public void onError(Throwable throwable) {
+      try {
+        observer.onError(throwable);
+      } catch (Throwable inner) {
+        Exceptions.throwIfFatal(inner);
+        RxJavaPlugins.onError(new CompositeException(throwable, inner));
+      }
+      return;
+    }
+  }
 }

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/ResponseObservable.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/ResponseObservable.java
@@ -10,24 +10,24 @@ import retrofit2.Response;
 
 
 /**
- * Created by jspiner on 2017. 7. 12..
+ * @author JSpiner (jspiner@naver.com)
  */
-public class ResponseObservable<T> extends Observable<T> {
+public class ResponseObservable<T> extends Observable<Response<T>> {
     private final Observable<Response<T>> upstream;
 
     ResponseObservable(Observable<Response<T>> upstream) {
         this.upstream = upstream;
     }
 
-    @Override protected void subscribeActual(Observer<? super T> observer) {
-        upstream.subscribe(new ResponseObservable.BodyObserver<T>(observer));
+    @Override protected void subscribeActual(Observer<? super Response<T>> observer) {
+        upstream.subscribe(new ResponseObservable.ResponseObserver<T>(observer));
     }
 
-    private static class BodyObserver<R> implements Observer<Response<R>> {
-        private final Observer<? super R> observer;
+    private static class ResponseObserver<R> implements Observer<Response<R>> {
+        private final Observer<? super Response<R>> observer;
         private boolean terminated;
 
-        BodyObserver(Observer<? super R> observer) {
+        ResponseObserver(Observer<? super Response<R>> observer) {
             this.observer = observer;
         }
 
@@ -37,7 +37,7 @@ public class ResponseObservable<T> extends Observable<T> {
 
         @Override public void onNext(Response<R> response) {
             if (response.isSuccessful()) {
-                observer.onNext(response.body());
+                observer.onNext(response);
             } else {
                 terminated = true;
                 Throwable t = new HttpException(response);

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
@@ -37,8 +37,8 @@ final class RxJava2CallAdapter<R> implements CallAdapter<R, Object> {
   private final boolean isCompletable;
 
   RxJava2CallAdapter(Type responseType, @Nullable Scheduler scheduler, boolean isAsync,
-      boolean isResponseObservable, boolean isResult, boolean isBody, boolean isFlowable, boolean isSingle, boolean isMaybe,
-      boolean isCompletable) {
+      boolean isResponseObservable, boolean isResult, boolean isBody, boolean isFlowable,
+      boolean isSingle, boolean isMaybe, boolean isCompletable) {
     this.responseType = responseType;
     this.scheduler = scheduler;
     this.isAsync = isAsync;
@@ -61,10 +61,9 @@ final class RxJava2CallAdapter<R> implements CallAdapter<R, Object> {
         : new CallExecuteObservable<>(call);
 
     Observable<?> observable;
-    if (isResponseObservable){
+    if (isResponseObservable) {
       observable = new ResponseObservable<>(responseObservable);
-    }
-    else if (isResult) {
+    } else if (isResult) {
       observable = new ResultObservable<>(responseObservable);
     } else if (isBody) {
       observable = new BodyObservable<>(responseObservable);

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
@@ -28,6 +28,7 @@ final class RxJava2CallAdapter<R> implements CallAdapter<R, Object> {
   private final Type responseType;
   private final @Nullable Scheduler scheduler;
   private final boolean isAsync;
+  private final boolean isResponseObservable;
   private final boolean isResult;
   private final boolean isBody;
   private final boolean isFlowable;
@@ -36,11 +37,12 @@ final class RxJava2CallAdapter<R> implements CallAdapter<R, Object> {
   private final boolean isCompletable;
 
   RxJava2CallAdapter(Type responseType, @Nullable Scheduler scheduler, boolean isAsync,
-      boolean isResult, boolean isBody, boolean isFlowable, boolean isSingle, boolean isMaybe,
+      boolean isResponseObservable, boolean isResult, boolean isBody, boolean isFlowable, boolean isSingle, boolean isMaybe,
       boolean isCompletable) {
     this.responseType = responseType;
     this.scheduler = scheduler;
     this.isAsync = isAsync;
+    this.isResponseObservable = isResponseObservable;
     this.isResult = isResult;
     this.isBody = isBody;
     this.isFlowable = isFlowable;
@@ -59,7 +61,10 @@ final class RxJava2CallAdapter<R> implements CallAdapter<R, Object> {
         : new CallExecuteObservable<>(call);
 
     Observable<?> observable;
-    if (isResult) {
+    if (isResponseObservable){
+      observable = new ResponseObservable<>(responseObservable);
+    }
+    else if (isResult) {
       observable = new ResultObservable<>(responseObservable);
     } else if (isBody) {
       observable = new BodyObservable<>(responseObservable);

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
@@ -97,15 +97,16 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
     if (rawType == Completable.class) {
       // Completable is not parameterized (which is what the rest of this method deals with) so it
       // can only be created with a single configuration.
-      return new RxJava2CallAdapter(Void.class, scheduler, isAsync, false, false, true, false, false,
-          false, true);
+      return new RxJava2CallAdapter(Void.class, scheduler, isAsync, false, false, true,
+          false, false, false, true);
     }
 
     boolean isFlowable = rawType == Flowable.class;
     boolean isSingle = rawType == Single.class;
     boolean isMaybe = rawType == Maybe.class;
     boolean isResponseObservable = rawType == ResponseObservable.class;
-    if (rawType != Observable.class && !isResponseObservable && !isFlowable && !isSingle && !isMaybe) {
+    if (rawType != Observable.class && !isResponseObservable && !isFlowable && !isSingle
+            && !isMaybe) {
       return null;
     }
 
@@ -140,7 +141,7 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
       isBody = true;
     }
 
-    return new RxJava2CallAdapter(responseType, scheduler, isAsync, isResponseObservable, isResult, isBody, isFlowable,
-        isSingle, isMaybe, false);
+    return new RxJava2CallAdapter(responseType, scheduler, isAsync, isResponseObservable, isResult,
+        isBody, isFlowable, isSingle, isMaybe, false);
   }
 }

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
@@ -97,14 +97,15 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
     if (rawType == Completable.class) {
       // Completable is not parameterized (which is what the rest of this method deals with) so it
       // can only be created with a single configuration.
-      return new RxJava2CallAdapter(Void.class, scheduler, isAsync, false, true, false, false,
+      return new RxJava2CallAdapter(Void.class, scheduler, isAsync, false, false, true, false, false,
           false, true);
     }
 
     boolean isFlowable = rawType == Flowable.class;
     boolean isSingle = rawType == Single.class;
     boolean isMaybe = rawType == Maybe.class;
-    if (rawType != Observable.class && !isFlowable && !isSingle && !isMaybe) {
+    boolean isResponseObservable = rawType == ResponseObservable.class;
+    if (rawType != Observable.class && !isResponseObservable && !isFlowable && !isSingle && !isMaybe) {
       return null;
     }
 
@@ -139,7 +140,7 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
       isBody = true;
     }
 
-    return new RxJava2CallAdapter(responseType, scheduler, isAsync, isResult, isBody, isFlowable,
+    return new RxJava2CallAdapter(responseType, scheduler, isAsync, isResponseObservable, isResult, isBody, isFlowable,
         isSingle, isMaybe, false);
   }
 }

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableTest.java
@@ -17,6 +17,7 @@ package retrofit2.adapter.rxjava2;
 
 import io.reactivex.Observable;
 import java.io.IOException;
+
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Before;
@@ -36,6 +37,7 @@ public final class ObservableTest {
   interface Service {
     @GET("/") Observable<String> body();
     @GET("/") Observable<Response<String>> response();
+    @GET("/") ResponseObservable<String> response2();
     @GET("/") Observable<Result<String>> result();
   }
 
@@ -51,6 +53,15 @@ public final class ObservableTest {
   }
 
   @Test public void bodySuccess200() {
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    RecordingObserver<String> observer = observerRule.create();
+    service.body().subscribe(observer);
+    observer.assertValue("Hi").assertComplete();
+  }
+
+
+  @Test public void rxBodySuccess200() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
     RecordingObserver<String> observer = observerRule.create();

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableTest.java
@@ -37,7 +37,6 @@ public final class ObservableTest {
   interface Service {
     @GET("/") Observable<String> body();
     @GET("/") Observable<Response<String>> response();
-    @GET("/") ResponseObservable<String> response2();
     @GET("/") Observable<Result<String>> result();
   }
 
@@ -53,15 +52,6 @@ public final class ObservableTest {
   }
 
   @Test public void bodySuccess200() {
-    server.enqueue(new MockResponse().setBody("Hi"));
-
-    RecordingObserver<String> observer = observerRule.create();
-    service.body().subscribe(observer);
-    observer.assertValue("Hi").assertComplete();
-  }
-
-
-  @Test public void rxBodySuccess200() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
     RecordingObserver<String> observer = observerRule.create();


### PR DESCRIPTION
Until now, to use rxjava-retrofit-adapter to get status code or response information, we had to mapping object twice. like `Observable<Response<ItemModel>>`.
Status codes are always needed in most api. So we define `Response` again and again...
But this makes the source code hard to see. Nobody wants it.

So I created a class `ResponseObservable`. Its `ResponseObservable.ResponseObserver` allows you to subscribe to a Response object. Like below.

```java
//before you know ResponseObservable
  interface Service {
    ...
    // Observable<Response<List<blahblah>> is too complicated...
    @GET("/api1") Observable<Response<String>> getRepository();
    @GET("/api2") Observable<Response<ItemModel>> getRepository2();
    @GET("/api3") Observable<Response<List<ItemModel>>> getRepository3();
    ...
  }
  
  void request(){
    service.getRepository().subscribe(new Observer<Response<String>>() {
      ...
      @Override
      public void onNext(Response<String> response) {
        int code = response.code();
        ...
      }
      ...
    });
  }

```

```java
//after you know ResponseObservable
  interface Service {
    ...
    // No need to be complicated anymore. Nice!
    @GET("/api1") ResponseObservable<String> getRepository();
    @GET("/api2") ResponseObservable<ItemModel> getRepository2();
    @GET("/api3") ResponseObservable<List<ItemModel>> getRepository3();
    ...
  }
  
  // same usage
  void request(){
    service.getRepository().subscribe(new Observer<Response<String>>() {
      ...
      @Override
      public void onNext(Response<String> response) {
        int code = response.code();
        ...
      }
      ...
    });
  }
```

This is my first pull request, so there might be a mistake. Let me know and I'll fix it. Thank you.