### PR TITLE
Update to Gson 2.8.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <guava.version>19.0</guava.version>
 
     <!-- Converter Dependencies -->
-    <gson.version>2.7</gson.version>
+    <gson.version>2.8.0</gson.version>
     <protobuf.version>3.0.0</protobuf.version>
     <jackson.version>2.7.2</jackson.version>
     <wire.version>2.2.0</wire.version>


### PR DESCRIPTION
2.8.1 is the latest, but it has an [explosive bug](https://github.com/google/gson/pull/1100).