### PR TITLE
Use "." as default String parameter for all HTTP method annotations.

### DIFF
--- a/retrofit/src/main/java/retrofit2/http/DELETE.java
+++ b/retrofit/src/main/java/retrofit2/http/DELETE.java
@@ -35,5 +35,5 @@ public @interface DELETE {
    * See {@linkplain retrofit2.Retrofit.Builder#baseUrl(HttpUrl) base URL} for details of how
    * this is resolved against a base URL to create the full endpoint URL.
    */
-  String value() default "";
+  String value() default ".";
 }

--- a/retrofit/src/main/java/retrofit2/http/GET.java
+++ b/retrofit/src/main/java/retrofit2/http/GET.java
@@ -35,5 +35,5 @@ public @interface GET {
    * See {@linkplain retrofit2.Retrofit.Builder#baseUrl(HttpUrl) base URL} for details of how
    * this is resolved against a base URL to create the full endpoint URL.
    */
-  String value() default "";
+  String value() default ".";
 }

--- a/retrofit/src/main/java/retrofit2/http/HEAD.java
+++ b/retrofit/src/main/java/retrofit2/http/HEAD.java
@@ -35,5 +35,5 @@ public @interface HEAD {
    * See {@linkplain retrofit2.Retrofit.Builder#baseUrl(HttpUrl) base URL} for details of how
    * this is resolved against a base URL to create the full endpoint URL.
    */
-  String value() default "";
+  String value() default ".";
 }

--- a/retrofit/src/main/java/retrofit2/http/HTTP.java
+++ b/retrofit/src/main/java/retrofit2/http/HTTP.java
@@ -51,6 +51,6 @@ public @interface HTTP {
    * See {@linkplain retrofit2.Retrofit.Builder#baseUrl(HttpUrl) base URL} for details of how
    * this is resolved against a base URL to create the full endpoint URL.
    */
-  String path() default "";
+  String path() default ".";
   boolean hasBody() default false;
 }

--- a/retrofit/src/main/java/retrofit2/http/OPTIONS.java
+++ b/retrofit/src/main/java/retrofit2/http/OPTIONS.java
@@ -35,5 +35,5 @@ public @interface OPTIONS {
    * See {@linkplain retrofit2.Retrofit.Builder#baseUrl(HttpUrl) base URL} for details of how
    * this is resolved against a base URL to create the full endpoint URL.
    */
-  String value() default "";
+  String value() default ".";
 }

--- a/retrofit/src/main/java/retrofit2/http/PATCH.java
+++ b/retrofit/src/main/java/retrofit2/http/PATCH.java
@@ -35,5 +35,5 @@ public @interface PATCH {
    * See {@linkplain retrofit2.Retrofit.Builder#baseUrl(HttpUrl) base URL} for details of how
    * this is resolved against a base URL to create the full endpoint URL.
    */
-  String value() default "";
+  String value() default ".";
 }

--- a/retrofit/src/main/java/retrofit2/http/POST.java
+++ b/retrofit/src/main/java/retrofit2/http/POST.java
@@ -35,5 +35,5 @@ public @interface POST {
    * See {@linkplain retrofit2.Retrofit.Builder#baseUrl(HttpUrl) base URL} for details of how
    * this is resolved against a base URL to create the full endpoint URL.
    */
-  String value() default "";
+  String value() default ".";
 }

--- a/retrofit/src/main/java/retrofit2/http/PUT.java
+++ b/retrofit/src/main/java/retrofit2/http/PUT.java
@@ -35,5 +35,5 @@ public @interface PUT {
    * See {@linkplain retrofit2.Retrofit.Builder#baseUrl(HttpUrl) base URL} for details of how
    * this is resolved against a base URL to create the full endpoint URL.
    */
-  String value() default "";
+  String value() default ".";
 }


### PR DESCRIPTION
This will make using `@GET` (or similar) without `@Url` possible and will call the base url.
N.B. Calling the base URL without any further path paremeters is still generally not a good idea, but at least now it won't crash at runtime.