### PR TITLE
provide more flexibility

### DIFF
--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
@@ -104,7 +104,7 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
     boolean isFlowable = rawType == Flowable.class;
     boolean isSingle = rawType == Single.class;
     boolean isMaybe = rawType == Maybe.class;
-    if (rawType != Observable.class && !isFlowable && !isSingle && !isMaybe) {
+    if (Observable.class.isAssignableFrom(rawType) && !isFlowable && !isSingle && !isMaybe) {
       return null;
     }
 

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
@@ -104,7 +104,7 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
     boolean isFlowable = rawType == Flowable.class;
     boolean isSingle = rawType == Single.class;
     boolean isMaybe = rawType == Maybe.class;
-    if (Observable.class.isAssignableFrom(rawType) && !isFlowable && !isSingle && !isMaybe) {
+    if (!Observable.class.isAssignableFrom(rawType) && !isFlowable && !isSingle && !isMaybe) {
       return null;
     }
 


### PR DESCRIPTION
Allow developers to do something with the Observable. Like this:

```
public abstract class HttpObservable<T> extends Observable<T> {

    public final void smartSubscribe(Observer<T> observer)
    {
        subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread()).subscribe(observer);
    }

}
```
