### PR TITLE
Add Retrofit.Builder.converterFactories().

### DIFF
--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -582,11 +582,12 @@ public final class Retrofit {
       adapterFactories.add(platform.defaultCallAdapterFactory(callbackExecutor));
 
       // Make a defensive copy of the converters.
-      List<Converter.Factory> converterFactories = new ArrayList<>(this.converterFactories);
+      List<Converter.Factory> converterFactories = new ArrayList<>();
 
       // Add the built-in converter factory first. This prevents overriding its behavior but also
       // ensures correct behavior when using converters that consume all types.
-      converterFactories.add(0, new BuiltInConverters());
+      converterFactories.add(new BuiltInConverters());
+      converterFactories.addAll(this.converterFactories);
 
       return new Retrofit(callFactory, baseUrl, converterFactories, adapterFactories,
           callbackExecutor, validateEagerly);

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -242,7 +242,7 @@ public final class Retrofit {
   }
 
   /**
-   * Returns a list of the factories tried when creating a
+   * Returns an unmodifiable list of the factories tried when creating a
    * {@linkplain #requestBodyConverter(Type, Annotation[], Annotation[]) request body converter}, a
    * {@linkplain #responseBodyConverter(Type, Annotation[]) response body converter}, or a
    * {@linkplain #stringConverter(Type, Annotation[]) string converter}.
@@ -402,9 +402,6 @@ public final class Retrofit {
 
     Builder(Platform platform) {
       this.platform = platform;
-      // Add the built-in converter factory first. This prevents overriding its behavior but also
-      // ensures correct behavior when using converters that consume all types.
-      converterFactories.add(new BuiltInConverters());
     }
 
     public Builder() {
@@ -416,6 +413,8 @@ public final class Retrofit {
       callFactory = retrofit.callFactory;
       baseUrl = retrofit.baseUrl;
       converterFactories.addAll(retrofit.converterFactories);
+      // BuiltInConverters instance added by build().
+      converterFactories.remove(0);
       adapterFactories.addAll(retrofit.adapterFactories);
       // Remove the default, platform-aware call adapter added by build().
       adapterFactories.remove(adapterFactories.size() - 1);
@@ -543,6 +542,11 @@ public final class Retrofit {
       return this;
     }
 
+    /** Returns a modifiable list of converter factories. */
+    public List<Converter.Factory> converterFactories() {
+      return this.converterFactories;
+    }
+
     /**
      * When calling {@link #create} on the resulting {@link Retrofit} instance, eagerly validate
      * the configuration of all methods in the supplied interface.
@@ -579,6 +583,10 @@ public final class Retrofit {
 
       // Make a defensive copy of the converters.
       List<Converter.Factory> converterFactories = new ArrayList<>(this.converterFactories);
+
+      // Add the built-in converter factory first. This prevents overriding its behavior but also
+      // ensures correct behavior when using converters that consume all types.
+      converterFactories.add(0, new BuiltInConverters());
 
       return new Retrofit(callFactory, baseUrl, converterFactories, adapterFactories,
           callbackExecutor, validateEagerly);

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -180,19 +180,6 @@ public final class RetrofitTest {
     assertEquals(0, retrofit.newBuilder().converterFactories().size());
   }
 
-  @Test public void builtInConvertersRemainFirstInClone() {
-    Retrofit one = new Retrofit.Builder()
-        .baseUrl(server.url("/"))
-        .addConverterFactory(mock(Converter.Factory.class))
-        .build();
-    Retrofit two = one.newBuilder()
-        .addConverterFactory(mock(Converter.Factory.class))
-        .build();
-
-    assertEquals(one.converterFactories().size() + 1, two.converterFactories().size());
-    assertTrue(two.converterFactories().get(0) instanceof BuiltInConverters);
-  }
-
   @Test public void responseTypeCannotBeRetrofitResponse() {
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl(server.url("/"))

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -176,8 +176,7 @@ public final class RetrofitTest {
         .baseUrl(server.url("/"))
         .build();
 
-    assertEquals(retrofit.converterFactories().size() - 1,
-        retrofit.newBuilder().converterFactories().size());
+    assertEquals(0, retrofit.newBuilder().converterFactories().size());
   }
 
   @Test public void builtInConvertersAddedOnBuild() {

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -171,6 +171,37 @@ public final class RetrofitTest {
     assertSame(callFactory, two.callFactory());
   }
 
+  @Test public void builtInConvertersAbsentInCloneBuilder() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .build();
+
+    assertEquals(retrofit.converterFactories().size() - 1,
+        retrofit.newBuilder().converterFactories().size());
+  }
+
+  @Test public void builtInConvertersAddedOnBuild() {
+    Retrofit.Builder builder = new Retrofit.Builder();
+    Retrofit retrofit = builder
+        .baseUrl(server.url("/"))
+        .build();
+
+    assertEquals(builder.converterFactories().size() + 1, retrofit.converterFactories().size());
+  }
+
+  @Test public void builtInConvertersRemainFirstInClone() {
+    Retrofit one = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(mock(Converter.Factory.class))
+        .build();
+    Retrofit two = one.newBuilder()
+        .addConverterFactory(mock(Converter.Factory.class))
+        .build();
+
+    assertEquals(one.converterFactories().size() + 1, two.converterFactories().size());
+    assertTrue(two.converterFactories().get(0) instanceof BuiltInConverters);
+  }
+
   @Test public void responseTypeCannotBeRetrofitResponse() {
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl(server.url("/"))

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -848,7 +848,7 @@ public final class RetrofitTest {
     assertThat(converterFactories.get(0)).isInstanceOf(BuiltInConverters.class);
   }
 
-  @Test public void builtInConvertersAddedOnBuild() {
+  @Test public void builtInConvertersFirstInClone() {
     Converter<ResponseBody, Void> converter = mock(Converter.class);
     Converter.Factory factory = mock(Converter.Factory.class);
     Annotation[] annotations = new Annotation[0];
@@ -860,7 +860,7 @@ public final class RetrofitTest {
 
     doReturn(converter).when(factory).responseBodyConverter(Void.class, annotations, retrofit);
 
-    retrofit.responseBodyConverter(Void.class, annotations);
+    retrofit.newBuilder().build().responseBodyConverter(Void.class, annotations);
 
     verifyZeroInteractions(factory);
   }

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -63,6 +63,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public final class RetrofitTest {
   @Rule public final MockWebServer server = new MockWebServer();
@@ -858,6 +859,23 @@ public final class RetrofitTest {
     List<Converter.Factory> converterFactories = retrofit.converterFactories();
     assertThat(converterFactories).hasSize(1);
     assertThat(converterFactories.get(0)).isInstanceOf(BuiltInConverters.class);
+  }
+
+  @Test public void builtInConvertersAddedOnBuild() {
+    Converter<ResponseBody, Void> converter = mock(Converter.class);
+    Converter.Factory factory = mock(Converter.Factory.class);
+    Annotation[] annotations = new Annotation[0];
+
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl("http://example.com/")
+        .addConverterFactory(factory)
+        .build();
+
+    doReturn(converter).when(factory).responseBodyConverter(Void.class, annotations, retrofit);
+
+    retrofit.responseBodyConverter(Void.class, annotations);
+
+    verifyZeroInteractions(factory);
   }
 
   @Test public void requestConverterFactoryQueried() {

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -179,15 +179,6 @@ public final class RetrofitTest {
     assertEquals(0, retrofit.newBuilder().converterFactories().size());
   }
 
-  @Test public void builtInConvertersAddedOnBuild() {
-    Retrofit.Builder builder = new Retrofit.Builder();
-    Retrofit retrofit = builder
-        .baseUrl(server.url("/"))
-        .build();
-
-    assertEquals(builder.converterFactories().size() + 1, retrofit.converterFactories().size());
-  }
-
   @Test public void builtInConvertersRemainFirstInClone() {
     Retrofit one = new Retrofit.Builder()
         .baseUrl(server.url("/"))


### PR DESCRIPTION
Addresses #2471.

The default converters are now added in `Builder.build()` and removed when copying the existing set into the builder in `newBuilder()`.