### PR TITLE
Add Retrofit.Builder.adapterFactories().

### DIFF
--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -542,6 +542,11 @@ public final class Retrofit {
       return this;
     }
 
+    /** Returns a modifiable list of call adapter factories. */
+    public List<CallAdapter.Factory> adapterFactories() {
+      return this.adapterFactories;
+    }
+
     /** Returns a modifiable list of converter factories. */
     public List<Converter.Factory> converterFactories() {
       return this.converterFactories;

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -543,7 +543,7 @@ public final class Retrofit {
     }
 
     /** Returns a modifiable list of call adapter factories. */
-    public List<CallAdapter.Factory> adapterFactories() {
+    public List<CallAdapter.Factory> callAdapterFactories() {
       return this.adapterFactories;
     }
 

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -1224,6 +1224,14 @@ public final class RetrofitTest {
     assertThat(nonMatchingFactory.called).isTrue();
   }
 
+  @Test public void platformAwareAdapterAbsentInCloneBuilder() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .build();
+
+    assertEquals(0, retrofit.newBuilder().adapterFactories().size());
+  }
+
   @Test public void callbackExecutorNullThrows() {
     try {
       new Retrofit.Builder().callbackExecutor(null);

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -1229,7 +1229,7 @@ public final class RetrofitTest {
         .baseUrl(server.url("/"))
         .build();
 
-    assertEquals(0, retrofit.newBuilder().adapterFactories().size());
+    assertEquals(0, retrofit.newBuilder().callAdapterFactories().size());
   }
 
   @Test public void callbackExecutorNullThrows() {


### PR DESCRIPTION
Adds a sister API to `Retrofit.Builder.converterFactories()` for adapter factories.

Follow-up to #2471.