### PR TITLE
Add a Kotlin coroutine adapter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 
     <!-- Compilation -->
     <java.version>1.7</java.version>
+    <kotlin.version>1.1.51</kotlin.version>
 
     <!-- Dependencies -->
     <android.version>4.1.1.4</android.version>
@@ -57,6 +58,7 @@
     <rxjava2.version>2.0.0</rxjava2.version>
     <guava.version>19.0</guava.version>
     <scala.version>2.12.3</scala.version>
+    <coroutines.version>0.19.3</coroutines.version>
 
     <!-- Converter Dependencies -->
     <gson.version>2.8.2</gson.version>
@@ -196,6 +198,16 @@
         <groupId>org.robolectric</groupId>
         <artifactId>robolectric</artifactId>
         <version>${robolectric.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlinx</groupId>
+        <artifactId>kotlinx-coroutines-core</artifactId>
+        <version>${coroutines.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/retrofit-adapters/kotlin-coroutines-experimental/README.md
+++ b/retrofit-adapters/kotlin-coroutines-experimental/README.md
@@ -1,0 +1,55 @@
+Kotlin Coroutine (Experimental) Adapter
+=======================================
+
+An `Adapter` for adapting [Kotlin coroutine's][1] `Deferred`.
+
+
+Usage
+-----
+
+Add `KotlinCoroutineCallAdapterFactory` as a `Call` adapter when building your `Retrofit` instance:
+```kotlin
+val retrofit = Retrofit.Builder()
+    .baseUrl("https://example.com/")
+    .addCallAdapterFactory(KotlinCoroutineCallAdapter())
+    .build()
+```
+
+Your service methods can now use `Deferred` as their return type.
+```kotlin
+interface MyService {
+  @GET("/user")
+  fun getUser(): Deferred<User>
+
+  // or
+
+  @GET("/user")
+  fun getUser(): Deferred<Response<User>>
+}
+```
+
+
+Download
+--------
+
+Download [the latest JAR][2] or grab via [Maven][3]:
+```xml
+<dependency>
+  <groupId>com.squareup.retrofit2</groupId>
+  <artifactId>adapter-kotlin-coroutines-experimental</artifactId>
+  <version>latest.version</version>
+</dependency>
+```
+or [Gradle][3]:
+```groovy
+compile 'com.squareup.retrofit2:adapter-kotlin-coroutines-experimental:latest.version'
+```
+
+Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].
+
+
+
+ [1]: https://kotlinlang.org/docs/reference/coroutines.html
+ [2]: https://search.maven.org/remote_content?g=com.squareup.retrofit2&a=adapter-kotlin-coroutines-experimental&v=LATEST
+ [3]: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.squareup.retrofit2%22%20a%3A%22adapter-kotlin-coroutines-experimental%22
+ [snap]: https://oss.sonatype.org/content/repositories/snapshots/

--- a/retrofit-adapters/kotlin-coroutines-experimental/pom.xml
+++ b/retrofit-adapters/kotlin-coroutines-experimental/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.squareup.retrofit2</groupId>
+    <artifactId>retrofit-adapters</artifactId>
+    <version>2.4.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>adapter-kotlin-coroutines-experimental</artifactId>
+  <name>Adapter: Kotlin Coroutines (Experimental)</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>retrofit</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlinx</groupId>
+      <artifactId>kotlinx-coroutines-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <jvmTarget>1.6</jvmTarget>
+          <experimentalCoroutines>enable</experimentalCoroutines>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/retrofit-adapters/kotlin-coroutines-experimental/src/main/java/retrofit/adapter/kotlin/coroutines/experimental/CoroutineCallAdapterFactory.kt
+++ b/retrofit-adapters/kotlin-coroutines-experimental/src/main/java/retrofit/adapter/kotlin/coroutines/experimental/CoroutineCallAdapterFactory.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit.adapter.kotlin.coroutines.experimental
+
+import kotlinx.coroutines.experimental.CompletableDeferred
+import kotlinx.coroutines.experimental.Deferred
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Callback
+import retrofit2.HttpException
+import retrofit2.Response
+import retrofit2.Retrofit
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+/**
+ * A [CallAdapter.Factory] for use with Kotlin coroutines.
+ *
+ * Adding this class to [Retrofit] allows you to return [Deferred] from
+ * service methods.
+ *
+ *     interface MyService {
+ *       &#64;GET("user/me")
+ *       Deferred&lt;User&gt; getUser()
+ *     }
+ *
+ * There are two configurations supported for the [Deferred] type parameter:
+ *
+ * * Direct body (e.g., `Deferred<User>`) returns the deserialized body for 2XX responses, throws
+ * [HttpException] errors for non-2XX responses, and throws [IOException][java.io.IOException] for
+ * network errors.
+ * * Response wrapped body (e.g., `Deferred<Response<User>>`) returns a [Response] object for all
+ * HTTP responses and throws [IOException][java.io.IOException] for network errors
+ */
+class CoroutineCallAdapterFactory private constructor() : CallAdapter.Factory() {
+  companion object {
+    @JvmStatic @JvmName("create")
+    operator fun invoke() = CoroutineCallAdapterFactory()
+  }
+
+  override fun get(
+      returnType: Type,
+      annotations: Array<out Annotation>,
+      retrofit: Retrofit
+  ): CallAdapter<*, *>? {
+    if (Deferred::class.java != getRawType(returnType)) {
+      return null
+    }
+    if (returnType !is ParameterizedType) {
+      throw IllegalStateException(
+          "Deferred return type must be parameterized as Deferred<Foo> or Deferred<out Foo>")
+    }
+    val responseType = getParameterUpperBound(0, returnType)
+
+    val rawDeferredType = getRawType(responseType)
+    return if (rawDeferredType == Response::class.java) {
+      if (responseType !is ParameterizedType) {
+        throw IllegalStateException(
+            "Response must be parameterized as Response<Foo> or Response<out Foo>")
+      }
+      ResponseCallAdapter<Any>(getParameterUpperBound(0, responseType))
+    } else {
+      BodyCallAdapter<Any>(responseType)
+    }
+  }
+
+  private class BodyCallAdapter<T>(
+      private val responseType: Type
+  ) : CallAdapter<T, Deferred<T>> {
+
+    override fun responseType() = responseType
+
+    override fun adapt(call: Call<T>): Deferred<T> {
+      val deferred = CompletableDeferred<T>()
+
+      deferred.invokeOnCompletion {
+        if (deferred.isCancelled) {
+          call.cancel()
+        }
+      }
+
+      call.enqueue(object : Callback<T> {
+        override fun onFailure(call: Call<T>, t: Throwable) {
+          deferred.completeExceptionally(t)
+        }
+
+        override fun onResponse(call: Call<T>, response: Response<T>) {
+          if (response.isSuccessful) {
+            deferred.complete(response.body()!!)
+          } else {
+            deferred.completeExceptionally(HttpException(response))
+          }
+        }
+      })
+
+      return deferred
+    }
+  }
+
+  private class ResponseCallAdapter<T>(
+      private val responseType: Type
+  ) : CallAdapter<T, Deferred<Response<T>>> {
+
+    override fun responseType() = responseType
+
+    override fun adapt(call: Call<T>): Deferred<Response<T>> {
+      val deferred = CompletableDeferred<Response<T>>()
+
+      deferred.invokeOnCompletion {
+        if (deferred.isCancelled) {
+          call.cancel()
+        }
+      }
+
+      call.enqueue(object : Callback<T> {
+        override fun onFailure(call: Call<T>, t: Throwable) {
+          deferred.completeExceptionally(t)
+        }
+
+        override fun onResponse(call: Call<T>, response: Response<T>) {
+          deferred.complete(response)
+        }
+      })
+
+      return deferred
+    }
+  }
+}

--- a/retrofit-adapters/kotlin-coroutines-experimental/src/test/java/retrofit/adapter/kotlin/coroutines/experimental/CoroutineCallAdapterFactoryTest.java
+++ b/retrofit-adapters/kotlin-coroutines-experimental/src/test/java/retrofit/adapter/kotlin/coroutines/experimental/CoroutineCallAdapterFactoryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit.adapter.kotlin.coroutines.experimental;
+
+import com.google.common.reflect.TypeToken;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+import kotlinx.coroutines.experimental.Deferred;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import retrofit2.CallAdapter;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public final class CoroutineCallAdapterFactoryTest {
+  private static final Annotation[] NO_ANNOTATIONS = new Annotation[0];
+
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  private final CallAdapter.Factory factory = CoroutineCallAdapterFactory.create();
+  private Retrofit retrofit;
+
+  @Before public void setUp() {
+    retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(new StringConverterFactory())
+        .addCallAdapterFactory(factory)
+        .build();
+  }
+
+  @Test public void responseType() {
+    Type bodyClass = new TypeToken<Deferred<String>>() {}.getType();
+    assertThat(factory.get(bodyClass, NO_ANNOTATIONS, retrofit).responseType())
+        .isEqualTo(String.class);
+    Type bodyWildcard = new TypeToken<Deferred<? extends String>>() {}.getType();
+    assertThat(factory.get(bodyWildcard, NO_ANNOTATIONS, retrofit).responseType())
+        .isEqualTo(String.class);
+    Type bodyGeneric = new TypeToken<Deferred<List<String>>>() {}.getType();
+    assertThat(factory.get(bodyGeneric, NO_ANNOTATIONS, retrofit).responseType())
+        .isEqualTo(new TypeToken<List<String>>() {}.getType());
+    Type responseClass = new TypeToken<Deferred<Response<String>>>() {}.getType();
+    assertThat(factory.get(responseClass, NO_ANNOTATIONS, retrofit).responseType())
+        .isEqualTo(String.class);
+    Type responseWildcard = new TypeToken<Deferred<Response<? extends String>>>() {}.getType();
+    assertThat(factory.get(responseWildcard, NO_ANNOTATIONS, retrofit).responseType())
+        .isEqualTo(String.class);
+    Type resultClass = new TypeToken<Deferred<Response<String>>>() {}.getType();
+    assertThat(factory.get(resultClass, NO_ANNOTATIONS, retrofit).responseType())
+        .isEqualTo(String.class);
+    Type resultWildcard = new TypeToken<Deferred<Response<? extends String>>>() {}.getType();
+    assertThat(factory.get(resultWildcard, NO_ANNOTATIONS, retrofit).responseType())
+        .isEqualTo(String.class);
+  }
+
+  @Test public void nonListenableFutureReturnsNull() {
+    CallAdapter<?, ?> adapter = factory.get(String.class, NO_ANNOTATIONS, retrofit);
+    assertThat(adapter).isNull();
+  }
+
+  @Test public void rawTypeThrows() {
+    Type observableType = new TypeToken<Deferred>() {}.getType();
+    try {
+      factory.get(observableType, NO_ANNOTATIONS, retrofit);
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage(
+          "Deferred return type must be parameterized as Deferred<Foo> or Deferred<out Foo>");
+    }
+  }
+
+  @Test public void rawResponseTypeThrows() {
+    Type observableType = new TypeToken<Deferred<Response>>() {}.getType();
+    try {
+      factory.get(observableType, NO_ANNOTATIONS, retrofit);
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage(
+          "Response must be parameterized as Response<Foo> or Response<out Foo>");
+    }
+  }
+}

--- a/retrofit-adapters/kotlin-coroutines-experimental/src/test/java/retrofit/adapter/kotlin/coroutines/experimental/DeferredTest.kt
+++ b/retrofit-adapters/kotlin-coroutines-experimental/src/test/java/retrofit/adapter/kotlin/coroutines/experimental/DeferredTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit.adapter.kotlin.coroutines.experimental
+
+import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.experimental.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import java.io.IOException
+
+class DeferredTest {
+  @get:Rule val server = MockWebServer()
+
+  private lateinit var service: Service
+
+  interface Service {
+    @GET("/") fun body(): Deferred<String>
+    @GET("/") fun response(): Deferred<Response<String>>
+  }
+
+  @Before fun setUp() {
+    val retrofit = Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(StringConverterFactory())
+        .addCallAdapterFactory(CoroutineCallAdapterFactory())
+        .build()
+    service = retrofit.create(Service::class.java)
+  }
+
+  @Test fun bodySuccess200() = runBlocking<Unit> {
+    server.enqueue(MockResponse().setBody("Hi"))
+
+    val deferred = service.body()
+    assertThat(deferred.await()).isEqualTo("Hi")
+  }
+
+  @Test fun bodySuccess404() = runBlocking<Unit> {
+    server.enqueue(MockResponse().setResponseCode(404))
+
+    val deferred = service.body()
+    try {
+      deferred.await()
+      fail()
+    } catch (e: HttpException) {
+      assertThat(e).hasMessage("HTTP 404 Client Error")
+    }
+  }
+
+  @Test fun bodyFailure() = runBlocking {
+    server.enqueue(MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST))
+
+    val deferred = service.body()
+    try {
+      deferred.await()
+      fail()
+    } catch (e: IOException) {
+    }
+  }
+
+  @Test fun responseSuccess200() = runBlocking<Unit> {
+    server.enqueue(MockResponse().setBody("Hi"))
+
+    val deferred = service.response()
+    val response = deferred.await()
+    assertThat(response.isSuccessful).isTrue()
+    assertThat(response.body()).isEqualTo("Hi")
+  }
+
+  @Test fun responseSuccess404() = runBlocking<Unit> {
+    server.enqueue(MockResponse().setResponseCode(404).setBody("Hi"))
+
+    val deferred = service.response()
+    val response = deferred.await()
+    assertThat(response.isSuccessful).isFalse()
+    assertThat(response.errorBody()!!.string()).isEqualTo("Hi")
+  }
+
+  @Test fun responseFailure() = runBlocking {
+    server.enqueue(MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST))
+
+    val deferred = service.response()
+    try {
+      deferred.await()
+      fail()
+    } catch (e: IOException) {
+    }
+  }
+}

--- a/retrofit-adapters/kotlin-coroutines-experimental/src/test/java/retrofit/adapter/kotlin/coroutines/experimental/StringConverterFactory.java
+++ b/retrofit-adapters/kotlin-coroutines-experimental/src/test/java/retrofit/adapter/kotlin/coroutines/experimental/StringConverterFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit.adapter.kotlin.coroutines.experimental;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+final class StringConverterFactory extends Converter.Factory {
+  @Override
+  public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
+      Retrofit retrofit) {
+    return new Converter<ResponseBody, String>() {
+      @Override public String convert(ResponseBody value) throws IOException {
+        return value.string();
+      }
+    };
+  }
+
+  @Override public Converter<?, RequestBody> requestBodyConverter(Type type,
+      Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
+    return new Converter<String, RequestBody>() {
+      @Override public RequestBody convert(String value) throws IOException {
+        return RequestBody.create(MediaType.parse("text/plain"), value);
+      }
+    };
+  }
+}

--- a/retrofit-adapters/pom.xml
+++ b/retrofit-adapters/pom.xml
@@ -17,6 +17,7 @@
   <modules>
     <module>guava</module>
     <module>java8</module>
+    <module>kotlin-coroutines-experimental</module>
     <module>rxjava</module>
     <module>rxjava2</module>
     <module>scala</module>


### PR DESCRIPTION
This supports returning a `Deferred` from your service methods allowing an easy call to `await()` inside a suspending function.

Kotlin coroutines are experimental. This does not make them API unstable, however, which is essential for including them inside Retrofit. When non-experimental coroutines are released we will add a second adapter for them and mark this one as deprecated for removal in the next major version. For more information see https://stackoverflow.com/a/46240340/132047.

Refs #2329.