### PR TITLE
Fix inconsistent example in QueryMap's javadoc.

### DIFF
--- a/retrofit/src/main/java/retrofit2/http/QueryMap.java
+++ b/retrofit/src/main/java/retrofit2/http/QueryMap.java
@@ -46,7 +46,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Call&lt;ResponseBody&gt; friends(@QueryMap(encoded=true) Map&lt;String, String&gt; filters);
  * </code></pre>
  * Calling with {@code foo.list(ImmutableMap.of("group", "coworker+bowling"))} yields
- * {@code /search?group=coworker+bowling}.
+ * {@code /friends?group=coworker+bowling}.
  * <p>
  * A {@code null} value for the map, as a key, or as a value is not allowed.
  *


### PR DESCRIPTION
Commit that made the example inconsistent: https://github.com/square/retrofit/commit/e4acf7bf2e84399076d62287bd373a71e75708bd#diff-4ccbb25352cc066a6dcd06e8ef5bd11a