### PR TITLE
Retain service method parameters when ProGuard optimization is enabled.

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -184,6 +184,10 @@ compile 'com.squareup.retrofit2:retrofit:<span class="version pln"><em>(insert l
 -keepattributes Signature
 # Retain declared checked exceptions for use by a Proxy instance.
 -keepattributes Exceptions
+# Retain service method parameters.
+-keepclassmembernames,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
 </pre>
             <p>Retrofit uses <a href="https://github.com/square/okio">Okio</a> under the hood, so you may want to look at its <a href="https://github.com/square/okio#proguard">ProGuard rules</a> as well.</p>
             </section>


### PR DESCRIPTION
Example:
```java
import com.sch.proguardtest.entities.PostBody;

import okhttp3.ResponseBody;
import retrofit2.Call;
import retrofit2.http.Body;
import retrofit2.http.GET;
import retrofit2.http.POST;
import retrofit2.http.Query;

public interface HttpBinService {
    @POST("post")
    Call<ResponseBody> post(@Query("q") String q, @Body PostBody body);

    @GET("get")
    Call<ResponseBody> post(@Query("q") String q); // This one is unused
}
```

becomes this:

```java
import b.b;
import b.b.o;
import b.b.t;
import okhttp3.ad;

public interface a {
    @o(a = "post")
    b<ad> a(@t(a = "q") String str, @b.b.a com.sch.proguardtest.a.b bVar);
}
```
As you can see ProGuard performed obfuscation and shrinking but all parameters were retained.