### PR TITLE
Remove old ProGuard nonsense.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,16 @@ Retrofit requires at minimum Java 7 or Android 2.3.
 ProGuard
 --------
 
-If you are using ProGuard you might need to add the following options:
+If you are using ProGuard you need to add the following options:
 ```
--dontwarn okio.**
--dontwarn javax.annotation.**
+# Retain generic type information for use by reflection by converters and adapters.
+-keepattributes Signature
+# Retain service method parameters.
+-keepclassmembernames,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 ```
 
 

--- a/website/index.html
+++ b/website/index.html
@@ -176,18 +176,14 @@ compile 'com.squareup.retrofit2:retrofit:<span class="version pln"><em>(insert l
               <h4>ProGuard</h4>
               <p>If you are using ProGuard in your project add the following lines to your configuration:</p>
               <pre class="prettyprint">
-# Platform calls Class.forName on types which do not exist on Android to determine platform.
--dontnote retrofit2.Platform
-# Platform used when running on Java 8 VMs. Will not be used at runtime.
--dontwarn retrofit2.Platform$Java8
 # Retain generic type information for use by reflection by converters and adapters.
 -keepattributes Signature
-# Retain declared checked exceptions for use by a Proxy instance.
--keepattributes Exceptions
 # Retain service method parameters.
 -keepclassmembernames,allowobfuscation interface * {
     @retrofit2.http.* <methods>;
 }
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 </pre>
             <p>Retrofit uses <a href="https://github.com/square/okio">Okio</a> under the hood, so you may want to look at its <a href="https://github.com/square/okio#proguard">ProGuard rules</a> as well.</p>
             </section>


### PR DESCRIPTION
As of API 26 the android.jar contains the classes checked by Platform and used by Platform.Java8. And we don't encourage throwing checked exceptions from the service method but instead routing them through your call adapter.