### PR TITLE
Completable has no body (Void.class), and thus will produce a null in onNext.

### DIFF
--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/BodyObservable.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/BodyObservable.java
@@ -48,7 +48,10 @@ final class BodyObservable<T> extends Observable<T> {
 
     @Override public void onNext(Response<R> response) {
       if (response.isSuccessful()) {
-        observer.onNext(response.body());
+        R body = response.body();
+        if (body != null) {
+          observer.onNext(body);
+        }
       } else {
         terminated = true;
         Throwable t = new HttpException(response);


### PR DESCRIPTION
While running with the akarnokd/RxJava2Extensions that verifies the observable contract; we noticed that Retrofit services that returned `Completable` and got no body from the server would fail.