### PR TITLE
Rename the Scala adapter package to retrofit2.adapter.scala.

### DIFF
--- a/retrofit-adapters/scala/pom.xml
+++ b/retrofit-adapters/scala/pom.xml
@@ -75,7 +75,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>retrofit2.converter.scala</Automatic-Module-Name>
+              <Automatic-Module-Name>retrofit2.adapter.scala</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>

--- a/retrofit-adapters/scala/src/main/java/retrofit2/adapter/scala/BodyCallAdapter.java
+++ b/retrofit-adapters/scala/src/main/java/retrofit2/adapter/scala/BodyCallAdapter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package retrofit2.converter.scala;
+package retrofit2.adapter.scala;
 
 import java.lang.reflect.Type;
 import javax.annotation.Nonnull;

--- a/retrofit-adapters/scala/src/main/java/retrofit2/adapter/scala/ResponseCallAdapter.java
+++ b/retrofit-adapters/scala/src/main/java/retrofit2/adapter/scala/ResponseCallAdapter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package retrofit2.converter.scala;
+package retrofit2.adapter.scala;
 
 import java.lang.reflect.Type;
 import javax.annotation.Nonnull;

--- a/retrofit-adapters/scala/src/main/java/retrofit2/adapter/scala/ScalaCallAdapterFactory.java
+++ b/retrofit-adapters/scala/src/main/java/retrofit2/adapter/scala/ScalaCallAdapterFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package retrofit2.converter.scala;
+package retrofit2.adapter.scala;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;

--- a/retrofit-adapters/scala/src/test/java/retrofit2/adapter/scala/FutureTest.java
+++ b/retrofit-adapters/scala/src/test/java/retrofit2/adapter/scala/FutureTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package retrofit2.converter.scala;
+package retrofit2.adapter.scala;
 
 import java.io.IOException;
 import okhttp3.mockwebserver.MockResponse;

--- a/retrofit-adapters/scala/src/test/java/retrofit2/adapter/scala/ScalaCallAdapterFactoryTest.java
+++ b/retrofit-adapters/scala/src/test/java/retrofit2/adapter/scala/ScalaCallAdapterFactoryTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package retrofit2.converter.scala;
+package retrofit2.adapter.scala;
 
 import com.google.common.reflect.TypeToken;
 import java.lang.annotation.Annotation;

--- a/retrofit-adapters/scala/src/test/java/retrofit2/adapter/scala/StringConverterFactory.java
+++ b/retrofit-adapters/scala/src/test/java/retrofit2/adapter/scala/StringConverterFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package retrofit2.converter.scala;
+package retrofit2.adapter.scala;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;


### PR DESCRIPTION
Previously it was retrofit2.converter.scala.