### PR TITLE
Bump Jackson version a bit.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <!-- Converter Dependencies -->
     <gson.version>2.8.2</gson.version>
     <protobuf.version>3.0.0</protobuf.version>
-    <jackson.version>2.7.2</jackson.version>
+    <jackson.version>2.8.0</jackson.version>
     <wire.version>2.2.0</wire.version>
     <simplexml.version>2.7.1</simplexml.version>
     <moshi.version>1.5.0</moshi.version>


### PR DESCRIPTION
This avoids a vulnerability on older 2.7 versions.

Figured a minor bump was easier than some arbitrary patch version on 2.7. 2.9 is latest but I don't see much reason to "force" it.

Closes #2657.