### PR TITLE
Don't ever pass fatal errors to the callback.

### DIFF
--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -115,6 +115,7 @@ final class OkHttpCall<T> implements Call<T> {
         try {
           response = parseResponse(rawResponse);
         } catch (Throwable e) {
+          throwIfFatal(e);
           callFailure(e);
           return;
         }


### PR DESCRIPTION
Right now, fatal errors from calling enqueue won't be passed to the callback. But, fatal errors from parsing the response are currently still passed to the callback.

This makes logging in a custom call (via a CallAdapter) awkward.

I don't want my logger to log fatal errors.
I have to check for fatal errors in `execute`, but I'd like to drop the `!isFatal` check in my callback in a future release.