### PR TITLE
Example showing onNext contract violation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <!-- Adapter Dependencies -->
     <rxjava.version>1.3.0</rxjava.version>
-    <rxjava2.version>2.0.0</rxjava2.version>
+    <rxjava2.version>2.1.3</rxjava2.version>
     <guava.version>19.0</guava.version>
     <scala.version>2.12.4</scala.version>
 

--- a/retrofit-adapters/rxjava2/pom.xml
+++ b/retrofit-adapters/rxjava2/pom.xml
@@ -49,6 +49,12 @@
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.akarnokd</groupId>
+      <artifactId>rxjava2-extensions</artifactId>
+      <version>0.17.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/NullBodyTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/NullBodyTest.java
@@ -1,0 +1,52 @@
+package retrofit2.adapter.rxjava2;
+
+import hu.akarnokd.rxjava2.debug.SavedHooks;
+import hu.akarnokd.rxjava2.debug.validator.RxJavaProtocolValidator;
+import io.reactivex.Completable;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.TestScheduler;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Rule;
+import org.junit.Test;
+import retrofit2.Retrofit;
+import retrofit2.http.GET;
+
+public class NullBodyTest {
+    @Rule
+    public final MockWebServer server = new MockWebServer();
+    private final TestScheduler scheduler = new TestScheduler();
+
+    interface Api {
+        @GET("/")
+        Completable doStuff();
+    }
+
+    @Test
+    public void nullBody() {
+        SavedHooks hooks = RxJavaProtocolValidator.enableAndChain();
+
+        final Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(server.url("/"))
+                .client(new OkHttpClient())
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.createWithScheduler(scheduler))
+                .build();
+
+        final Api api = retrofit.create(Api.class);
+
+        server.enqueue(new MockResponse());
+        TestObserver<Void> observer = api.doStuff().test();
+
+        scheduler.triggerActions();
+
+        observer
+                .assertComplete()
+                .assertNoErrors();
+
+
+        hooks.restore();
+    }
+}
+
+


### PR DESCRIPTION
In reference to PR #2621 

I had to pull in the RxJava2-Extension library in order to showcase this, maybe you have other means of detecting this.

In order to trigger this defect you have to use the `createWithScheduler` method.

Running the test below would yield:
```
Mar 18, 2018 10:11:28 PM okhttp3.mockwebserver.MockWebServer$2 execute
INFO: MockWebServer[50114] starting to accept connections
Mar 18, 2018 10:11:28 PM okhttp3.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[50114] received request: GET / HTTP/1.1 and responded: HTTP/1.1 200 OK
hu.akarnokd.rxjava2.debug.validator.NullOnNextParameterException
	at hu.akarnokd.rxjava2.debug.validator.ObservableValidator$ValidatorConsumer.onNext(ObservableValidator.java:77)
	at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeOnObserver.onNext(ObservableSubscribeOn.java:58)
	at retrofit2.adapter.rxjava2.BodyObservable$BodyObserver.onNext(BodyObservable.java:51)
	at retrofit2.adapter.rxjava2.BodyObservable$BodyObserver.onNext(BodyObservable.java:37)
	at retrofit2.adapter.rxjava2.CallExecuteObservable.subscribeActual(CallExecuteObservable.java:44)
	at io.reactivex.Observable.subscribe(Observable.java:10903)
	at retrofit2.adapter.rxjava2.BodyObservable.subscribeActual(BodyObservable.java:34)
	at io.reactivex.Observable.subscribe(Observable.java:10903)
	at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
	at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:452)
	at io.reactivex.schedulers.TestScheduler.triggerActions(TestScheduler.java:116)
	at io.reactivex.schedulers.TestScheduler.triggerActions(TestScheduler.java:101)
	at retrofit2.adapter.rxjava2.NullBodyTest.nullBody(NullBodyTest.java:41)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Exception in thread "main" hu.akarnokd.rxjava2.debug.validator.NullOnNextParameterException
	at hu.akarnokd.rxjava2.debug.validator.ObservableValidator$ValidatorConsumer.onNext(ObservableValidator.java:77)
	at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeOnObserver.onNext(ObservableSubscribeOn.java:58)
	at retrofit2.adapter.rxjava2.BodyObservable$BodyObserver.onNext(BodyObservable.java:51)
	at retrofit2.adapter.rxjava2.BodyObservable$BodyObserver.onNext(BodyObservable.java:37)
	at retrofit2.adapter.rxjava2.CallExecuteObservable.subscribeActual(CallExecuteObservable.java:44)
	at io.reactivex.Observable.subscribe(Observable.java:10903)
	at retrofit2.adapter.rxjava2.BodyObservable.subscribeActual(BodyObservable.java:34)
	at io.reactivex.Observable.subscribe(Observable.java:10903)
	at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
	at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:452)
	at io.reactivex.schedulers.TestScheduler.triggerActions(TestScheduler.java:116)
	at io.reactivex.schedulers.TestScheduler.triggerActions(TestScheduler.java:101)
	at retrofit2.adapter.rxjava2.NullBodyTest.nullBody(NullBodyTest.java:41)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Mar 18, 2018 10:11:28 PM okhttp3.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[50114] done accepting connections: Socket closed
```