### PR TITLE
Ability to add Http status code to Response.success

### DIFF
--- a/retrofit/src/main/java/retrofit2/Response.java
+++ b/retrofit/src/main/java/retrofit2/Response.java
@@ -44,11 +44,11 @@ public final class Response<T> {
       throw new IllegalArgumentException("code < 200 or >= 300: " + code);
     }
     return success(body, new okhttp3.Response.Builder() //
-            .code(code)
-            .message("Response.success()")
-            .protocol(Protocol.HTTP_1_1)
-            .request(new Request.Builder().url("http://localhost/").build())
-            .build());
+        .code(code)
+        .message("Response.success()")
+        .protocol(Protocol.HTTP_1_1)
+        .request(new Request.Builder().url("http://localhost/").build())
+        .build());
   }
 
   /**

--- a/retrofit/src/main/java/retrofit2/Response.java
+++ b/retrofit/src/main/java/retrofit2/Response.java
@@ -36,6 +36,20 @@ public final class Response<T> {
   }
 
   /**
+   * Create a synthetic successful response with an HTTP status code of {@code code} and
+   * {@code body} as the deserialized body.
+   */
+  public static <T> Response<T> success(int code, @Nullable T body) {
+    if (code < 200 || code >= 300) throw new IllegalArgumentException("code < 200 or >= 300: " + code);
+    return success(body, new okhttp3.Response.Builder() //
+            .code(code)
+            .message("Response.success()")
+            .protocol(Protocol.HTTP_1_1)
+            .request(new Request.Builder().url("http://localhost/").build())
+            .build());
+  }
+
+  /**
    * Create a synthetic successful response using {@code headers} with {@code body} as the
    * deserialized body.
    */

--- a/retrofit/src/main/java/retrofit2/Response.java
+++ b/retrofit/src/main/java/retrofit2/Response.java
@@ -40,7 +40,9 @@ public final class Response<T> {
    * {@code body} as the deserialized body.
    */
   public static <T> Response<T> success(int code, @Nullable T body) {
-    if (code < 200 || code >= 300) throw new IllegalArgumentException("code < 200 or >= 300: " + code);
+    if (code < 200 || code >= 300) {
+      throw new IllegalArgumentException("code < 200 or >= 300: " + code);
+    }
     return success(body, new okhttp3.Response.Builder() //
             .code(code)
             .message("Response.success()")

--- a/retrofit/src/test/java/retrofit2/ResponseTest.java
+++ b/retrofit/src/test/java/retrofit2/ResponseTest.java
@@ -77,6 +77,17 @@ public final class ResponseTest {
     }
   }
 
+  @Test public void successWithStatusCode() {
+    Object body = new Object();
+    Response<Object> response = Response.success(204, body);
+    assertThat(response.code()).isEqualTo(204);
+    assertThat(response.message()).isEqualTo("Response.success()");
+    assertThat(response.headers().size()).isZero();
+    assertThat(response.isSuccessful()).isTrue();
+    assertThat(response.body()).isSameAs(body);
+    assertThat(response.errorBody()).isNull();
+  }
+
   @Test public void successWithRawResponse() {
     Object body = new Object();
     Response<Object> response = Response.success(body, successResponse);


### PR DESCRIPTION
When writing tests using Retrofit, it would be great if there were a way to set the "success" Http status code in order to verify functionality of other status codes, like 204 no content.