### PR TITLE
Cache default method's MethodHandler to avoid large LambdaForm loading.

### DIFF
--- a/retrofit/src/main/java/retrofit2/Platform.java
+++ b/retrofit/src/main/java/retrofit2/Platform.java
@@ -18,9 +18,12 @@ package retrofit2;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
@@ -70,20 +73,74 @@ class Platform {
 
   @IgnoreJRERequirement // Only classloaded and used on Java 8.
   static class Java8 extends Platform {
+
+    private final Map<CacheKey, MethodHandle> methodHandleCache = new ConcurrentHashMap<>();
+
+    private static class CacheKey {
+      private final Method method;
+      private final Class<?> declaringClass;
+      private final Object object;
+
+      CacheKey(Method method, Class<?> declaringClass, Object object) {
+        this.method = method;
+        this.declaringClass = declaringClass;
+        this.object = object;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        if (this == o) {
+          return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+          return false;
+        }
+
+        CacheKey cacheKey = (CacheKey) o;
+
+        if (!method.equals(cacheKey.method)) {
+          return false;
+        }
+        if (!declaringClass.equals(cacheKey.declaringClass)) {
+          return false;
+        }
+        return object == cacheKey.object;
+      }
+
+      @Override
+      public int hashCode() {
+        int result = method.hashCode();
+        result = 31 * result + declaringClass.hashCode();
+        result = 31 * result + object.hashCode();
+        return result;
+      }
+    }
+
     @Override boolean isDefaultMethod(Method method) {
       return method.isDefault();
     }
 
     @Override Object invokeDefaultMethod(Method method, Class<?> declaringClass, Object object,
         @Nullable Object... args) throws Throwable {
-      // Because the service interface might not be public, we need to use a MethodHandle lookup
-      // that ignores the visibility of the declaringClass.
-      Constructor<Lookup> constructor = Lookup.class.getDeclaredConstructor(Class.class, int.class);
-      constructor.setAccessible(true);
-      return constructor.newInstance(declaringClass, -1 /* trusted */)
-          .unreflectSpecial(method, declaringClass)
-          .bindTo(object)
-          .invokeWithArguments(args);
+      CacheKey key = new CacheKey(method, declaringClass, object);
+      MethodHandle result = methodHandleCache.get(key);
+      if (result == null) {
+        synchronized (methodHandleCache) {
+          result = methodHandleCache.get(key);
+          if (result == null) {
+            // Because the service interface might not be public, we need to use a MethodHandle
+            // lookup that ignores the visibility of the declaringClass.
+            Constructor<Lookup> constructor =
+                    Lookup.class.getDeclaredConstructor(Class.class, int.class);
+            constructor.setAccessible(true);
+            result = constructor.newInstance(declaringClass, -1 /* trusted */)
+                    .unreflectSpecial(method, declaringClass)
+                    .bindTo(object);
+            methodHandleCache.put(key, result);
+          }
+        }
+      }
+      return result.invokeWithArguments(args);
     }
   }
 


### PR DESCRIPTION
We met lots of class loading/unloading problem when using default method. After each young gc, jvm  unload LambdaForm and re-load new one when we call method again. 
When we met mix gc, it needs some time to unloading classes.
