### PR TITLE
Add support for creating failed test call instances with any exception.

### DIFF
--- a/retrofit-mock/src/main/java/retrofit2/mock/Calls.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/Calls.java
@@ -47,9 +47,10 @@ public final class Calls {
   }
 
   /**
-   * Creates a failed {@link Call} from the provided {@code failure}. If {@code failure} is a {@link RuntimeException},
-   * {@link Error} or {@link IOException} subtype it is thrown with a cast. Otherwise the {@code failure} is
-   * "sneaky thrown" via {@linkplain Calls#sneakyThrow(Throwable)}.
+   * Creates a failed {@link Call} from the provided {@code failure}. If {@code failure} is a
+   * {@link RuntimeException}, {@link Error} or {@link IOException} subtype it is thrown with a
+   * cast. Otherwise the {@code failure} is "sneaky thrown" via
+   * {@linkplain Calls#sneakyThrow(Throwable)}.
    */
   public static <T> Call<T> failure(Throwable failure) {
     return new FakeCall<>(null, failure);
@@ -94,7 +95,8 @@ public final class Calls {
       }
 
       sneakyThrow(error);
-      throw new RuntimeException("error is a checked exception and should have been thrown by sneakyThrow()");
+      throw new RuntimeException(
+          "error is a checked exception and should have been thrown by sneakyThrow()");
     }
 
     @SuppressWarnings("ConstantConditions") // Guarding public API nullability.
@@ -197,8 +199,8 @@ public final class Calls {
     Calls.<Error>sneakyThrow2(t);
   }
 
-  @SuppressWarnings("unchecked")
-  private static <T extends Throwable> void sneakyThrow2(Throwable t) throws T {
+  @SuppressWarnings("unchecked") private static <T extends Throwable> void sneakyThrow2(Throwable t)
+      throws T {
     throw (T) t;
   }
 }

--- a/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java
+++ b/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java
@@ -281,13 +281,11 @@ public final class CallsTest {
     final RuntimeException failure = new RuntimeException("Hey");
     final AtomicReference<Throwable> failureRef = new AtomicReference<>();
     Calls.failure(failure).enqueue(new Callback<Object>() {
-      @Override
-      public void onResponse(Call<Object> call, Response<Object> response) {
+      @Override public void onResponse(Call<Object> call, Response<Object> response) {
         fail();
       }
 
-      @Override
-      public void onFailure(Call<Object> call, Throwable t) {
+      @Override public void onFailure(Call<Object> call, Throwable t) {
         failureRef.set(t);
       }
     });

--- a/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java
+++ b/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java
@@ -15,7 +15,9 @@
  */
 package retrofit2.mock;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.security.cert.CertificateException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
@@ -156,15 +158,15 @@ public final class CallsTest {
     assertTrue(taco.isExecuted());
   }
 
-  @Test public void failureExecuteWrapsInIOException() {
-    NullPointerException failure = new NullPointerException("Hey");
+  @Test public void failureExecuteCheckedException() {
+    CertificateException failure = new CertificateException("Hey");
     Call<Object> taco = Calls.failure(failure);
     assertFalse(taco.isExecuted());
     try {
       taco.execute();
       fail();
-    } catch (IOException e) {
-      assertSame(failure, e.getCause());
+    } catch (Throwable e) {
+      assertSame(failure, e);
     }
     assertTrue(taco.isExecuted());
   }
@@ -275,8 +277,8 @@ public final class CallsTest {
     assertSame(failure, failureRef.get());
   }
 
-  @Test public void deferredThrowEnqueueDeliversException() {
-    final Exception failure = new Exception("Hey");
+  @Test public void deferredThrowUncheckedExceptionEnqueue() {
+    final RuntimeException failure = new RuntimeException("Hey");
     final AtomicReference<Throwable> failureRef = new AtomicReference<>();
     Calls.failure(failure).enqueue(new Callback<Object>() {
       @Override


### PR DESCRIPTION
When using `Calls.failure()` to create a failed `Call` object for test you can now pass in any `Throwable`.

If the `Throwable` is a `RuntimeException`, `Error` or `IOException` subtype it is thrown with a cast. Otherwise the `Throwable` is "sneaky thrown".

Addresses #2693 