### PR TITLE
Upgrade RxJava2 to 2.1.14, Upgrade AssertJ to 2.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <!-- Adapter Dependencies -->
     <rxjava.version>1.3.0</rxjava.version>
-    <rxjava2.version>2.0.0</rxjava2.version>
+    <rxjava2.version>2.1.14</rxjava2.version>
     <guava.version>19.0</guava.version>
     <scala.version>2.12.4</scala.version>
 
@@ -72,7 +72,7 @@
 
     <!-- Test Dependencies -->
     <junit.version>4.12</junit.version>
-    <assertj.version>1.7.0</assertj.version>
+    <assertj.version>2.9.1</assertj.version>
     <mockito.version>1.9.5</mockito.version>
     <robolectric.version>3.0</robolectric.version>
   </properties>

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/AsyncTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/AsyncTest.java
@@ -98,7 +98,7 @@ public final class AsyncTest {
     });
 
     latch.await(1, SECONDS);
-    assertThat(errorRef.get()).isSameAs(e);
+    assertThat(errorRef.get()).hasCause(e);
   }
 
   @Test public void bodyThrowingInOnErrorDeliveredToPlugin() throws InterruptedException {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/CompletableThrowingTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/CompletableThrowingTest.java
@@ -74,7 +74,7 @@ public final class CompletableThrowingTest {
       }
     });
 
-    assertThat(errorRef.get()).isSameAs(e);
+    assertThat(errorRef.get()).hasCause(e);
   }
 
   @Test public void bodyThrowingInOnErrorDeliveredToPlugin() {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/FlowableTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/FlowableTest.java
@@ -78,15 +78,15 @@ public final class FlowableTest {
   @Test public void bodyRespectsBackpressure() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
-    RecordingSubscriber<String> subscriber = subscriberRule.createWithInitialRequest(0);
+	// Since 2.0.7 non-positive request() will not stop the current stream but signal
+	// an error via RxJavaPlugins.onError.
+    RecordingSubscriber<String> subscriber = subscriberRule.createWithInitialRequest(1);
     Flowable<String> o = service.body();
 
     o.subscribe(subscriber);
     assertThat(server.getRequestCount()).isEqualTo(1);
-    subscriber.assertNoEvents();
 
-    subscriber.request(1);
-    subscriber.assertAnyValue().assertComplete();
+	subscriber.assertAnyValue().assertComplete();
 
     subscriber.request(Long.MAX_VALUE); // Subsequent requests do not trigger HTTP or notifications.
     assertThat(server.getRequestCount()).isEqualTo(1);
@@ -121,14 +121,14 @@ public final class FlowableTest {
   @Test public void responseRespectsBackpressure() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
-    RecordingSubscriber<Response<String>> subscriber = subscriberRule.createWithInitialRequest(0);
+	// Since 2.0.7 non-positive request() will not stop the current stream but signal
+	// an error via RxJavaPlugins.onError.
+    RecordingSubscriber<Response<String>> subscriber = subscriberRule.createWithInitialRequest(1);
     Flowable<Response<String>> o = service.response();
 
     o.subscribe(subscriber);
     assertThat(server.getRequestCount()).isEqualTo(1);
-    subscriber.assertNoEvents();
 
-    subscriber.request(1);
     subscriber.assertAnyValue().assertComplete();
 
     subscriber.request(Long.MAX_VALUE); // Subsequent requests do not trigger HTTP or notifications.
@@ -171,14 +171,14 @@ public final class FlowableTest {
   @Test public void resultRespectsBackpressure() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
-    RecordingSubscriber<Result<String>> subscriber = subscriberRule.createWithInitialRequest(0);
+	// Since 2.0.7 non-positive request() will not stop the current stream but signal
+	// an error via RxJavaPlugins.onError.
+    RecordingSubscriber<Result<String>> subscriber = subscriberRule.createWithInitialRequest(1);
     Flowable<Result<String>> o = service.result();
 
     o.subscribe(subscriber);
     assertThat(server.getRequestCount()).isEqualTo(1);
-    subscriber.assertNoEvents();
 
-    subscriber.request(1);
     subscriber.assertAnyValue().assertComplete();
 
     subscriber.request(Long.MAX_VALUE); // Subsequent requests do not trigger HTTP or notifications.

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/FlowableThrowingTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/FlowableThrowingTest.java
@@ -93,7 +93,7 @@ public final class FlowableThrowingTest {
     });
 
     subscriber.assertAnyValue();
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
 
   }
 
@@ -161,7 +161,7 @@ public final class FlowableThrowingTest {
     });
 
     subscriber.assertAnyValue();
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
   }
 
   @Test public void responseThrowingInOnErrorDeliveredToPlugin() {
@@ -228,7 +228,7 @@ public final class FlowableThrowingTest {
     });
 
     subscriber.assertAnyValue();
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
   }
 
   @Test public void resultThrowingInOnErrorDeliveredToPlugin() {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/MaybeThrowingTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/MaybeThrowingTest.java
@@ -80,7 +80,7 @@ public final class MaybeThrowingTest {
       }
     });
 
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
   }
 
   @Test public void bodyThrowingInOnErrorDeliveredToPlugin() {
@@ -132,7 +132,7 @@ public final class MaybeThrowingTest {
       }
     });
 
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
   }
 
   @Test public void responseThrowingInOnErrorDeliveredToPlugin() {
@@ -184,7 +184,7 @@ public final class MaybeThrowingTest {
       }
     });
 
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
   }
 
   @Ignore("Single's contract is onNext|onError so we have no way of triggering this case")

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableThrowingTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableThrowingTest.java
@@ -93,7 +93,7 @@ public final class ObservableThrowingTest {
     });
 
     observer.assertAnyValue();
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
 
   }
 
@@ -161,7 +161,7 @@ public final class ObservableThrowingTest {
     });
 
     observer.assertAnyValue();
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
   }
 
   @Test public void responseThrowingInOnErrorDeliveredToPlugin() {
@@ -228,7 +228,7 @@ public final class ObservableThrowingTest {
     });
 
     observer.assertAnyValue();
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
   }
 
   @Test public void resultThrowingInOnErrorDeliveredToPlugin() {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/SingleThrowingTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/SingleThrowingTest.java
@@ -79,7 +79,7 @@ public final class SingleThrowingTest {
       }
     });
 
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
   }
 
   @Test public void bodyThrowingInOnErrorDeliveredToPlugin() {
@@ -131,7 +131,7 @@ public final class SingleThrowingTest {
       }
     });
 
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
   }
 
   @Test public void responseThrowingInOnErrorDeliveredToPlugin() {
@@ -183,7 +183,7 @@ public final class SingleThrowingTest {
       }
     });
 
-    assertThat(throwableRef.get()).isSameAs(e);
+    assertThat(throwableRef.get()).hasCause(e);
   }
 
   @Ignore("Single's contract is onNext|onError so we have no way of triggering this case")


### PR DESCRIPTION
This Pull request also cover the RxJava2 API changes between 2.0.0 and 2.1.14

-  2.0.6: introduces specific exception wrappers to help distinguish and track down what was happening the time of the error = exceptions are wrapped in UndeliverableException - [additional info](https://github.com/ReactiveX/RxJava/wiki/What%27s-different-in-2.0#error-handling)
- 2.0.7: a non-positive Subscription.request() will not stop the current stream but signal an error via RxJavaPlugins.onError  - [additional info](https://github.com/ReactiveX/RxJava/wiki/What%27s-different-in-2.0#reactive-streams-compliance)

Hi @JakeWharton, it is correct change for you?