### PR TITLE
Update ProGuard rules

### DIFF
--- a/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -1,10 +1,13 @@
 # Retain generic type information for use by reflection by converters and adapters.
 -keepattributes Signature
 
-# Retain service method parameters.
+# Retain service method parameters when optimizing.
 -keepclassmembers,allowshrinking,allowobfuscation interface * {
     @retrofit2.http.* <methods>;
 }
 
 # Ignore annotation used for build tooling.
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Ignore JSR 305 annotations for embedding nullability information.
+-dontwarn javax.annotation.**


### PR DESCRIPTION
- Use module name as file name to prevent conflicts
- Ignore JSR 305 annotations
- Clarify optimization rule