### PR TITLE
Implement correct isDefault check for Android

### DIFF
--- a/retrofit/src/main/java/retrofit2/Platform.java
+++ b/retrofit/src/main/java/retrofit2/Platform.java
@@ -88,6 +88,14 @@ class Platform {
   }
 
   static class Android extends Platform {
+    @IgnoreJRERequirement // Guarded by API check.
+    @Override boolean isDefaultMethod(Method method) {
+      if (Build.VERSION.SDK_INT < 24) {
+        return false;
+      }
+      return method.isDefault();
+    }
+
     @Override public Executor defaultCallbackExecutor() {
       return new MainThreadExecutor();
     }


### PR DESCRIPTION
There is no ability to invoke a default method yet, but at least now you'll get a UOE thrown instead of it being treated as a normal service method.

Unfortunately we can't test this for the same reason we don't test normal Java 8 functionality, it requires the language level be set to 8 and we can't vary the value between the main sources and test sources.