### PR TITLE
Fix error message for out-of-order parameters.

### DIFF
--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -127,6 +127,8 @@ final class RequestFactory {
     boolean gotBody;
     boolean gotPath;
     boolean gotQuery;
+    boolean gotQueryName;
+    boolean gotQueryMap;
     boolean gotUrl;
     String httpMethod;
     boolean hasBody;
@@ -322,7 +324,13 @@ final class RequestFactory {
           throw parameterError(method, p, "@Path parameters may not be used with @Url.");
         }
         if (gotQuery) {
-          throw parameterError(method, p, "A @Url parameter must not come after a @Query");
+          throw parameterError(method, p, "A @Url parameter must not come after a @Query.");
+        }
+        if (gotQueryName) {
+          throw parameterError(method, p, "A @Url parameter must not come after a @QueryName.");
+        }
+        if (gotQueryMap) {
+          throw parameterError(method, p, "A @Url parameter must not come after a @QueryMap.");
         }
         if (relativeUrl != null) {
           throw parameterError(method, p, "@Url cannot be used with @%s URL", httpMethod);
@@ -343,6 +351,12 @@ final class RequestFactory {
       } else if (annotation instanceof Path) {
         if (gotQuery) {
           throw parameterError(method, p, "A @Path parameter must not come after a @Query.");
+        }
+        if (gotQueryName) {
+          throw parameterError(method, p, "A @Path parameter must not come after a @QueryName.");
+        }
+        if (gotQueryMap) {
+          throw parameterError(method, p, "A @Path parameter must not come after a @QueryMap.");
         }
         if (gotUrl) {
           throw parameterError(method, p, "@Path parameters may not be used with @Url.");
@@ -395,7 +409,7 @@ final class RequestFactory {
         boolean encoded = query.encoded();
 
         Class<?> rawParameterType = Utils.getRawType(type);
-        gotQuery = true;
+        gotQueryName = true;
         if (Iterable.class.isAssignableFrom(rawParameterType)) {
           if (!(type instanceof ParameterizedType)) {
             throw parameterError(method, p, rawParameterType.getSimpleName()
@@ -421,6 +435,7 @@ final class RequestFactory {
 
       } else if (annotation instanceof QueryMap) {
         Class<?> rawParameterType = Utils.getRawType(type);
+        gotQueryMap = true;
         if (!Map.class.isAssignableFrom(rawParameterType)) {
           throw parameterError(method, p, "@QueryMap parameter type must be Map.");
         }

--- a/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
@@ -1005,6 +1005,40 @@ public final class RequestFactoryTest {
     }
   }
 
+  @Test public void getWithQueryNameThenPathThrows() {
+    class Example {
+      @GET("/foo/bar/{ping}/") //
+      Call<ResponseBody> method(@QueryName String kit, @Path("ping") String ping) {
+        throw new AssertionError();
+      }
+    }
+
+    try {
+      buildRequest(Example.class, "kat", "pong");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("A @Path parameter must not come after a @QueryName. (parameter #2)\n"
+          + "    for method Example.method");
+    }
+  }
+
+  @Test public void getWithQueryMapThenPathThrows() {
+    class Example {
+      @GET("/foo/bar/{ping}/") //
+      Call<ResponseBody> method(@QueryMap Map<String, String> queries, @Path("ping") String ping) {
+        throw new AssertionError();
+      }
+    }
+
+    try {
+      buildRequest(Example.class, Collections.singletonMap("kit", "kat"), "pong");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("A @Path parameter must not come after a @QueryMap. (parameter #2)\n"
+          + "    for method Example.method");
+    }
+  }
+
   @Test public void getWithPathAndQueryQuestionMarkParam() {
     class Example {
       @GET("/foo/bar/{ping}/") //
@@ -1444,7 +1478,41 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, "hey", "foo/bar/");
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("A @Url parameter must not come after a @Query (parameter #2)\n"
+      assertThat(e).hasMessage("A @Url parameter must not come after a @Query. (parameter #2)\n"
+          + "    for method Example.method");
+    }
+  }
+
+  @Test public void getWithQueryNameThenUrlThrows() {
+    class Example {
+      @GET
+      Call<ResponseBody> method(@QueryName String name, @Url String url) {
+        throw new AssertionError();
+      }
+    }
+
+    try {
+      buildRequest(Example.class, Collections.singletonMap("kit", "kat"), "foo/bar/");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("A @Url parameter must not come after a @QueryName. (parameter #2)\n"
+          + "    for method Example.method");
+    }
+  }
+
+  @Test public void getWithQueryMapThenUrlThrows() {
+    class Example {
+      @GET
+      Call<ResponseBody> method(@QueryMap Map<String, String> queries, @Url String url) {
+        throw new AssertionError();
+      }
+    }
+
+    try {
+      buildRequest(Example.class, Collections.singletonMap("kit", "kat"), "foo/bar/");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("A @Url parameter must not come after a @QueryMap. (parameter #2)\n"
           + "    for method Example.method");
     }
   }


### PR DESCRIPTION
Give QueryName and QueryMap their own error messages when they are put before Path or Url.

Closes #2845 and closes #2710.