### PR TITLE
Add built-in support for Kotlin's Unit type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 
     <!-- Compilation -->
     <java.version>1.7</java.version>
+    <kotlin.version>1.2.60</kotlin.version>
 
     <!-- Dependencies -->
     <android.version>4.1.1.4</android.version>
@@ -107,6 +108,11 @@
         <groupId>com.google.android</groupId>
         <artifactId>android</artifactId>
         <version>${android.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin.version}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.mojo</groupId>

--- a/retrofit/pom.xml
+++ b/retrofit/pom.xml
@@ -24,6 +24,11 @@
       <artifactId>android</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>org.codehaus.mojo</groupId>

--- a/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -11,3 +11,6 @@
 
 # Ignore JSR 305 annotations for embedding nullability information.
 -dontwarn javax.annotation.**
+
+# Guarded by a NoClassDefFoundError try/catch and only used when on the classpath.
+-dontwarn kotlin.Unit

--- a/retrofit/src/test/java/retrofit2/KotlinUnitTest.java
+++ b/retrofit/src/test/java/retrofit2/KotlinUnitTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2;
+
+import java.io.IOException;
+import kotlin.Unit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import retrofit2.http.GET;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class KotlinUnitTest {
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  interface Service {
+    @GET("/")
+    Call<Unit> empty();
+  }
+
+  @Test public void unitOnClasspath() throws IOException {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .build();
+    Service example = retrofit.create(Service.class);
+
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    Response<Unit> response = example.empty().execute();
+    assertThat(response.isSuccessful()).isTrue();
+    assertThat(response.body()).isSameAs(Unit.INSTANCE);
+  }
+
+  @Ignore("This is implicitly tested by integration tests of the adapters and converters")
+  @Test public void unitMissingFromClasspath() {
+  }
+}


### PR DESCRIPTION
This is built in a way such that its absence from the classpath will not cause failures.

Closes #2329.