### PR TITLE
Update Proguard rules for D8

### DIFF
--- a/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -1,5 +1,5 @@
-# Retain generic type information for use by reflection by converters and adapters.
--keepattributes Signature
+# Retrofit does reflection on generic parameters and InnerClass is required to use Signature.
+-keepattributes Signature, InnerClasses
 
 # Retain service method parameters when optimizing.
 -keepclassmembers,allowshrinking,allowobfuscation interface * {


### PR DESCRIPTION
Otherwise, Android builds may encounter the following error when migrating to AGP 3.2.

```
D8: Attribute Signature requires InnerClasses attribute. Check -keepattributes directive.
```