### PR TITLE
Fix `Unit` converter not being called on a 204 response.

### DIFF
--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -213,11 +213,6 @@ final class OkHttpCall<T> implements Call<T> {
       }
     }
 
-    if (code == 204 || code == 205) {
-      rawBody.close();
-      return Response.success(null, rawResponse);
-    }
-
     ExceptionCatchingResponseBody catchingBody = new ExceptionCatchingResponseBody(rawBody);
     try {
       T body = responseConverter.convert(catchingBody);

--- a/retrofit/src/test/java/retrofit2/CallTest.java
+++ b/retrofit/src/test/java/retrofit2/CallTest.java
@@ -47,8 +47,6 @@ import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public final class CallTest {
   @Rule public final MockWebServer server = new MockWebServer();
@@ -367,58 +365,6 @@ public final class CallTest {
 
     assertThat(failureRef.get()).isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("I am broken!");
-  }
-
-  @Test public void http204SkipsConverter() throws IOException {
-    final Converter<ResponseBody, String> converter = spy(new Converter<ResponseBody, String>() {
-      @Override public String convert(ResponseBody value) throws IOException {
-        return value.string();
-      }
-    });
-    Retrofit retrofit = new Retrofit.Builder()
-        .baseUrl(server.url("/"))
-        .addConverterFactory(new ToStringConverterFactory() {
-          @Override
-          public Converter<ResponseBody, ?> responseBodyConverter(Type type,
-              Annotation[] annotations, Retrofit retrofit) {
-            return converter;
-          }
-        })
-        .build();
-    Service example = retrofit.create(Service.class);
-
-    server.enqueue(new MockResponse().setStatus("HTTP/1.1 204 Nothin"));
-
-    Response<String> response = example.getString().execute();
-    assertThat(response.code()).isEqualTo(204);
-    assertThat(response.body()).isNull();
-    verifyNoMoreInteractions(converter);
-  }
-
-  @Test public void http205SkipsConverter() throws IOException {
-    final Converter<ResponseBody, String> converter = spy(new Converter<ResponseBody, String>() {
-      @Override public String convert(ResponseBody value) throws IOException {
-        return value.string();
-      }
-    });
-    Retrofit retrofit = new Retrofit.Builder()
-        .baseUrl(server.url("/"))
-        .addConverterFactory(new ToStringConverterFactory() {
-          @Override
-          public Converter<ResponseBody, ?> responseBodyConverter(Type type,
-              Annotation[] annotations, Retrofit retrofit) {
-            return converter;
-          }
-        })
-        .build();
-    Service example = retrofit.create(Service.class);
-
-    server.enqueue(new MockResponse().setStatus("HTTP/1.1 205 Nothin"));
-
-    Response<String> response = example.getString().execute();
-    assertThat(response.code()).isEqualTo(205);
-    assertThat(response.body()).isNull();
-    verifyNoMoreInteractions(converter);
   }
 
   @Test public void executeCallOnce() throws IOException {

--- a/retrofit/src/test/java/retrofit2/KotlinUnitTest.java
+++ b/retrofit/src/test/java/retrofit2/KotlinUnitTest.java
@@ -47,6 +47,19 @@ public final class KotlinUnitTest {
     assertThat(response.body()).isSameAs(Unit.INSTANCE);
   }
 
+  @Test public void unitSucceedsOnEmptyResponse() throws IOException {
+    Retrofit retrofit = new Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .build();
+    Service example = retrofit.create(Service.class);
+
+    server.enqueue(new MockResponse().setResponseCode(204));
+
+    Response<Unit> response = example.empty().execute();
+    assertThat(response.isSuccessful()).isTrue();
+    assertThat(response.body()).isSameAs(Unit.INSTANCE);
+  }
+
   @Ignore("This is implicitly tested by integration tests of the adapters and converters")
   @Test public void unitMissingFromClasspath() {
   }


### PR DESCRIPTION
This is probably very wrong but I thought it would be interesting to put it up for comment given I didn't see anyone else running into this issue.

I'm using retrofit + kotlin coroutines and all current coroutines adapters rely on successful responses to not have a `null` body. This becomes an issue when you try to deserialise an empty response. Recently a `Unit` converter was [added](https://github.com/square/retrofit/commit/7cbfa055d7f69317bfd33e5a5b206e60cfff3347) but it fails if the backend response is a `204` (and by digging into retrofit code also a `205` code).

This is just a proposed quick fix with a failing test added on `KotlinUnitTest` but I imagine the implications are quite big and will have a hit on performance.

I guess my argument is that if a succesful response on a given api call would be a `204` I would expect an interface like the following one to work fine.

```kotlin
interface Service {
  @POST("event")
  fun sendEvent(...): Call<Unit>
}
```