### PR TITLE
Fix Optional converter factories not delegating properly.

### DIFF
--- a/retrofit-converters/guava/src/main/java/retrofit/converter/guava/GuavaOptionalConverterFactory.java
+++ b/retrofit-converters/guava/src/main/java/retrofit/converter/guava/GuavaOptionalConverterFactory.java
@@ -45,7 +45,7 @@ public final class GuavaOptionalConverterFactory extends Converter.Factory {
 
     Type innerType = getParameterUpperBound(0, (ParameterizedType) type);
     Converter<ResponseBody, Object> delegate =
-        retrofit.nextResponseBodyConverter(this, innerType, annotations);
+        retrofit.responseBodyConverter(innerType, annotations);
     return new OptionalConverter<>(delegate);
   }
 }

--- a/retrofit-converters/guava/src/test/java/retrofit/converter/guava/GuavaOptionalConverterFactoryTest.java
+++ b/retrofit-converters/guava/src/test/java/retrofit/converter/guava/GuavaOptionalConverterFactoryTest.java
@@ -17,12 +17,17 @@ package retrofit.converter.guava;
 
 import com.google.common.base.Optional;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import javax.annotation.Nullable;
+import okhttp3.ResponseBody;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import retrofit2.Call;
+import retrofit2.Converter;
 import retrofit2.Retrofit;
 import retrofit2.http.GET;
 
@@ -60,5 +65,32 @@ public final class GuavaOptionalConverterFactoryTest {
 
     Object body = service.object().execute().body();
     assertThat(body).isNull();
+  }
+
+  @Test public void delegates() throws IOException {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(new Converter.Factory() {
+          @Nullable @Override public Converter<ResponseBody, ?> responseBodyConverter(Type type,
+              Annotation[] annotations, Retrofit retrofit) {
+            if (getRawType(type) != Object.class) {
+              return null;
+            }
+            return new Converter<ResponseBody, Object>() {
+              @Override public Object convert(ResponseBody value) {
+                return null;
+              }
+            };
+          }
+        })
+        .addConverterFactory(GuavaOptionalConverterFactory.create())
+        .build();
+
+    server.enqueue(new MockResponse());
+
+    Service service = retrofit.create(Service.class);
+    Optional<Object> optional = service.optional().execute().body();
+    assertThat(optional).isNotNull();
+    assertThat(optional.isPresent()).isFalse();
   }
 }

--- a/retrofit-converters/java8/src/main/java/retrofit/converter/java8/Java8OptionalConverterFactory.java
+++ b/retrofit-converters/java8/src/main/java/retrofit/converter/java8/Java8OptionalConverterFactory.java
@@ -45,7 +45,7 @@ public final class Java8OptionalConverterFactory extends Converter.Factory {
 
     Type innerType = getParameterUpperBound(0, (ParameterizedType) type);
     Converter<ResponseBody, Object> delegate =
-        retrofit.nextResponseBodyConverter(this, innerType, annotations);
+        retrofit.responseBodyConverter(innerType, annotations);
     return new OptionalConverter<>(delegate);
   }
 }

--- a/retrofit-converters/java8/src/test/java/retrofit/converter/java8/Java8OptionalConverterFactoryTest.java
+++ b/retrofit-converters/java8/src/test/java/retrofit/converter/java8/Java8OptionalConverterFactoryTest.java
@@ -16,13 +16,18 @@
 package retrofit.converter.java8;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.Optional;
+import javax.annotation.Nullable;
+import okhttp3.ResponseBody;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import retrofit2.Call;
+import retrofit2.Converter;
 import retrofit2.Retrofit;
 import retrofit2.http.GET;
 
@@ -60,5 +65,32 @@ public final class Java8OptionalConverterFactoryTest {
 
     Object body = service.object().execute().body();
     assertThat(body).isNull();
+  }
+
+  @Test public void delegates() throws IOException {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(new Converter.Factory() {
+          @Nullable @Override public Converter<ResponseBody, ?> responseBodyConverter(Type type,
+              Annotation[] annotations, Retrofit retrofit) {
+            if (getRawType(type) != Object.class) {
+              return null;
+            }
+            return new Converter<ResponseBody, Object>() {
+              @Override public Object convert(ResponseBody value) {
+                return null;
+              }
+            };
+          }
+        })
+        .addConverterFactory(Java8OptionalConverterFactory.create())
+        .build();
+
+    server.enqueue(new MockResponse());
+
+    Service service = retrofit.create(Service.class);
+    Optional<Object> optional = service.optional().execute().body();
+    assertThat(optional).isNotNull();
+    assertThat(optional.isPresent()).isFalse();
   }
 }


### PR DESCRIPTION
before, these test would fail with

```
java.lang.IllegalArgumentException: Unable to create converter for com.google.common.base.Optional<java.lang.Object>
    for method Service.optional

Caused by: java.lang.IllegalArgumentException: Could not locate ResponseBody converter for class java.lang.Object.
  Skipped:
   * retrofit2.BuiltInConverters
   * retrofit.converter.guava.GuavaOptionalConverterFactoryTest$1
   * retrofit.converter.guava.GuavaOptionalConverterFactory
  Tried:
   * retrofit2.OptionalConverterFactory
```