### PR TITLE
Allow for use of customer marshaller and unmarshaller properties to be used

### DIFF
--- a/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbConverterFactory.java
+++ b/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbConverterFactory.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlRootElement;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
@@ -38,25 +36,41 @@ import retrofit2.Retrofit;
 public final class JaxbConverterFactory extends Converter.Factory {
   static final MediaType XML = MediaType.get("application/xml; charset=utf-8");
 
-  /** Create an instance using a default {@link JAXBContext} instance for conversion. */
+  /** Create an instance using a default {@link JAXBContext} instance for conversion.
+   *
+   * @return JaxbConverterFactory
+   */
   public static JaxbConverterFactory create() {
     return new JaxbConverterFactory(null);
   }
 
-  /** Create an instance using {@code context} for conversion. */
+  /** Create an instance using {@code context} for conversion.
+   * @param context JAXBContext
+   *
+   * @return JaxbConverterFactory
+   */
   @SuppressWarnings("ConstantConditions") // Guarding public API nullability.
   public static JaxbConverterFactory create(JAXBContext context) {
     if (context == null) throw new NullPointerException("context == null");
     return new JaxbConverterFactory(context);
   }
 
-  /** Create an instance using {@code context}, {@code marshaller}, and {@code unmarshaller} for conversion. */
+  /** Create an instance using {@code context}, {@code marshaller}, and {@code unmarshaller} for
+   * conversion.
+   * @param context JAXBContext
+   * @param marshallerProperties Map
+   * @param unmarshallerProperties Map
+   *
+   * @return JaxbConverterFactory
+   */
   @SuppressWarnings("ConstantConditions")
-  public static JaxbConverterFactory create(JAXBContext context, Map<String, Object> marshallerProperties,
-       Map<String, Object> unmarshallerProperties) {
+  public static JaxbConverterFactory create(JAXBContext context,
+       Map<String, Object> marshallerProperties, Map<String, Object> unmarshallerProperties) {
     if (context == null) throw new NullPointerException("context == null");
-    if (marshallerProperties == null) throw new NullPointerException("marshallerProperties == null");
-    if (unmarshallerProperties == null) throw new NullPointerException("unmarshallerProperties == null");
+    if (marshallerProperties == null)
+      throw new NullPointerException("marshallerProperties == null");
+    if (unmarshallerProperties == null)
+      throw new NullPointerException("unmarshallerProperties == null");
     return new JaxbConverterFactory(context, marshallerProperties, unmarshallerProperties);
   }
 
@@ -68,10 +82,11 @@ public final class JaxbConverterFactory extends Converter.Factory {
   private JaxbConverterFactory(@Nullable JAXBContext context) {
     this.context = context;
     this.marshallerProperties = new HashMap<>();
-    this. unmarshallerProperties = new HashMap<>();
+    this.unmarshallerProperties = new HashMap<>();
   }
 
-  private JaxbConverterFactory(@Nullable JAXBContext context, @Nullable Map<String, Object> marshallerProperties,
+  private JaxbConverterFactory(@Nullable JAXBContext context,
+      @Nullable Map<String, Object> marshallerProperties,
       @Nullable Map<String, Object> unmarshallerProperties) {
     this.context = context;
     this.marshallerProperties = marshallerProperties;
@@ -81,7 +96,8 @@ public final class JaxbConverterFactory extends Converter.Factory {
   @Override public @Nullable Converter<?, RequestBody> requestBodyConverter(Type type,
       Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
     if (type instanceof Class && ((Class<?>) type).isAnnotationPresent(XmlRootElement.class)) {
-      return new JaxbRequestConverter<>(contextForType((Class<?>) type), (Class<?>) type, marshallerProperties);
+      return new JaxbRequestConverter<>(contextForType((Class<?>) type),
+              (Class<?>) type, marshallerProperties);
     }
     return null;
   }
@@ -89,7 +105,8 @@ public final class JaxbConverterFactory extends Converter.Factory {
   @Override public @Nullable Converter<ResponseBody, ?> responseBodyConverter(
       Type type, Annotation[] annotations, Retrofit retrofit) {
     if (type instanceof Class && ((Class<?>) type).isAnnotationPresent(XmlRootElement.class)) {
-      return new JaxbResponseConverter<>(contextForType((Class<?>) type), (Class<?>) type, unmarshallerProperties);
+      return new JaxbResponseConverter<>(contextForType((Class<?>) type),
+              (Class<?>) type, unmarshallerProperties);
     }
     return null;
   }

--- a/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbRequestConverter.java
+++ b/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbRequestConverter.java
@@ -16,6 +16,8 @@
 package retrofit2.converter.jaxb;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
@@ -30,16 +32,24 @@ final class JaxbRequestConverter<T> implements Converter<T, RequestBody> {
   final XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
   final JAXBContext context;
   final Class<T> type;
+  final Map<String, Object> marshallerProperties;
 
-  JaxbRequestConverter(JAXBContext context, Class<T> type) {
+  JaxbRequestConverter(JAXBContext context, Class<T> type, Map<String, Object> marshallerProperties) {
     this.context = context;
     this.type = type;
+    this.marshallerProperties = marshallerProperties;
   }
 
   @Override public RequestBody convert(final T value) throws IOException {
     Buffer buffer = new Buffer();
     try {
       Marshaller marshaller = context.createMarshaller();
+      if (!marshallerProperties.isEmpty()) {
+        Set<String> keys = marshallerProperties.keySet();
+        for (String key : keys) {
+          marshaller.setProperty(key, marshallerProperties.get(key));
+        }
+      }
 
       XMLStreamWriter xmlWriter = xmlOutputFactory.createXMLStreamWriter(
           buffer.outputStream(), JaxbConverterFactory.XML.charset().name());

--- a/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbRequestConverter.java
+++ b/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbRequestConverter.java
@@ -34,7 +34,8 @@ final class JaxbRequestConverter<T> implements Converter<T, RequestBody> {
   final Class<T> type;
   final Map<String, Object> marshallerProperties;
 
-  JaxbRequestConverter(JAXBContext context, Class<T> type, Map<String, Object> marshallerProperties) {
+  JaxbRequestConverter(JAXBContext context, Class<T> type,
+      Map<String, Object> marshallerProperties) {
     this.context = context;
     this.type = type;
     this.marshallerProperties = marshallerProperties;

--- a/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbResponseConverter.java
+++ b/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbResponseConverter.java
@@ -33,7 +33,8 @@ final class JaxbResponseConverter<T> implements Converter<ResponseBody, T> {
   final Class<T> type;
   final Map<String, Object> unmarshallerProperties;
 
-  JaxbResponseConverter(JAXBContext context, Class<T> type, Map<String, Object> unmarshallerProperties) {
+  JaxbResponseConverter(JAXBContext context, Class<T> type,
+      Map<String, Object> unmarshallerProperties) {
     this.context = context;
     this.type = type;
     this.unmarshallerProperties = unmarshallerProperties;

--- a/retrofit/src/main/java/retrofit2/Converter.java
+++ b/retrofit/src/main/java/retrofit2/Converter.java
@@ -20,8 +20,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import javax.annotation.Nullable;
-import javax.xml.bind.Marshaller;
-
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.http.Body;

--- a/retrofit/src/main/java/retrofit2/Converter.java
+++ b/retrofit/src/main/java/retrofit2/Converter.java
@@ -20,6 +20,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import javax.annotation.Nullable;
+import javax.xml.bind.Marshaller;
+
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.http.Body;


### PR DESCRIPTION
## Purpose

Some webservices I consume do not accept valid xml with the header line e.g. `<?xml version=\"1.0\" ?>`.  As such, having the ability to set properties for the marshaller was needed.  For completeness, though not all implementations have unmarshaller properties, I also included the ability to provide those properties as well.  

## Use

```
    Map<String, Object> marshallerProperties = new HashMap<>();
    marshallerProperties.put(Marshaller.JAXB_FRAGMENT, true);
```

What is needed is a map which has the property name for the key, and the setting for the value.  If the map is null or empty, JaxB defaults are used.

