### PR TITLE
Update link to moved repository

### DIFF
--- a/retrofit-converters/jaxb/README.md
+++ b/retrofit-converters/jaxb/README.md
@@ -28,7 +28,7 @@ Snapshots of the development version are available in [Sonatype's `snapshots` re
 
 
 
- [1]: https://github.com/javaee/jaxb-v2
- [2]: https://search.maven.org/remote_content?g=com.squareup.retrofit2&a=converter-jaxb&v=LATEST
- [3]: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.squareup.retrofit2%22%20a%3A%22converter-jaxb%22
- [snap]: https://oss.sonatype.org/content/repositories/snapshots/
+[1]: https://github.com/eclipse-ee4j/jaxb-ri
+[2]: https://search.maven.org/remote_content?g=com.squareup.retrofit2&amp;a=converter-jaxb&amp;v=LATEST
+[3]: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.squareup.retrofit2%22%20a%3A%22converter-jaxb%22
+[snap]: https://oss.sonatype.org/content/repositories/snapshots/


### PR DESCRIPTION
This project is now part of the EE4J initiative. This repository has been archived as all activities are now happening in the [corresponding Eclipse repository](https://github.com/eclipse-ee4j/jaxb-ri).

See [here](https://www.eclipse.org/ee4j/status.php) for the overall
EE4J transition status.