### PR TITLE
Handle 204/205 responses in RxJava 2 types

### DIFF
--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/BodyObservable.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/BodyObservable.java
@@ -51,11 +51,10 @@ final class BodyObservable<T> extends Observable<T> {
     }
 
     @Override public void onNext(Response<R> response) {
-      boolean noContent = errorOnNoContent
-          && (response.code() == 204 || response.code() == 205);
+      boolean noContent = response.code() == 204 || response.code() == 205;
       if (response.isSuccessful() && !noContent) {
         observer.onNext(response.body());
-      } else {
+      } else if (!noContent || errorOnNoContent) {
         terminated = true;
         Throwable t;
         if (noContent) {

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/NoContentException.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/NoContentException.java
@@ -16,6 +16,7 @@
 package retrofit2.adapter.rxjava2;
 
 import io.reactivex.Completable;
+import javax.annotation.Nullable;
 import retrofit2.Response;
 
 /** Exception for an unexpected, 204/205 HTTP response when not used with {@link Completable}. */
@@ -51,6 +52,7 @@ public final class NoContentException extends RuntimeException {
   /**
    * The full HTTP response. This may be null if the exception was serialized.
    */
+  @Nullable
   public Response<?> response() {
     return response;
   }

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/NoContentException.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/NoContentException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.adapter.rxjava2;
+
+import io.reactivex.Completable;
+import retrofit2.Response;
+
+/** Exception for an unexpected, 204/205 HTTP response when not used with {@link Completable}. */
+public final class NoContentException extends RuntimeException {
+  private static String getMessage(Response<?> response) {
+    if (response == null) {
+      throw new NullPointerException("response == null");
+    }
+    return "HTTP " + response.code() + " " + response.message();
+  }
+
+  private final int code;
+  private final String message;
+  private final transient Response<?> response;
+
+  public NoContentException(Response<?> response) {
+    super(getMessage(response));
+    this.code = response.code();
+    this.message = response.message();
+    this.response = response;
+  }
+
+  /** HTTP status code. */
+  public int code() {
+    return code;
+  }
+
+  /** HTTP status message. */
+  public String message() {
+    return message;
+  }
+
+  /**
+   * The full HTTP response. This may be null if the exception was serialized.
+   */
+  public Response<?> response() {
+    return response;
+  }
+}

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
@@ -63,7 +63,7 @@ final class RxJava2CallAdapter<R> implements CallAdapter<R, Object> {
     if (isResult) {
       observable = new ResultObservable<>(responseObservable);
     } else if (isBody) {
-      observable = new BodyObservable<>(responseObservable, !isCompletable);
+      observable = new BodyObservable<>(responseObservable, isSingle);
     } else {
       observable = responseObservable;
     }

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
@@ -63,7 +63,7 @@ final class RxJava2CallAdapter<R> implements CallAdapter<R, Object> {
     if (isResult) {
       observable = new ResultObservable<>(responseObservable);
     } else if (isBody) {
-      observable = new BodyObservable<>(responseObservable);
+      observable = new BodyObservable<>(responseObservable, !isCompletable);
     } else {
       observable = responseObservable;
     }

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/CompletableTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/CompletableTest.java
@@ -54,6 +54,22 @@ public final class CompletableTest {
     observer.assertComplete();
   }
 
+  @Test public void completableSuccess204() {
+    server.enqueue(new MockResponse().setResponseCode(204));
+
+    RecordingCompletableObserver observer = observerRule.create();
+    service.completable().subscribe(observer);
+    observer.assertComplete();
+  }
+
+  @Test public void completableSuccess205() {
+    server.enqueue(new MockResponse().setResponseCode(205));
+
+    RecordingCompletableObserver observer = observerRule.create();
+    service.completable().subscribe(observer);
+    observer.assertComplete();
+  }
+
   @Test public void completableSuccess404() {
     server.enqueue(new MockResponse().setResponseCode(404));
 

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/FlowableTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/FlowableTest.java
@@ -72,7 +72,7 @@ public final class FlowableTest {
 
     RecordingSubscriber<String> subscriber = subscriberRule.create();
     service.body().subscribe(subscriber);
-    subscriber.assertError(NoContentException.class, "HTTP 204 OK");
+    subscriber.assertComplete();
   }
 
   @Test public void bodySuccess205() {
@@ -80,7 +80,7 @@ public final class FlowableTest {
 
     RecordingSubscriber<String> subscriber = subscriberRule.create();
     service.body().subscribe(subscriber);
-    subscriber.assertError(NoContentException.class, "HTTP 205 OK");
+    subscriber.assertComplete();
   }
 
   @Test public void bodyFailure() {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/FlowableTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/FlowableTest.java
@@ -67,6 +67,22 @@ public final class FlowableTest {
     subscriber.assertError(HttpException.class, "HTTP 404 Client Error");
   }
 
+  @Test public void bodySuccess204() {
+    server.enqueue(new MockResponse().setResponseCode(204));
+
+    RecordingSubscriber<String> subscriber = subscriberRule.create();
+    service.body().subscribe(subscriber);
+    subscriber.assertError(NoContentException.class, "HTTP 204 OK");
+  }
+
+  @Test public void bodySuccess205() {
+    server.enqueue(new MockResponse().setResponseCode(205));
+
+    RecordingSubscriber<String> subscriber = subscriberRule.create();
+    service.body().subscribe(subscriber);
+    subscriber.assertError(NoContentException.class, "HTTP 205 OK");
+  }
+
   @Test public void bodyFailure() {
     server.enqueue(new MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST));
 

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/MaybeTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/MaybeTest.java
@@ -72,7 +72,7 @@ public final class MaybeTest {
 
     RecordingMaybeObserver<String> observer = observerRule.create();
     service.body().subscribe(observer);
-    observer.assertError(NoContentException.class, "HTTP 204 OK");
+    observer.assertComplete();
   }
 
   @Test public void bodySuccess205() {
@@ -80,7 +80,7 @@ public final class MaybeTest {
 
     RecordingMaybeObserver<String> observer = observerRule.create();
     service.body().subscribe(observer);
-    observer.assertError(NoContentException.class, "HTTP 205 OK");
+    observer.assertComplete();
   }
 
   @Test public void bodyFailure() {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/MaybeTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/MaybeTest.java
@@ -67,6 +67,22 @@ public final class MaybeTest {
     observer.assertError(HttpException.class, "HTTP 404 Client Error");
   }
 
+  @Test public void bodySuccess204() {
+    server.enqueue(new MockResponse().setResponseCode(204));
+
+    RecordingMaybeObserver<String> observer = observerRule.create();
+    service.body().subscribe(observer);
+    observer.assertError(NoContentException.class, "HTTP 204 OK");
+  }
+
+  @Test public void bodySuccess205() {
+    server.enqueue(new MockResponse().setResponseCode(205));
+
+    RecordingMaybeObserver<String> observer = observerRule.create();
+    service.body().subscribe(observer);
+    observer.assertError(NoContentException.class, "HTTP 205 OK");
+  }
+
   @Test public void bodyFailure() {
     server.enqueue(new MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST));
 

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableTest.java
@@ -74,7 +74,7 @@ public final class ObservableTest {
 
     RecordingObserver<String> observer = observerRule.create();
     service.body().subscribe(observer);
-    observer.assertError(NoContentException.class, "HTTP 204 OK");
+    observer.assertComplete();
   }
 
   @Test public void bodySuccess205() {
@@ -82,7 +82,7 @@ public final class ObservableTest {
 
     RecordingObserver<String> observer = observerRule.create();
     service.body().subscribe(observer);
-    observer.assertError(NoContentException.class, "HTTP 205 OK");
+    observer.assertComplete();
   }
 
   @Test public void bodyFailure() {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableTest.java
@@ -69,6 +69,22 @@ public final class ObservableTest {
     observer.assertError(HttpException.class, "HTTP 404 Client Error");
   }
 
+  @Test public void bodySuccess204() {
+    server.enqueue(new MockResponse().setResponseCode(204));
+
+    RecordingObserver<String> observer = observerRule.create();
+    service.body().subscribe(observer);
+    observer.assertError(NoContentException.class, "HTTP 204 OK");
+  }
+
+  @Test public void bodySuccess205() {
+    server.enqueue(new MockResponse().setResponseCode(205));
+
+    RecordingObserver<String> observer = observerRule.create();
+    service.body().subscribe(observer);
+    observer.assertError(NoContentException.class, "HTTP 205 OK");
+  }
+
   @Test public void bodyFailure() {
     server.enqueue(new MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST));
 

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/RecordingMaybeObserver.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/RecordingMaybeObserver.java
@@ -107,6 +107,14 @@ final class RecordingMaybeObserver<T> implements MaybeObserver<T> {
     assertThat(events).as("Unconsumed events found!").isEmpty();
   }
 
+  public void assertComplete() {
+    Notification<T> notification = takeNotification();
+    assertThat(notification.isOnComplete())
+        .as("Expected onCompleted event but was " + notification)
+        .isTrue();
+    assertNoEvents();
+  }
+
   public static final class Rule implements TestRule {
     final List<RecordingMaybeObserver<?>> subscribers = new ArrayList<>();
 

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/SingleTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/SingleTest.java
@@ -67,6 +67,22 @@ public final class SingleTest {
     observer.assertError(HttpException.class, "HTTP 404 Client Error");
   }
 
+  @Test public void bodySuccess204() {
+    server.enqueue(new MockResponse().setResponseCode(204));
+
+    RecordingSingleObserver<String> observer = observerRule.create();
+    service.body().subscribe(observer);
+    observer.assertError(NoContentException.class, "HTTP 204 OK");
+  }
+
+  @Test public void bodySuccess205() {
+    server.enqueue(new MockResponse().setResponseCode(205));
+
+    RecordingSingleObserver<String> observer = observerRule.create();
+    service.body().subscribe(observer);
+    observer.assertError(NoContentException.class, "HTTP 205 OK");
+  }
+
   @Test public void bodyFailure() {
     server.enqueue(new MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST));
 


### PR DESCRIPTION
This is a proposal implementation to address #2867.

The issue is two-fold

1 - Retrofit 2's RxJava 2 `BodyObservable` will, on 204/205 status codes, still try to send the `null` body into `Observer#onNext`, even though RxJava 2 does not allow nulls in the stream
2 - RxJava 2's `Single#fromObservable()` implementation does not null-check the onNext value, and instead just silently skips it. When an `onComplete` event comes from `BodyObserver` later, it then throws a `NoSuchElementException`

This tries to solve it by being aware of 204/205 status codes in `BodyObservable` and sending a new `NoContentException` through `onError` in these events instead of the obscured `null` into RxJava. `NoContentException` is basically identical to `HttpException` except that it's only for 204/205 codes and used to indicate that a 204/205 event happened in a non-`Completable` environment.

Other considerations made:
- Converter - not feasible because converters are not given a chance at 204/205 responses
- Forwarding call adapter - can work, but requires a lot of knowledge of how the underlying RxJava 2 adapter behaves and would (IMO) be something that's always required. Even if consumers before this had custom adapters to handle this, they can still lean on Retrofit and now catch a more concrete exception if they were trying to guess from an `onErrorResumeNext` or something similar.

Open questions: Unclear how to handle other `null`-body scenarios, such as a misbehaving converter.