### PR TITLE
Replace directly thrown exceptions with Utils.parameterError

### DIFF
--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -65,9 +65,9 @@ abstract class ParameterHandler<T> {
     }
 
     @Override void apply(RequestBuilder builder, @Nullable Object value) {
-      try{
+      try {
         checkNotNull(value, "@Url parameter is null.");
-      }catch (NullPointerException npe){
+      } catch (NullPointerException npe) {
         throw Utils.parameterError(method, npe, p, "@Url parameter is null.");
       }
       builder.setRelativeUrl(value);
@@ -111,7 +111,8 @@ abstract class ParameterHandler<T> {
 
     @Override void apply(RequestBuilder builder, @Nullable T value) throws IOException {
       if (value == null) {
-        throw Utils.parameterError(method, p, "Path parameter \"" + name + "\" value must not be null.");
+        throw Utils.parameterError(method, p,
+                "Path parameter \"" + name + "\" value must not be null.");
       }
       builder.addPathParam(name, valueConverter.convert(value), encoded);
     }
@@ -197,7 +198,7 @@ abstract class ParameterHandler<T> {
       }
     }
 
-    private void throwParameterError(String message){
+    private void throwParameterError(String message) {
       throw Utils.parameterError(method, p, message);
     }
   }
@@ -233,7 +234,7 @@ abstract class ParameterHandler<T> {
       }
     }
 
-    private void throwParameterError(String message){
+    private void throwParameterError(String message) {
       throw Utils.parameterError(method, p, message);
     }
   }
@@ -304,7 +305,7 @@ abstract class ParameterHandler<T> {
       }
     }
 
-    private void throwParameterError(String message){
+    private void throwParameterError(String message) {
       throw Utils.parameterError(method, p, message);
     }
   }
@@ -354,7 +355,8 @@ abstract class ParameterHandler<T> {
     private final Method method;
     private final int p;
 
-    PartMap(Method method, int p, Converter<T, RequestBody> valueConverter, String transferEncoding) {
+    PartMap(Method method, int p,
+            Converter<T, RequestBody> valueConverter, String transferEncoding) {
       this.valueConverter = valueConverter;
       this.transferEncoding = transferEncoding;
       this.method = method;
@@ -386,7 +388,7 @@ abstract class ParameterHandler<T> {
       }
     }
 
-    private void throwParameterError(String message){
+    private void throwParameterError(String message) {
       throw Utils.parameterError(method, p, message);
     }
   }

--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -65,7 +65,7 @@ abstract class ParameterHandler<T> {
     }
 
     @Override void apply(RequestBuilder builder, @Nullable Object value) {
-      if(value == null){
+      if (value == null) {
         throw Utils.parameterError(method, p, "@Url parameter is null.");
       }
       builder.setRelativeUrl(value);
@@ -174,16 +174,17 @@ abstract class ParameterHandler<T> {
       for (Map.Entry<String, T> entry : value.entrySet()) {
         String entryKey = entry.getKey();
         if (entryKey == null) {
-          throwParameterError("Query map contained null key.");
+          throw Utils.parameterError(method, p, "Query map contained null key.");
         }
         T entryValue = entry.getValue();
         if (entryValue == null) {
-          throwParameterError("Query map contained null value for key '" + entryKey + "'.");
+          throw Utils.parameterError(method, p,
+                  "Query map contained null value for key '" + entryKey + "'.");
         }
 
         String convertedEntryValue = valueConverter.convert(entryValue);
         if (convertedEntryValue == null) {
-          throwParameterError("Query map value '"
+          throw Utils.parameterError(method, p, "Query map value '"
               + entryValue
               + "' converted to null by "
               + valueConverter.getClass().getName()
@@ -194,10 +195,6 @@ abstract class ParameterHandler<T> {
 
         builder.addQueryParam(entryKey, convertedEntryValue, encoded);
       }
-    }
-
-    private void throwParameterError(String message) {
-      throw Utils.parameterError(method, p, message);
     }
   }
 
@@ -215,25 +212,21 @@ abstract class ParameterHandler<T> {
     @Override void apply(RequestBuilder builder, @Nullable Map<String, T> value)
         throws IOException {
       if (value == null) {
-        throwParameterError("Header map was null.");
+        throw Utils.parameterError(method, p, "Header map was null.");
       }
 
       for (Map.Entry<String, T> entry : value.entrySet()) {
         String headerName = entry.getKey();
         if (headerName == null) {
-          throwParameterError("Header map contained null key.");
+          throw Utils.parameterError(method, p, "Header map contained null key.");
         }
         T headerValue = entry.getValue();
         if (headerValue == null) {
-          throwParameterError(
-              "Header map contained null value for key '" + headerName + "'.");
+          throw Utils.parameterError(method, p,
+                  "Header map contained null value for key '" + headerName + "'.");
         }
         builder.addHeader(headerName, valueConverter.convert(headerValue));
       }
-    }
-
-    private void throwParameterError(String message) {
-      throw Utils.parameterError(method, p, message);
     }
   }
 
@@ -274,23 +267,23 @@ abstract class ParameterHandler<T> {
     @Override void apply(RequestBuilder builder, @Nullable Map<String, T> value)
         throws IOException {
       if (value == null) {
-        throwParameterError("Field map was null.");
+        throw Utils.parameterError(method, p, "Field map was null.");
       }
 
       for (Map.Entry<String, T> entry : value.entrySet()) {
         String entryKey = entry.getKey();
         if (entryKey == null) {
-          throwParameterError("Field map contained null key.");
+          throw Utils.parameterError(method, p, "Field map contained null key.");
         }
         T entryValue = entry.getValue();
         if (entryValue == null) {
-          throwParameterError(
-              "Field map contained null value for key '" + entryKey + "'.");
+          throw Utils.parameterError(method, p,
+                  "Field map contained null value for key '" + entryKey + "'.");
         }
 
         String fieldEntry = valueConverter.convert(entryValue);
         if (fieldEntry == null) {
-          throwParameterError("Field map value '"
+          throw Utils.parameterError(method, p, "Field map value '"
               + entryValue
               + "' converted to null by "
               + valueConverter.getClass().getName()
@@ -301,10 +294,6 @@ abstract class ParameterHandler<T> {
 
         builder.addFormField(entryKey, fieldEntry, encoded);
       }
-    }
-
-    private void throwParameterError(String message) {
-      throw Utils.parameterError(method, p, message);
     }
   }
 
@@ -364,18 +353,18 @@ abstract class ParameterHandler<T> {
     @Override void apply(RequestBuilder builder, @Nullable Map<String, T> value)
         throws IOException {
       if (value == null) {
-        throwParameterError("Part map was null.");
+        throw Utils.parameterError(method, p, "Part map was null.");
       }
 
       for (Map.Entry<String, T> entry : value.entrySet()) {
         String entryKey = entry.getKey();
         if (entryKey == null) {
-          throwParameterError("Part map contained null key.");
+          throw Utils.parameterError(method, p, "Part map contained null key.");
         }
         T entryValue = entry.getValue();
         if (entryValue == null) {
-          throwParameterError(
-              "Part map contained null value for key '" + entryKey + "'.");
+          throw Utils.parameterError(method, p,
+                  "Part map contained null value for key '" + entryKey + "'.");
         }
 
         Headers headers = Headers.of(
@@ -384,10 +373,6 @@ abstract class ParameterHandler<T> {
 
         builder.addPart(headers, valueConverter.convert(entryValue));
       }
-    }
-
-    private void throwParameterError(String message) {
-      throw Utils.parameterError(method, p, message);
     }
   }
 
@@ -414,6 +399,5 @@ abstract class ParameterHandler<T> {
       }
       builder.setBody(body);
     }
-
   }
 }

--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -65,10 +65,8 @@ abstract class ParameterHandler<T> {
     }
 
     @Override void apply(RequestBuilder builder, @Nullable Object value) {
-      try {
-        checkNotNull(value, "@Url parameter is null.");
-      } catch (NullPointerException npe) {
-        throw Utils.parameterError(method, npe, p, "@Url parameter is null.");
+      if(value == null){
+        throw Utils.parameterError(method, p, "@Url parameter is null.");
       }
       builder.setRelativeUrl(value);
     }

--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -94,19 +94,19 @@ abstract class ParameterHandler<T> {
   }
 
   static final class Path<T> extends ParameterHandler<T> {
+    private final Method method;
+    private final int p;
     private final String name;
     private final Converter<T, String> valueConverter;
     private final boolean encoded;
-    private final Method method;
-    private final int p;
 
 
     Path(Method method, int p, String name, Converter<T, String> valueConverter, boolean encoded) {
+      this.method = method;
+      this.p = p;
       this.name = checkNotNull(name, "name == null");
       this.valueConverter = valueConverter;
       this.encoded = encoded;
-      this.method = method;
-      this.p = p;
     }
 
     @Override void apply(RequestBuilder builder, @Nullable T value) throws IOException {
@@ -155,16 +155,16 @@ abstract class ParameterHandler<T> {
   }
 
   static final class QueryMap<T> extends ParameterHandler<Map<String, T>> {
-    private final Converter<T, String> valueConverter;
-    private final boolean encoded;
     private final Method method;
     private final int p;
+    private final Converter<T, String> valueConverter;
+    private final boolean encoded;
 
     QueryMap(Method method, int p, Converter<T, String> valueConverter, boolean encoded) {
-      this.valueConverter = valueConverter;
-      this.encoded = encoded;
       this.method = method;
       this.p = p;
+      this.valueConverter = valueConverter;
+      this.encoded = encoded;
     }
 
     @Override void apply(RequestBuilder builder, @Nullable Map<String, T> value)
@@ -204,14 +204,14 @@ abstract class ParameterHandler<T> {
   }
 
   static final class HeaderMap<T> extends ParameterHandler<Map<String, T>> {
-    private final Converter<T, String> valueConverter;
     private final Method method;
     private final int p;
+    private final Converter<T, String> valueConverter;
 
     HeaderMap(Method method, int p, Converter<T, String> valueConverter) {
-      this.valueConverter = valueConverter;
       this.method = method;
       this.p = p;
+      this.valueConverter = valueConverter;
     }
 
     @Override void apply(RequestBuilder builder, @Nullable Map<String, T> value)
@@ -261,16 +261,16 @@ abstract class ParameterHandler<T> {
   }
 
   static final class FieldMap<T> extends ParameterHandler<Map<String, T>> {
-    private final Converter<T, String> valueConverter;
-    private final boolean encoded;
     private final Method method;
     private final int p;
+    private final Converter<T, String> valueConverter;
+    private final boolean encoded;
 
     FieldMap(Method method, int p, Converter<T, String> valueConverter, boolean encoded) {
-      this.valueConverter = valueConverter;
-      this.encoded = encoded;
       this.method = method;
       this.p = p;
+      this.valueConverter = valueConverter;
+      this.encoded = encoded;
     }
 
     @Override void apply(RequestBuilder builder, @Nullable Map<String, T> value)
@@ -311,16 +311,16 @@ abstract class ParameterHandler<T> {
   }
 
   static final class Part<T> extends ParameterHandler<T> {
-    private final Headers headers;
-    private final Converter<T, RequestBody> converter;
     private final Method method;
     private final int p;
+    private final Headers headers;
+    private final Converter<T, RequestBody> converter;
 
     Part(Method method, int p, Headers headers, Converter<T, RequestBody> converter) {
-      this.headers = headers;
-      this.converter = converter;
       this.method = method;
       this.p = p;
+      this.headers = headers;
+      this.converter = converter;
     }
 
     @Override void apply(RequestBuilder builder, @Nullable T value) {
@@ -350,17 +350,17 @@ abstract class ParameterHandler<T> {
   }
 
   static final class PartMap<T> extends ParameterHandler<Map<String, T>> {
-    private final Converter<T, RequestBody> valueConverter;
-    private final String transferEncoding;
     private final Method method;
     private final int p;
+    private final Converter<T, RequestBody> valueConverter;
+    private final String transferEncoding;
 
     PartMap(Method method, int p,
             Converter<T, RequestBody> valueConverter, String transferEncoding) {
-      this.valueConverter = valueConverter;
-      this.transferEncoding = transferEncoding;
       this.method = method;
       this.p = p;
+      this.valueConverter = valueConverter;
+      this.transferEncoding = transferEncoding;
     }
 
     @Override void apply(RequestBuilder builder, @Nullable Map<String, T> value)
@@ -394,14 +394,14 @@ abstract class ParameterHandler<T> {
   }
 
   static final class Body<T> extends ParameterHandler<T> {
-    private final Converter<T, RequestBody> converter;
     private final Method method;
     private final int p;
+    private final Converter<T, RequestBody> converter;
 
     Body(Method method, int p, Converter<T, RequestBody> converter) {
-      this.converter = converter;
       this.method = method;
       this.p = p;
+      this.converter = converter;
     }
 
     @Override void apply(RequestBuilder builder, @Nullable T value) {

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -344,7 +344,7 @@ final class RequestFactory {
             || type == String.class
             || type == URI.class
             || (type instanceof Class && "android.net.Uri".equals(((Class<?>) type).getName()))) {
-          return new ParameterHandler.RelativeUrl();
+          return new ParameterHandler.RelativeUrl(method, p);
         } else {
           throw parameterError(method, p,
               "@Url must be okhttp3.HttpUrl, String, java.net.URI, or android.net.Uri type.");
@@ -375,7 +375,7 @@ final class RequestFactory {
         validatePathName(p, name);
 
         Converter<?, String> converter = retrofit.stringConverter(type, annotations);
-        return new ParameterHandler.Path<>(name, converter, path.encoded());
+        return new ParameterHandler.Path<>(method, p, name, converter, path.encoded());
 
       } else if (annotation instanceof Query) {
         validateResolvableType(p, type);
@@ -459,7 +459,7 @@ final class RequestFactory {
         Converter<?, String> valueConverter =
             retrofit.stringConverter(valueType, annotations);
 
-        return new ParameterHandler.QueryMap<>(valueConverter, ((QueryMap) annotation).encoded());
+        return new ParameterHandler.QueryMap<>(method, p, valueConverter, ((QueryMap) annotation).encoded());
 
       } else if (annotation instanceof Header) {
         validateResolvableType(p, type);
@@ -510,7 +510,7 @@ final class RequestFactory {
         Converter<?, String> valueConverter =
             retrofit.stringConverter(valueType, annotations);
 
-        return new ParameterHandler.HeaderMap<>(valueConverter);
+        return new ParameterHandler.HeaderMap<>(method, p, valueConverter);
 
       } else if (annotation instanceof Field) {
         validateResolvableType(p, type);
@@ -572,7 +572,7 @@ final class RequestFactory {
             retrofit.stringConverter(valueType, annotations);
 
         gotField = true;
-        return new ParameterHandler.FieldMap<>(valueConverter, ((FieldMap) annotation).encoded());
+        return new ParameterHandler.FieldMap<>(method, p, valueConverter, ((FieldMap) annotation).encoded());
 
       } else if (annotation instanceof Part) {
         validateResolvableType(p, type);
@@ -634,7 +634,7 @@ final class RequestFactory {
             }
             Converter<?, RequestBody> converter =
                 retrofit.requestBodyConverter(iterableType, annotations, methodAnnotations);
-            return new ParameterHandler.Part<>(headers, converter).iterable();
+            return new ParameterHandler.Part<>(method, p, headers, converter).iterable();
           } else if (rawParameterType.isArray()) {
             Class<?> arrayComponentType = boxIfPrimitive(rawParameterType.getComponentType());
             if (MultipartBody.Part.class.isAssignableFrom(arrayComponentType)) {
@@ -644,7 +644,7 @@ final class RequestFactory {
             }
             Converter<?, RequestBody> converter =
                 retrofit.requestBodyConverter(arrayComponentType, annotations, methodAnnotations);
-            return new ParameterHandler.Part<>(headers, converter).array();
+            return new ParameterHandler.Part<>(method, p, headers, converter).array();
           } else if (MultipartBody.Part.class.isAssignableFrom(rawParameterType)) {
             throw parameterError(method, p,
                 "@Part parameters using the MultipartBody.Part must not "
@@ -652,7 +652,7 @@ final class RequestFactory {
           } else {
             Converter<?, RequestBody> converter =
                 retrofit.requestBodyConverter(type, annotations, methodAnnotations);
-            return new ParameterHandler.Part<>(headers, converter);
+            return new ParameterHandler.Part<>(method, p, headers, converter);
           }
         }
 
@@ -689,7 +689,7 @@ final class RequestFactory {
             retrofit.requestBodyConverter(valueType, annotations, methodAnnotations);
 
         PartMap partMap = (PartMap) annotation;
-        return new ParameterHandler.PartMap<>(valueConverter, partMap.encoding());
+        return new ParameterHandler.PartMap<>(method, p, valueConverter, partMap.encoding());
 
       } else if (annotation instanceof Body) {
         validateResolvableType(p, type);
@@ -709,7 +709,7 @@ final class RequestFactory {
           throw parameterError(method, e, p, "Unable to create @Body converter for %s", type);
         }
         gotBody = true;
-        return new ParameterHandler.Body<>(converter);
+        return new ParameterHandler.Body<>(method, p, converter);
       }
 
       return null; // Not a Retrofit annotation.

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -459,7 +459,8 @@ final class RequestFactory {
         Converter<?, String> valueConverter =
             retrofit.stringConverter(valueType, annotations);
 
-        return new ParameterHandler.QueryMap<>(method, p, valueConverter, ((QueryMap) annotation).encoded());
+        return new ParameterHandler.QueryMap<>(method, p,
+                valueConverter, ((QueryMap) annotation).encoded());
 
       } else if (annotation instanceof Header) {
         validateResolvableType(p, type);
@@ -572,7 +573,8 @@ final class RequestFactory {
             retrofit.stringConverter(valueType, annotations);
 
         gotField = true;
-        return new ParameterHandler.FieldMap<>(method, p, valueConverter, ((FieldMap) annotation).encoded());
+        return new ParameterHandler.FieldMap<>(method, p,
+                valueConverter, ((FieldMap) annotation).encoded());
 
       } else if (annotation instanceof Part) {
         validateResolvableType(p, type);

--- a/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
@@ -488,7 +488,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, new Object[] { null });
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Query map was null.");
+      assertThat(e).hasMessage("Query map was null (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -508,7 +509,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, queryParams);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Query map contained null key.");
+      assertThat(e).hasMessage("Query map contained null key. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -528,7 +530,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, queryParams);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Query map contained null value for key 'kit'.");
+      assertThat(e).hasMessage("Query map contained null value for key 'kit'. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -601,7 +604,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, (Map<String, String>) null);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Header map was null.");
+      assertThat(e).hasMessage("Header map was null. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -621,7 +625,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, headers);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Header map contained null key.");
+      assertThat(e).hasMessage("Header map contained null key. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -641,7 +646,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, headers);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Header map contained null value for key 'Accept-Charset'.");
+      assertThat(e).hasMessage("Header map contained null value for key 'Accept-Charset'. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -971,7 +977,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, new Object[] { null });
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage()).isEqualTo("Path parameter \"ping\" value must not be null.");
+      assertThat(e.getMessage()).isEqualTo("Path parameter \"ping\" value must not be null. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -1683,7 +1690,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, new Object[] { null });
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage()).isEqualTo("Body parameter value must not be null.");
+      assertThat(e.getMessage()).isEqualTo("Body parameter value must not be null. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -2183,7 +2191,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, new Object[] { null });
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Part map was null.");
+      assertThat(e).hasMessage("Part map was null. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -2204,7 +2213,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, params);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Part map contained null key.");
+      assertThat(e).hasMessage("Part map contained null key. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -2225,7 +2235,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, params);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Part map contained null value for key 'kit'.");
+      assertThat(e).hasMessage("Part map contained null value for key 'kit'. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -2438,7 +2449,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, new Object[] { null });
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Field map was null.");
+      assertThat(e).hasMessage("Field map was null. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -2459,7 +2471,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, fieldMap);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Field map contained null key.");
+      assertThat(e).hasMessage("Field map contained null key. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 
@@ -2480,7 +2493,8 @@ public final class RequestFactoryTest {
       buildRequest(Example.class, fieldMap);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Field map contained null value for key 'foo'.");
+      assertThat(e).hasMessage("Field map contained null value for key 'foo'. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 

--- a/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
@@ -1456,8 +1456,9 @@ public final class RequestFactoryTest {
     try {
       buildRequest(Example.class, (HttpUrl) null);
       fail();
-    } catch (NullPointerException expected) {
-      assertThat(expected).hasMessage("@Url parameter is null.");
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("@Url parameter is null. (parameter #1)\n" +
+              "    for method Example.method");
     }
   }
 


### PR DESCRIPTION
Proposal of feature implementation regarding #2773.

It does not include the URL per say, but says exactly which defined method, from which class was the one which passed parameter was invalid. Which might be even more informative for issue mitigation.