### PR TITLE
Fatal errors should crash the dispatcher thread

### DIFF
--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/CallEnqueueObservable.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/CallEnqueueObservable.java
@@ -64,6 +64,7 @@ final class CallEnqueueObservable<T> extends Observable<Response<T>> {
           observer.onComplete();
         }
       } catch (Throwable t) {
+        Exceptions.throwIfFatal(t);
         if (terminated) {
           RxJavaPlugins.onError(t);
         } else if (!disposed) {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/AsyncTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/AsyncTest.java
@@ -22,10 +22,18 @@ import io.reactivex.functions.Consumer;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.Dispatcher;
+import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,7 +44,10 @@ import retrofit2.http.GET;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public final class AsyncTest {
   @Rule public final MockWebServer server = new MockWebServer();
@@ -46,12 +57,34 @@ public final class AsyncTest {
   }
 
   private Service service;
+  private List<Throwable> uncaughtExceptions = new ArrayList<>();
+
   @Before public void setUp() {
+    ExecutorService executorService = Executors.newCachedThreadPool(new ThreadFactory() {
+      @Override public Thread newThread(Runnable r) {
+        Thread thread = new Thread(r);
+        thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+          @Override public void uncaughtException(Thread t, Throwable e) {
+            uncaughtExceptions.add(e);
+          }
+        });
+        return thread;
+      }
+    });
+
+    OkHttpClient client = new OkHttpClient.Builder()
+        .dispatcher(new Dispatcher(executorService))
+        .build();
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl(server.url("/"))
+        .client(client)
         .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
         .build();
     service = retrofit.create(Service.class);
+  }
+
+  @After public void tearDown() {
+    assertTrue("Uncaught exceptions: " + uncaughtExceptions, uncaughtExceptions.isEmpty());
   }
 
   @Test public void success() throws InterruptedException {
@@ -129,5 +162,24 @@ public final class AsyncTest {
     //noinspection ThrowableResultOfMethodCallIgnored
     CompositeException composite = (CompositeException) pluginRef.get();
     assertThat(composite.getExceptions()).containsExactly(errorRef.get(), e);
+  }
+
+  @Test public void bodyThrowingFatalInOnErrorPropagates() throws InterruptedException {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    TestObserver<Void> observer = new TestObserver<>();
+    final Error e = new OutOfMemoryError("Not real");
+    service.completable().subscribe(new ForwardingCompletableObserver(observer) {
+      @Override public void onError(Throwable throwable) {
+        throw e;
+      }
+    });
+
+    latch.await(1, SECONDS);
+
+    assertEquals(1, uncaughtExceptions.size());
+    assertSame(e, uncaughtExceptions.remove(0));
   }
 }

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -128,7 +128,8 @@ final class OkHttpCall<T> implements Call<T> {
         try {
           callback.onResponse(OkHttpCall.this, response);
         } catch (Throwable t) {
-          t.printStackTrace();
+          throwIfFatal(t);
+          t.printStackTrace(); // TODO this is not great
         }
       }
 
@@ -140,7 +141,8 @@ final class OkHttpCall<T> implements Call<T> {
         try {
           callback.onFailure(OkHttpCall.this, e);
         } catch (Throwable t) {
-          t.printStackTrace();
+          throwIfFatal(t);
+          t.printStackTrace(); // TODO this is not great
         }
       }
     });


### PR DESCRIPTION
This is an imperfect fix as uncaught exceptions reaching OkHttpCall which are not fatal still only log, but most of the adapters are defending against anything getting this far already.

Also contained is a fix for the RxJava 2 async adapter. Non-200 responses delivered to the body observer would be forwarded to onError. If that callback threw a fatal exception, it would be re-delivered to the body observer despite it having already called a downstream terminal method. The fatal error should have been propagated by the async observer instead of attempting to make its way back downstream.

Closes #2994.