### PR TITLE
#3018 Fix dependency conflict issue for com.squareup.okio:okio

### DIFF
--- a/retrofit-converters/moshi/pom.xml
+++ b/retrofit-converters/moshi/pom.xml
@@ -31,7 +31,7 @@
 <dependency>
     	<groupId>com.squareup.okio</groupId>
       		<artifactId>okio</artifactId>
-      		<version>2.2.1</version>
+      		<version>1.16.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/retrofit-converters/moshi/pom.xml
+++ b/retrofit-converters/moshi/pom.xml
@@ -31,7 +31,7 @@
 <dependency>
     	<groupId>com.squareup.okio</groupId>
       		<artifactId>okio</artifactId>
-      		<version>1.15.0</version>
+      		<version>2.2.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/retrofit-converters/moshi/pom.xml
+++ b/retrofit-converters/moshi/pom.xml
@@ -22,6 +22,12 @@
     <dependency>
       <groupId>com.squareup.moshi</groupId>
       <artifactId>moshi</artifactId>
+      <exclusions>
+      	<exclusion>
+      		<groupId>com.squareup.okio</groupId>
+      		<artifactId>okio</artifactId>
+      	</exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/retrofit-converters/moshi/pom.xml
+++ b/retrofit-converters/moshi/pom.xml
@@ -31,7 +31,7 @@
 <dependency>
     	<groupId>com.squareup.okio</groupId>
       		<artifactId>okio</artifactId>
-      		<version>1.16.1</version>
+      		<version>1.16.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/retrofit-converters/moshi/pom.xml
+++ b/retrofit-converters/moshi/pom.xml
@@ -28,7 +28,11 @@
       <artifactId>jsr305</artifactId>
       <scope>provided</scope>
     </dependency>
-
+<dependency>
+    	<groupId>com.squareup.okio</groupId>
+      		<artifactId>okio</artifactId>
+      		<version>1.15.0</version>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/retrofit-converters/moshi/pom.xml
+++ b/retrofit-converters/moshi/pom.xml
@@ -22,12 +22,6 @@
     <dependency>
       <groupId>com.squareup.moshi</groupId>
       <artifactId>moshi</artifactId>
-      <exclusions>
-      	<exclusion>
-      		<groupId>com.squareup.okio</groupId>
-      		<artifactId>okio</artifactId>
-      	</exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
#3018 Fix dependency conflict issue for com.squareup.okio:okio. (conflict version:1.13.0:-1.15.0)
Dependency tree after revision:

[INFO] com.squareup.retrofit2:converter-moshi:jar:2.5.0
[INFO] +- com.squareup.retrofit2:retrofit:jar:2.5.0:compile
[INFO] |  \- com.squareup.okhttp3:okhttp:jar:3.12.0:compile
[INFO] |     **\- com.squareup.okio:okio:jar:1.15.0:compile**
[INFO] +- com.squareup.moshi:moshi:jar:1.5.0:compile
[INFO] +- com.google.code.findbugs:jsr305:jar:3.0.2:provided
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- com.squareup.okhttp3:mockwebserver:jar:3.12.0:test
[INFO] |  +- (com.squareup.okhttp3:okhttp:jar:3.12.0:test - omitted for duplicate)
[INFO] |  \- (junit:junit:jar:4.12:test - omitted for duplicate)
[INFO] \- org.assertj:assertj-core:jar:1.7.0:test
