### PR TITLE
Add more attributes to Retrofit's R8/ProGuard rules

### DIFF
--- a/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -2,6 +2,9 @@
 # EnclosingMethod is required to use InnerClasses.
 -keepattributes Signature, InnerClasses, EnclosingMethod
 
+# Retrofit does reflection on method and parameter annotations.
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+
 # Retain service method parameters when optimizing.
 -keepclassmembers,allowshrinking,allowobfuscation interface * {
     @retrofit2.http.* <methods>;


### PR DESCRIPTION
Usually these are supplied by things like the defaults from the Android SDK, but if you are not using those then Retrofit will fail. Seems like we should be including a complete set rather than assuming any defaults.