### PR TITLE
Upgrade to OkHttp 3.14.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <!-- Dependencies -->
     <android.version>4.1.1.4</android.version>
-    <okhttp.version>3.12.0</okhttp.version>
+    <okhttp.version>3.14.0</okhttp.version>
     <kotlinx.coroutines.version>1.1.0</kotlinx.coroutines.version>
     <animal.sniffer.version>1.14</animal.sniffer.version>
 


### PR DESCRIPTION
This causes Retrofit to itself require Java 8 or Android 5+. We may want to avoid
merging this PR until there is a feature in OkHttp 3.14 compelling enough to
break support for Android 4.x.