### PR TITLE
Remove serviceMethodCache synchronized lock

### DIFF
--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -163,12 +163,10 @@ public final class Retrofit {
     ServiceMethod<?> result = serviceMethodCache.get(method);
     if (result != null) return result;
 
-    synchronized (serviceMethodCache) {
-      result = serviceMethodCache.get(method);
-      if (result == null) {
-        result = ServiceMethod.parseAnnotations(this, method);
-        serviceMethodCache.put(method, result);
-      }
+    result = serviceMethodCache.get(method);
+    if (result == null) {
+      result = new ServiceMethod.Builder<>(this, method).build();
+      serviceMethodCache.put(method, result);
     }
     return result;
   }


### PR DESCRIPTION
serviceMethodCache now is Thread-safe's ConcurrentHashMap, so the performance is better if delete the sync lock