### PR TITLE
`URL` overload for `Retrofit.Builder#baseUrl`

### DIFF
--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -459,7 +459,7 @@ public final class Retrofit {
       checkNotNull(baseUrl, "baseUrl == null");
       return baseUrl(HttpUrl.get(baseUrl.toString()));
     }
-    
+
     /**
      * Set the API base URL.
      *

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -449,6 +450,16 @@ public final class Retrofit {
       return this;
     }
 
+    /**
+     * Set the API base URL.
+     *
+     * @see #baseUrl(HttpUrl)
+     */
+    public Builder baseUrl(URL baseUrl) {
+      checkNotNull(baseUrl, "baseUrl == null");
+      return baseUrl(HttpUrl.get(baseUrl.toString()));
+    }
+    
     /**
      * Set the API base URL.
      *


### PR DESCRIPTION
Functionally does nothing, just somewhat cleaner to be able to do `baseUrl(URL)` than `baseUrl(URL#toString());` if handling a `URL` rather than `String`.
Used `HttpUrl.get(String)` as `HttpUrl.get(URL)` returns null instead of throwing an exception.