### PR TITLE
Fix missing body in raw response for error

### DIFF
--- a/retrofit/src/main/java/retrofit2/Response.java
+++ b/retrofit/src/main/java/retrofit2/Response.java
@@ -85,6 +85,7 @@ public final class Response<T> {
   public static <T> Response<T> error(int code, ResponseBody body) {
     if (code < 400) throw new IllegalArgumentException("code < 400: " + code);
     return error(body, new okhttp3.Response.Builder() //
+        .body(body)
         .code(code)
         .message("Response.error()")
         .protocol(Protocol.HTTP_1_1)

--- a/retrofit/src/main/java/retrofit2/Response.java
+++ b/retrofit/src/main/java/retrofit2/Response.java
@@ -85,7 +85,7 @@ public final class Response<T> {
   public static <T> Response<T> error(int code, ResponseBody body) {
     if (code < 400) throw new IllegalArgumentException("code < 400: " + code);
     return error(body, new okhttp3.Response.Builder() //
-        .body(body)
+        .body(new OkHttpCall.NoContentResponseBody(body.contentType(), body.contentLength()))
         .code(code)
         .message("Response.error()")
         .protocol(Protocol.HTTP_1_1)

--- a/retrofit/src/test/java/retrofit2/ResponseTest.java
+++ b/retrofit/src/test/java/retrofit2/ResponseTest.java
@@ -122,6 +122,7 @@ public final class ResponseTest {
     ResponseBody errorBody = ResponseBody.create(null, "Broken!");
     Response<?> response = Response.error(400, errorBody);
     assertThat(response.raw()).isNotNull();
+    assertThat(response.raw().body()).isNotNull();
     assertThat(response.code()).isEqualTo(400);
     assertThat(response.message()).isEqualTo("Response.error()");
     assertThat(response.headers().size()).isZero();


### PR DESCRIPTION
Context: for some of our tests, we use `Response.error()` to mock an error response from the server. We are attempting to then call `response.raw().body()` and it comes back as null, due to the fact that the body is not getting set on the raw OkHttp response. 