### PR TITLE
Allow service interfaces to extend other interfaces

### DIFF
--- a/retrofit/src/main/java/retrofit2/Utils.java
+++ b/retrofit/src/main/java/retrofit2/Utils.java
@@ -317,18 +317,6 @@ final class Utils {
     return ResponseBody.create(body.contentType(), body.contentLength(), buffer);
   }
 
-  static <T> void validateServiceInterface(Class<T> service) {
-    if (!service.isInterface()) {
-      throw new IllegalArgumentException("API declarations must be interfaces.");
-    }
-    // Prevent API interfaces from extending other interfaces. This not only avoids a bug in
-    // Android (http://b.android.com/58753) but it forces composition of API declarations which is
-    // the recommended pattern.
-    if (service.getInterfaces().length > 0) {
-      throw new IllegalArgumentException("API interfaces must not extend other interfaces.");
-    }
-  }
-
   static Type getParameterUpperBound(int index, ParameterizedType type) {
     Type[] types = type.getActualTypeArguments();
     if (index < 0 || index >= types.length) {

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -85,6 +85,10 @@ public final class RetrofitTest {
   }
   interface Extending extends CallMethod {
   }
+  interface TypeParam<T> {
+  }
+  interface ExtendingTypeParam extends TypeParam<String> {
+  }
   interface StringService {
     @GET("/") String get();
   }
@@ -129,15 +133,47 @@ public final class RetrofitTest {
     assertThat(example.toString()).isNotEmpty();
   }
 
-  @Test public void interfaceWithExtendIsNotSupported() {
+  @Test public void interfaceWithTypeParameterThrows() {
     Retrofit retrofit = new Retrofit.Builder()
         .baseUrl(server.url("/"))
         .build();
+
+    server.enqueue(new MockResponse().setBody("Hi"));
+
     try {
-      retrofit.create(Extending.class);
+      retrofit.create(TypeParam.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("API interfaces must not extend other interfaces.");
+      assertThat(e).hasMessage("Type parameters are unsupported on retrofit2.RetrofitTest$TypeParam");
+    }
+  }
+
+  @Test public void interfaceWithExtend() throws IOException {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .build();
+
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    Extending extending = retrofit.create(Extending.class);
+    String result = extending.getResponseBody().execute().body().string();
+    assertEquals("Hi", result);
+  }
+
+  @Test public void interfaceWithExtendWithTypeParameterThrows() {
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .build();
+
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    try {
+      retrofit.create(ExtendingTypeParam.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(
+          "Type parameters are unsupported on retrofit2.RetrofitTest$TypeParam "
+              + "which is an interface of retrofit2.RetrofitTest$ExtendingTypeParam");
     }
   }
 


### PR DESCRIPTION
With a higher minSdkVersion, the bug which prevented this on Android no longer exists.

Closes #504.