### PR TITLE
Avoid synchronous checked exceptions in 'suspend fun's

### DIFF
--- a/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
@@ -186,9 +186,22 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
 
       //noinspection unchecked Checked by reflection inside RequestFactory.
       Continuation<ResponseT> continuation = (Continuation<ResponseT>) args[args.length - 1];
-      return isNullable
-          ? KotlinExtensions.awaitNullable(call, continuation)
-          : KotlinExtensions.await(call, continuation);
+
+      // Calls to OkHttp Call.enqueue() like those inside await and awaitNullable can sometimes
+      // invoke the supplied callback with an exception before the invoking stack frame can return.
+      // Coroutines will intercept the subsequent invocation of the Continuation and throw the
+      // exception synchronously. A Java Proxy cannot throw checked exceptions without them being
+      // declared on the interface method. To avoid the synchronous checked exception being wrapped
+      // in an UndeclaredThrowableException, it is intercepted and supplied to a helper which will
+      // force suspension to occur so that it can be instead delivered to the continuation to
+      // bypass this restriction.
+      try {
+        return isNullable
+            ? KotlinExtensions.awaitNullable(call, continuation)
+            : KotlinExtensions.await(call, continuation);
+      } catch (Exception e) {
+        return KotlinExtensions.yieldAndThrow(e, continuation);
+      }
     }
   }
 }

--- a/retrofit/src/main/java/retrofit2/KotlinExtensions.kt
+++ b/retrofit/src/main/java/retrofit2/KotlinExtensions.kt
@@ -19,6 +19,7 @@
 package retrofit2
 
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.yield
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -94,4 +95,9 @@ suspend fun <T : Any> Call<T>.awaitResponse(): Response<T> {
       }
     })
   }
+}
+
+internal suspend fun Exception.yieldAndThrow(): Nothing {
+  yield()
+  throw this
 }


### PR DESCRIPTION
Because of a race condition caused by thread preemption, this can sometimes happen. Explicitly yield to ensure the exception is delivered asynchronously to the continuation.

Closes #3128.