### PR TITLE
Lazily get gson TypeAdapter in GsonResponseBodyConverter

### DIFF
--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonConverterFactory.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonConverterFactory.java
@@ -61,8 +61,7 @@ public final class GsonConverterFactory extends Converter.Factory {
   @Override
   public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
       Retrofit retrofit) {
-    TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
-    return new GsonResponseBodyConverter<>(gson, adapter);
+    return new GsonResponseBodyConverter<>(gson, TypeToken.get(type));
   }
 
   @Override

--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonResponseBodyConverter.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonResponseBodyConverter.java
@@ -18,6 +18,7 @@ package retrofit2.converter.gson;
 import com.google.gson.Gson;
 import com.google.gson.JsonIOException;
 import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import java.io.IOException;
@@ -26,14 +27,20 @@ import retrofit2.Converter;
 
 final class GsonResponseBodyConverter<T> implements Converter<ResponseBody, T> {
   private final Gson gson;
-  private final TypeAdapter<T> adapter;
+  private final TypeToken<T> typeToken;
+  private TypeAdapter<T> adapter;
 
-  GsonResponseBodyConverter(Gson gson, TypeAdapter<T> adapter) {
+  GsonResponseBodyConverter(Gson gson, TypeToken<T> typeToken) {
     this.gson = gson;
-    this.adapter = adapter;
+    this.typeToken = typeToken;
   }
 
   @Override public T convert(ResponseBody value) throws IOException {
+    TypeAdapter<T> adapter = this.adapter;
+    if (adapter == null) {
+      adapter = gson.getAdapter(typeToken);
+      this.adapter = adapter;
+    }
     JsonReader jsonReader = gson.newJsonReader(value.charStream());
     try {
       T result = adapter.read(jsonReader);


### PR DESCRIPTION
`Gson.getAdapter` usually creates a TypeAdapter from `ReflectiveTypeAdapterFactory`, which uses reflection to scan all fields immediately, can cost a lot of time. And it makes thing worse that the scanning goes through types of fields recursively as well.
We usually use an asynchronous CallAdapter, because we want the time-costing work to be done on worker threads. Method `Converter.Factory.responseBodyConverter` is called on the caller thread (e.g. Android UI thread), while method `Converter.convert` is called on the scheduled worker thread. So moving the time-costing `Gson.getAdapter` call from `responseBodyConverter` to `convert` should reduce blocking time on the caller thread.