### PR TITLE
Add request URL to HttpException's message

### DIFF
--- a/retrofit-adapters/guava/src/test/java/retrofit2/adapter/guava/ListenableFutureTest.java
+++ b/retrofit-adapters/guava/src/test/java/retrofit2/adapter/guava/ListenableFutureTest.java
@@ -68,7 +68,7 @@ public final class ListenableFutureTest {
       assertThat(e.getCause())
           .isInstanceOf(HttpException.class) // Required for backwards compatibility.
           .isInstanceOf(retrofit2.HttpException.class)
-          .hasMessage("HTTP 404 Client Error");
+          .hasMessage("HTTP 404 Client Error from " + server.url("/"));
     }
   }
 

--- a/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/CompletableFutureTest.java
+++ b/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/CompletableFutureTest.java
@@ -68,7 +68,7 @@ public final class CompletableFutureTest {
       assertThat(e.getCause())
           .isInstanceOf(HttpException.class) // Required for backwards compatibility.
           .isInstanceOf(retrofit2.HttpException.class)
-          .hasMessage("HTTP 404 Client Error");
+          .hasMessage("HTTP 404 Client Error from " + server.url("/"));
     }
   }
 

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/CompletableTest.java
@@ -61,7 +61,7 @@ public final class CompletableTest {
     RecordingSubscriber<Void> subscriber = subscriberRule.create();
     service.completable().unsafeSubscribe(subscriber);
     // Required for backwards compatibility.
-    subscriber.assertError(HttpException.class, "HTTP 404 Client Error");
+    subscriber.assertError(HttpException.class, "HTTP 404 Client Error from " + server.url("/"));
   }
 
   @Test public void completableFailure() {

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/ObservableTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/ObservableTest.java
@@ -66,7 +66,7 @@ public final class ObservableTest {
     RecordingSubscriber<String> subscriber = subscriberRule.create();
     service.body().unsafeSubscribe(subscriber);
     // Required for backwards compatibility.
-    subscriber.assertError(HttpException.class, "HTTP 404 Client Error");
+    subscriber.assertError(HttpException.class, "HTTP 404 Client Error from " + server.url("/"));
   }
 
   @Test public void bodyFailure() {

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/SingleTest.java
@@ -66,7 +66,7 @@ public final class SingleTest {
     RecordingSubscriber<String> subscriber = subscriberRule.create();
     service.body().unsafeSubscribe(subscriber);
     // Required for backwards compatibility.
-    subscriber.assertError(HttpException.class, "HTTP 404 Client Error");
+    subscriber.assertError(HttpException.class, "HTTP 404 Client Error from " + server.url("/"));
   }
 
   @Test public void bodyFailure() {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/CompletableTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/CompletableTest.java
@@ -60,7 +60,7 @@ public final class CompletableTest {
     RecordingCompletableObserver observer = observerRule.create();
     service.completable().subscribe(observer);
     // Required for backwards compatibility.
-    observer.assertError(HttpException.class, "HTTP 404 Client Error");
+    observer.assertError(HttpException.class, "HTTP 404 Client Error from " + server.url("/"));
   }
 
   @Test public void completableFailure() {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/FlowableTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/FlowableTest.java
@@ -64,7 +64,7 @@ public final class FlowableTest {
     RecordingSubscriber<String> subscriber = subscriberRule.create();
     service.body().subscribe(subscriber);
     // Required for backwards compatibility.
-    subscriber.assertError(HttpException.class, "HTTP 404 Client Error");
+    subscriber.assertError(HttpException.class, "HTTP 404 Client Error from " + server.url("/"));
   }
 
   @Test public void bodyFailure() {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/MaybeTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/MaybeTest.java
@@ -64,7 +64,7 @@ public final class MaybeTest {
     RecordingMaybeObserver<String> observer = observerRule.create();
     service.body().subscribe(observer);
     // Required for backwards compatibility.
-    observer.assertError(HttpException.class, "HTTP 404 Client Error");
+    observer.assertError(HttpException.class, "HTTP 404 Client Error from " + server.url("/"));
   }
 
   @Test public void bodyFailure() {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/ObservableTest.java
@@ -65,7 +65,7 @@ public final class ObservableTest {
     RecordingObserver<String> observer = observerRule.create();
     service.body().subscribe(observer);
     // Required for backwards compatibility.
-    observer.assertError(HttpException.class, "HTTP 404 Client Error");
+    observer.assertError(HttpException.class, "HTTP 404 Client Error from " + server.url("/"));
   }
 
   @Test public void bodyFailure() {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/SingleTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/SingleTest.java
@@ -64,7 +64,7 @@ public final class SingleTest {
     RecordingSingleObserver<String> observer = observerRule.create();
     service.body().subscribe(observer);
     // Required for backwards compatibility.
-    observer.assertError(HttpException.class, "HTTP 404 Client Error");
+    observer.assertError(HttpException.class, "HTTP 404 Client Error from " + server.url("/"));
   }
 
   @Test public void bodyFailure() {

--- a/retrofit-adapters/scala/src/test/java/retrofit2/adapter/scala/FutureTest.java
+++ b/retrofit-adapters/scala/src/test/java/retrofit2/adapter/scala/FutureTest.java
@@ -72,7 +72,7 @@ public final class FutureTest {
       assertThat(e)
           .isInstanceOf(HttpException.class) // Required for backwards compatibility.
           .isInstanceOf(retrofit2.HttpException.class)
-          .hasMessage("HTTP 404 Client Error");
+          .hasMessage("HTTP 404 Client Error from " + server.url("/"));
     }
   }
 

--- a/retrofit/src/main/java/retrofit2/HttpException.java
+++ b/retrofit/src/main/java/retrofit2/HttpException.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
 public class HttpException extends RuntimeException {
   private static String getMessage(Response<?> response) {
     Objects.requireNonNull(response, "response == null");
-    return "HTTP " + response.code() + " " + response.message();
+    return "HTTP " + response.code() + " " + response.message() + " from " + response.raw().request().url();
   }
 
   private final int code;

--- a/retrofit/src/test/java/retrofit2/CompletableFutureTest.java
+++ b/retrofit/src/test/java/retrofit2/CompletableFutureTest.java
@@ -66,7 +66,7 @@ public final class CompletableFutureTest {
       assertThat(e.getCause())
           .isInstanceOf(HttpException.class) // Required for backwards compatibility.
           .isInstanceOf(HttpException.class)
-          .hasMessage("HTTP 404 Client Error");
+          .hasMessage("HTTP 404 Client Error from " + server.url("/"));
     }
   }
 


### PR DESCRIPTION
`HttpExceptions` can currently be difficult to track down depending on how an application makes HTTP calls and which call adapters the application is using.

For example, an application using the RxJava2 call adapter might see a stacktrace that looks something like this in Firebase or other similar reporting tools:

```
retrofit2.adapter.rxjava2.HttpException: HTTP 403 
       at retrofit2.adapter.rxjava2.BodyObservable$BodyObserver.onNext(BodyObservable.java:54)
       at retrofit2.adapter.rxjava2.BodyObservable$BodyObserver.onNext(BodyObservable.java:37)
       at retrofit2.adapter.rxjava2.CallEnqueueObservable$CallCallback.onResponse(CallEnqueueObservable.java:60)
       at retrofit2.OkHttpCall$1.onResponse(OkHttpCall.java:129)
       at okhttp3.RealCall$AsyncCall.execute(RealCall.java:174)
       at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
       at java.lang.Thread.run(Thread.java:764)
```

There is very little context for a developer to use to identify the cause since no client code is in the stack trace and the `HttpException` could have come from any Retrofit HTTP call.

This PR aims to address that problem by including the request URL in the exception's message. While clients could previously access that by catching the `HttpException` and performing that logging manually, this makes the default behavior for `HttpException` more helpful.