### PR TITLE
Correcting RxJavaCallAdapterFactory.createAsync() Javadoc

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactory.java
@@ -67,8 +67,7 @@ public final class RxJavaCallAdapterFactory extends CallAdapter.Factory {
   }
 
   /**
-   * Returns an instance which creates asynchronous observables. Applying
-   * {@link Observable#subscribeOn} has no effect on stream types created by this factory.
+   * Returns an instance which creates asynchronous observables.
    */
   public static RxJavaCallAdapterFactory createAsync() {
     return new RxJavaCallAdapterFactory(null, true);

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java
@@ -65,8 +65,7 @@ public final class RxJava2CallAdapterFactory extends CallAdapter.Factory {
   }
 
   /**
-   * Returns an instance which creates asynchronous observables. Applying
-   * {@link Observable#subscribeOn} has no effect on stream types created by this factory.
+   * Returns an instance which creates asynchronous observables.
    */
   public static RxJava2CallAdapterFactory createAsync() {
     return new RxJava2CallAdapterFactory(null, true);


### PR DESCRIPTION
Existing javadoc for `createAsync()` states
```
  /**
   * Returns an instance which creates asynchronous observables. Applying
   * {@link Observable#subscribeOn} has no effect on stream types created by this factory.
   */
```
This is incorrect - although the HTTP call will happen on a background thread and shift subsequent Observable operations onto OkHttp's thread pool, it still performs _subscribeOn_ actions on whatever thread calls into retrofit.

Example

```
class FooClient(client: OkHttpClient) {
  private val api = Retrofit.Builder()
         .baseUrl("https://www.foo.com/")
         .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
         .callFactory { client.newCall(it) }
         .build()
         .create(FooApi::class.java)

  fun getFoo(): Single<Foo> {
    // Assume this is being called on the main thread
    return api.getFoo()
        .doOnSubscribe { /* this will happen on the main thread */ }
        .doOnSuccess { /* this will happen on okhttp thread */ }
  }

  fun getFooSubscribeOn(): Single<Foo> {
    // Assume this is being called on the main thread
    return getFoo()
        .subscribeOn(Schedulers.io())
        .doOnSubscribe { /* this will happen on the io thread pool */ }
        .doOnSuccess { /* this will happen on okhttp thread */ }
}

interface FooApi {
  @GET("foo/api")
  fun getFoo(): Single<Foo>
}
```

The onSubscribe actions will still be called on the main thread, which goes counter to what the javadoc on `createAsync()` says - `subscribeOn` will absolutely have an effect on how the created Observable behaves. This threw me for a loop when I was attempting to allow `callFactory { client.newCall(it) }` to [operate on the background thread](https://www.zacsweers.dev/dagger-party-tricks-deferred-okhttp-init/) instead of the main thread. I had to change it to use `createWithScheduler()` to get that to work.

I'm not sure if it's worth detailing this behavior in the javadoc or not, so I just went with the simplest phrasing here. I'm happy to add more detail or change this doc any way you think is best. 
