### PR TITLE
Add error body to HttpException for easier debugging

### DIFF
--- a/retrofit/src/main/java/retrofit2/HttpException.java
+++ b/retrofit/src/main/java/retrofit2/HttpException.java
@@ -22,17 +22,21 @@ import javax.annotation.Nullable;
 public class HttpException extends RuntimeException {
   private static String getMessage(Response<?> response) {
     Objects.requireNonNull(response, "response == null");
-    return "HTTP " + response.code() + " " + response.message();
+    String maybeErrorBody = response.errorBody()
+        != null ? " " + response.errorBody().string() : "";
+    return "HTTP " + response.code() + " " + response.message() + maybeErrorBody;
   }
 
   private final int code;
   private final String message;
+  private final String errorBody;
   private final transient Response<?> response;
 
   public HttpException(Response<?> response) {
     super(getMessage(response));
     this.code = response.code();
     this.message = response.message();
+    this.errorBody = response.errorBody() != null ? response.errorBody().string() : "";
     this.response = response;
   }
 
@@ -45,6 +49,9 @@ public class HttpException extends RuntimeException {
   public String message() {
     return message;
   }
+
+  /** HTTP error body. */
+  public String errorBody() { return errorBody; }
 
   /**
    * The full HTTP response. This may be null if the exception was serialized.


### PR DESCRIPTION
HttpExceptions are difficult to pinpoint to a specific call or what the underlying error was even though it may be present in the response.

Adding the `errorBody` to `HttpException` reveals more information that can be relevant and vital for debugging.

For example, this response includes more details in the body of why it is a bad request but that doesn't show up in the HttpException.

```
retrofit2.adapter.rxjava2.HttpException: HTTP 400 
       at retrofit2.adapter.rxjava2.BodyObservable$BodyObserver.onNext(BodyObservable.java:54)
       at retrofit2.adapter.rxjava2.BodyObservable$BodyObserver.onNext(BodyObservable.java:37)
       at retrofit2.adapter.rxjava2.CallEnqueueObservable$CallCallback.onResponse(CallEnqueueObservable.java:60)
       at retrofit2.OkHttpCall$1.onResponse(OkHttpCall.java:129)
       at okhttp3.RealCall$AsyncCall.execute(RealCall.java:174)
       at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
       at java.lang.Thread.run(Thread.java:764)
```