### PR TITLE
Test may fail due to a different order of items in XML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
     <junit.version>4.12</junit.version>
     <assertj.version>3.13.2</assertj.version>
     <robolectric.version>3.8</robolectric.version><!-- 4.3 requires com.android.support:support-annotations:jar:28.0.0 -->
+    <xmlunitcore.version>2.2.1</xmlunitcore.version>
+    <xmlunitmatchers.version>2.2.1</xmlunitmatchers.version>
   </properties>
 
   <scm>

--- a/retrofit-converters/jaxb/pom.xml
+++ b/retrofit-converters/jaxb/pom.xml
@@ -44,6 +44,18 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-core</artifactId>
+      <version>${xmlunitcore.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+       <groupId>org.xmlunit</groupId>
+       <artifactId>xmlunit-matchers</artifactId>
+       <version>${xmlunitmatchers.version}</version>
+       <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/retrofit-converters/jaxb/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
+++ b/retrofit-converters/jaxb/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
@@ -23,6 +23,8 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
 import retrofit2.Call;
 import retrofit2.Response;
 import retrofit2.Retrofit;
@@ -32,6 +34,8 @@ import retrofit2.http.POST;
 
 import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 public final class JaxbConverterFactoryTest {
   static final Contact SAMPLE_CONTACT = new Contact("Jenny",
@@ -72,7 +76,8 @@ public final class JaxbConverterFactoryTest {
 
     RecordedRequest request = server.takeRequest();
     assertThat(request.getHeader("Content-Type")).isEqualTo("application/xml; charset=utf-8");
-    assertThat(request.getBody().readUtf8()).isEqualTo(SAMPLE_CONTACT_XML);
+    assertThat(request.getBody().readUtf8(), isSimilarTo(SAMPLE_CONTACT_XML).ignoreWhitespace()
+                     .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
   }
 
   @Test public void xmlResponseBody() throws Exception {
@@ -114,7 +119,8 @@ public final class JaxbConverterFactoryTest {
 
     RecordedRequest request = server.takeRequest();
     assertThat(request.getHeader("Content-Type")).isEqualTo("application/xml; charset=utf-8");
-    assertThat(request.getBody().readUtf8()).isEqualTo(SAMPLE_CONTACT_XML);
+    assertThat(request.getBody().readUtf8(), isSimilarTo(SAMPLE_CONTACT_XML).ignoreWhitespace()
+                   .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
   }
 
   @Test public void malformedXml() throws Exception {


### PR DESCRIPTION
Tests `xmlRequestBody` and `userSuppliedJaxbContext` in `JaxbConverterFactoryTest` depend on `RecordedRequest.getBody()` to get the request body. The test assertions use hard-coded strings. However, the test may fail due to a different order of serialization results. So tests may fail or pass without any modifications to source code.

This PR proposes to use XMLUnit to fix the problem. It ignores the order of XML elements to make the tests more robust.