### PR TITLE
[RFC] Easier creation of new calls

### DIFF
--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -29,8 +29,8 @@ import okio.Okio;
 
 import static retrofit2.Utils.throwIfFatal;
 
-final class OkHttpCall<T> implements Call<T> {
-  private final RequestFactory requestFactory;
+public final class OkHttpCall<T> implements Call<T> {
+  private final SimpleRequestFactory requestFactory;
   private final Object[] args;
   private final okhttp3.Call.Factory callFactory;
   private final Converter<ResponseBody, T> responseConverter;
@@ -44,7 +44,7 @@ final class OkHttpCall<T> implements Call<T> {
   @GuardedBy("this")
   private boolean executed;
 
-  OkHttpCall(RequestFactory requestFactory, Object[] args,
+  OkHttpCall(SimpleRequestFactory requestFactory, Object[] args,
       okhttp3.Call.Factory callFactory, Converter<ResponseBody, T> responseConverter) {
     this.requestFactory = requestFactory;
     this.args = args;
@@ -55,6 +55,15 @@ final class OkHttpCall<T> implements Call<T> {
   @SuppressWarnings("CloneDoesntCallSuperClone") // We are a final type & this saves clearing state.
   @Override public OkHttpCall<T> clone() {
     return new OkHttpCall<>(requestFactory, args, callFactory, responseConverter);
+  }
+
+  public OkHttpCall<T> clone(Request request) {
+    SimpleRequestFactory newRequestFactory = new SimpleRequestFactory() {
+      @Override public Request create(Object[] args) throws IOException {
+        return request;
+      }
+    };
+    return new OkHttpCall<>(newRequestFactory, args, callFactory, responseConverter);
   }
 
   @Override public synchronized Request request() {

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -62,7 +62,7 @@ import retrofit2.http.Url;
 import static retrofit2.Utils.methodError;
 import static retrofit2.Utils.parameterError;
 
-final class RequestFactory {
+final class RequestFactory implements SimpleRequestFactory {
   static RequestFactory parseAnnotations(Retrofit retrofit, Method method) {
     return new Builder(retrofit, method).build();
   }
@@ -93,7 +93,7 @@ final class RequestFactory {
     isKotlinSuspendFunction = builder.isKotlinSuspendFunction;
   }
 
-  okhttp3.Request create(Object[] args) throws IOException {
+  public okhttp3.Request create(Object[] args) throws IOException {
     @SuppressWarnings("unchecked") // It is an error to invoke a method with the wrong arg types.
     ParameterHandler<Object>[] handlers = (ParameterHandler<Object>[]) parameterHandlers;
 

--- a/retrofit/src/main/java/retrofit2/SimpleRequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/SimpleRequestFactory.java
@@ -1,0 +1,7 @@
+package retrofit2;
+
+import java.io.IOException;
+
+public interface SimpleRequestFactory {
+  okhttp3.Request create(Object[] args) throws IOException;
+}


### PR DESCRIPTION
Creating new `Call<T>` is far too difficult. Currently, it requires creating a new class implementing `Call`. Vut this is not handy in the case you just want to modify the call at run-time according to custom annotations using adapters.