### PR TITLE
FIX:  #3281 Don't call private Lookup constructor

### DIFF
--- a/retrofit/src/test/java/retrofit2/PlatformTest.java
+++ b/retrofit/src/test/java/retrofit2/PlatformTest.java
@@ -1,0 +1,18 @@
+package retrofit2;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+public class PlatformTest {
+    private interface DoNothing {
+        default void doNothing() { }
+    }
+
+    @Test public void testDefaultMethodInvoke() throws Throwable {
+        Object doNothing = new DoNothing() {};
+        Platform p = new Platform(true);
+        Method doNothingMethod = DoNothing.class.getMethod("doNothing");
+        p.invokeDefaultMethod(doNothingMethod, DoNothing.class, doNothing);
+    }
+}


### PR DESCRIPTION
This fixes #3281

This change is to sniff whether the current private lookup constructor is available.  If it isn't available, assume that we are running on a newer version of the JVM (in which case, the unreflectSpecial should work correctly).

I've added a test that I manually exercised using newer and older versions of the jdk.  Pre change, it fails on JVMs higher than 14.  Post change it works on all JVMs (I tested 8, 12, 13, and 14.  I did not test android, I assume it should still work.)

This change relies on the fix for https://bugs.openjdk.java.net/browse/JDK-8209005