### PR TITLE
Use computeIfAbsent method to simplify this method

### DIFF
--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -183,17 +183,7 @@ public final class Retrofit {
   }
 
   ServiceMethod<?> loadServiceMethod(Method method) {
-    ServiceMethod<?> result = serviceMethodCache.get(method);
-    if (result != null) return result;
-
-    synchronized (serviceMethodCache) {
-      result = serviceMethodCache.get(method);
-      if (result == null) {
-        result = ServiceMethod.parseAnnotations(this, method);
-        serviceMethodCache.put(method, result);
-      }
-    }
-    return result;
+    return serviceMethodCache.computeIfAbsent(method, (m)-> ServiceMethod.parseAnnotations(this, m));
   }
 
   /**


### PR DESCRIPTION
This is a minor change.  This relies on the internal locking mechanisms of the concurrent hash map instead of doing manual synchronization work.

Not that it matters, but it ends up being somewhat faster (this is not likely a hot path).  There is only a single key lookup instead of 2 in the worst case and it relies on CHMs internal locking scheme only (instead of having an extra one outside).