### PR TITLE
Use system properties to detect Android

### DIFF
--- a/retrofit/android-test/src/androidTest/java/retrofit2/PlatformTest.java
+++ b/retrofit/android-test/src/androidTest/java/retrofit2/PlatformTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public final class PlatformTest {
+  @Test public void isAndroid() {
+    assertTrue(Platform.get() instanceof Platform.Android);
+  }
+}

--- a/retrofit/src/main/java/retrofit2/Platform.java
+++ b/retrofit/src/main/java/retrofit2/Platform.java
@@ -39,14 +39,9 @@ class Platform {
   }
 
   private static Platform findPlatform() {
-    try {
-      Class.forName("android.os.Build");
-      if (Build.VERSION.SDK_INT != 0) {
-        return new Android();
-      }
-    } catch (ClassNotFoundException ignored) {
-    }
-    return new Platform(true);
+    return "Dalvik".equals(System.getProperty("java.vm.name"))
+        ? new Android() //
+        : new Platform(true);
   }
 
   private final boolean hasJava8Types;

--- a/retrofit/src/test/java/retrofit2/PlatformTest.java
+++ b/retrofit/src/test/java/retrofit2/PlatformTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2;
+
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+
+public final class PlatformTest {
+  @Test
+  public void isAndroid() {
+    assertFalse(Platform.get() instanceof Platform.Android);
+  }
+}


### PR DESCRIPTION
Android classes can show up on the classpath on the JvM in places like IntelliJ when you have the Android plugin applied.

Closes #2103. Closes #2102. Closes #3389.