### PR TITLE
Binary support implemented in JacksonConverterFactory

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ robovm = "2.3.14"
 kotlinx-serialization = "1.6.3"
 autoService = "1.1.1"
 incap = "1.0.0"
+jackson = "2.16.1"
 
 [libraries]
 androidPlugin = { module = "com.android.tools.build:gradle", version = "8.2.2" }
@@ -67,7 +68,8 @@ rxjava3 = { module = "io.reactivex.rxjava3:rxjava", version = "3.1.8" }
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version = "1.0.4" }
 scalaLibrary = { module = "org.scala-lang:scala-library", version = "2.13.12" }
 gson = { module = "com.google.code.gson:gson", version = "2.10.1" }
-jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.16.1" }
+jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jacksonDataformatCbor = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor", version.ref = "jackson" }
 jaxbApi = { module = "javax.xml.bind:jaxb-api", version = "2.3.1" }
 jaxbImpl = { module = "org.glassfish.jaxb:jaxb-runtime", version = "4.0.4" }
 jaxb3Api = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version = "3.0.1" }

--- a/retrofit-converters/jackson/build.gradle
+++ b/retrofit-converters/jackson/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation libs.mockwebserver
+  testImplementation libs.jacksonDataformatCbor
 }
 
 jar {

--- a/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonRequestBodyConverter.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonRequestBodyConverter.java
@@ -22,17 +22,17 @@ import okhttp3.RequestBody;
 import retrofit2.Converter;
 
 final class JacksonRequestBodyConverter<T> implements Converter<T, RequestBody> {
-  private static final MediaType MEDIA_TYPE = MediaType.get("application/json; charset=UTF-8");
-
   private final ObjectWriter adapter;
+  private final MediaType mediaType;
 
-  JacksonRequestBodyConverter(ObjectWriter adapter) {
+  JacksonRequestBodyConverter(ObjectWriter adapter, MediaType mediaType) {
     this.adapter = adapter;
+    this.mediaType = mediaType;
   }
 
   @Override
   public RequestBody convert(T value) throws IOException {
     byte[] bytes = adapter.writeValueAsBytes(value);
-    return RequestBody.create(MEDIA_TYPE, bytes);
+    return RequestBody.create(mediaType, bytes);
   }
 }

--- a/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonResponseBodyConverter.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonResponseBodyConverter.java
@@ -30,7 +30,7 @@ final class JacksonResponseBodyConverter<T> implements Converter<ResponseBody, T
   @Override
   public T convert(ResponseBody value) throws IOException {
     try {
-      return adapter.readValue(value.charStream());
+      return adapter.readValue(value.byteStream());
     } finally {
       value.close();
     }

--- a/retrofit-converters/jackson/src/test/java/retrofit2/converter/jackson/JacksonCborConverterFactoryTest.java
+++ b/retrofit-converters/jackson/src/test/java/retrofit2/converter/jackson/JacksonCborConverterFactoryTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.converter.jackson;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
+import java.io.IOException;
+import okhttp3.MediaType;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okio.Buffer;
+import okio.ByteString;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
+
+public class JacksonCborConverterFactoryTest {
+  static class IntWrapper {
+    public int value;
+
+    public IntWrapper(int v) {
+      value = v;
+    }
+
+    protected IntWrapper() {}
+  }
+
+  interface Service {
+    @POST("/")
+    Call<IntWrapper> post(@Body IntWrapper person);
+  }
+
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  private Service service;
+
+  @Before
+  public void setUp() {
+    Retrofit retrofit =
+        new Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .addConverterFactory(
+                JacksonConverterFactory.create(new CBORMapper(), MediaType.get("application/cbor")))
+            .build();
+    service = retrofit.create(Service.class);
+  }
+
+  @Test
+  public void post() throws IOException, InterruptedException {
+    server.enqueue(
+        new MockResponse()
+            .setBody(new Buffer().write(ByteString.decodeHex("bf6576616c7565182aff"))));
+
+    Call<IntWrapper> call = service.post(new IntWrapper(12));
+    Response<IntWrapper> response = call.execute();
+    assertThat(response.body().value).isEqualTo(42);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getBody().readByteString())
+        .isEqualTo(ByteString.decodeHex("bf6576616c75650cff"));
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/cbor");
+  }
+}


### PR DESCRIPTION
Closes #3403

### What?
Binary support implemented in `JacksonConverterFactory` implemented.

### Why?
Currently, in `JacksonResponseBodyConverter` a `charStream` is used to convert the content of the response body. This requires a text formatted content to be able to serialize, making it impossible to send binary data. It is possible to resolve this with workarounds, but it would be nice to support this simply by passing in a custom ObjectMapper.

### How?
- `charStream` changed to `byteStream` in `JacksonResponseBodyConverter`
- `mediaType` made changeable via a constructor parameter in `JacksonRequestBodyConverter`
- an overload with two parameters of the `create` function is implemented in `JacksonConverterFactory`, where it is possible to set the `mediaType` via a nullable second parameter (other overloads calls this new function, to support backward compatibility)