### PR TITLE
Prevent use of Java 8 classes on RoboVM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,12 +64,26 @@ jobs:
         env:
           API_LEVEL: ${{ matrix.api-level }}
 
+  robovm:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Run Tests
+        run: ./gradlew retrofit:robovm-test:robovmTest
+
   publish:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     needs:
       - jvm
       - android
+      - robovm
 
     steps:
       - name: Checkout

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
       'okhttp': '3.14.9',
       'protobuf': '3.10.0',
       'jaxb': '2.3.1',
+      'robovm': '2.3.9',
   ]
   ext.deps = [
       'kotlinStdLib': "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
@@ -34,6 +35,7 @@ buildscript {
       'simpleXml': 'org.simpleframework:simple-xml:2.7.1',
       'wireRuntime': 'com.squareup.wire:wire-runtime:2.2.0',
       'jsoup': 'org.jsoup:jsoup:1.12.1',
+      'robovm': "com.mobidevelop.robovm:robovm-rt:${versions.robovm}",
   ]
 
   dependencies {
@@ -44,6 +46,7 @@ buildscript {
     classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
     classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.5.0'
     classpath 'gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.9'
+    classpath "com.mobidevelop.robovm:robovm-gradle-plugin:${versions.robovm}"
   }
   repositories {
     mavenCentral()

--- a/retrofit/robovm-test/build.gradle
+++ b/retrofit/robovm-test/build.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'java'
+apply plugin: 'robovm'
+
+ext.mainClassName = 'retrofit2.RoboVmPlatformTest'
+
+robovm {
+  archs = 'x86_64'
+}
+
+dependencies {
+  implementation project(':retrofit')
+  implementation deps.robovm
+}
+
+task robovmTest(type: Exec) {
+  dependsOn {
+    robovmInstall
+  }
+  commandLine './build/robovm/retrofit2.RoboVmPlatformTest'
+}

--- a/retrofit/robovm-test/src/main/java/retrofit2/RoboVmPlatformTest.java
+++ b/retrofit/robovm-test/src/main/java/retrofit2/RoboVmPlatformTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2;
+
+public final class RoboVmPlatformTest {
+  public static void main(String[] args) {
+    System.exit(new RoboVmPlatformTest().isRoboVM() ? 0 : 1);
+  }
+
+  boolean isRoboVM() {
+    if (!"RoboVM".equals(System.getProperty("java.vm.name"))) {
+      return false;
+    }
+
+    // This is a proxy for the private property hasJava8Classes.
+    return Platform.get().defaultCallAdapterFactoriesSize() == 1;
+  }
+}

--- a/retrofit/src/main/java/retrofit2/Platform.java
+++ b/retrofit/src/main/java/retrofit2/Platform.java
@@ -39,9 +39,14 @@ class Platform {
   }
 
   private static Platform findPlatform() {
-    return "Dalvik".equals(System.getProperty("java.vm.name"))
-        ? new Android() //
-        : new Platform(true);
+    switch (System.getProperty("java.vm.name")) {
+      case "Dalvik":
+        return new Android();
+      case "RoboVM":
+        return new Platform(false);
+      default:
+        return new Platform(true);
+    }
   }
 
   private final boolean hasJava8Types;

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include ':retrofit'
 include ':retrofit:android-test'
+include ':retrofit:robovm-test'
 include ':retrofit:test-helpers'
 
 include ':retrofit-mock'


### PR DESCRIPTION
Retrofit used to work on RoboVM, but not all Java 8 features are supported by its VM, so Retrofit2 fails with "class not found" errors. This PR checks the VM and suppresses the use of Java 8 features when running on RoboVM.