### PR TITLE
Allow parameters with custom annotations in service methods

### DIFF
--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -126,7 +126,10 @@ final class RequestFactory {
     List<Object> argumentList = new ArrayList<>(argumentCount);
     for (int p = 0; p < argumentCount; p++) {
       argumentList.add(args[p]);
-      handlers[p].apply(requestBuilder, args[p]);
+      ParameterHandler<Object> handler = handlers[p];
+      if (handler != null) {
+        handlers[p].apply(requestBuilder, args[p]);
+      }
     }
 
     return requestBuilder.get().tag(Invocation.class, new Invocation(method, argumentList)).build();
@@ -347,7 +350,9 @@ final class RequestFactory {
           } catch (NoClassDefFoundError ignored) {
           }
         }
-        throw parameterError(method, p, "No Retrofit annotation found.");
+        if (annotations == null || annotations.length == 0) {
+          throw parameterError(method, p, "No annotation found.");
+        }
       }
 
       return result;

--- a/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
@@ -465,7 +465,7 @@ public final class RequestFactoryTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessage(
-              "No Retrofit annotation found. (parameter #1)\n    for method Example.method");
+              "No annotation found. (parameter #1)\n    for method Example.method");
     }
   }
 


### PR DESCRIPTION
**What**
Support for parameters with custom annotations.
For example:

```Kotlin
annotation class CustomAnnotation

interface SomeApiService {
  @GET("operation")
  fun getData(@CustomAnnotation customValue: String)
}
```

**Why**
When implementing a custom `Call.Factory` implementation, its nice to be able to access custom data provided to the request. We can access the `Invocation` from the newCall method, which can be used to inspect all annotations (both method and parameter annotations), as well as the arguments provided. Using this we can access what value is provided for the argument annotated with `@CustomAnnotation`. See example below:

```Kotlin
class CustomCallFactory : Call.Factory {
  override fun newCall(request: Request): Call {
    val invocation = request.tag(Invocation::class.java)!!
    val customAnnotationArgumentIndex = invocation.method().parameterAnnotations.indexOfFirst { it.find { it is CustomAnnotation } } ?: -1
    if (customAnnotationArgumentIndex != -1) {
      val customValue = invocation.arguments()[customAnnotationArgumentIndex]
    }
  }
}
```

In my particular use-case, I want to use this for a `@ForceRefresh` annotation, since I am trying to implement a secure caching solution (protected by an app specific pincode and AndroidKeystore, backed by an sqlcipher database), and sometimes you dont want to use the cache (hence the ForceRefresh annotation). Custom method annotations is not an issue luckily, but custom argument annotations are not supported yet.

**How**
Don't throw the `No Retrofit annotation found.` exception, but instead only throw an exception when there is a parameter without any annotation. Furthermore I made the logic that applies the handlers null-aware for this and I updated the unit test assertion.