### PR TITLE
Allowing Unit return type

### DIFF
--- a/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import javax.annotation.Nullable;
+import kotlin.Unit;
 import kotlin.coroutines.Continuation;
 import okhttp3.ResponseBody;
 
@@ -50,6 +51,8 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
         // Unwrap the actual body type from Response<T>.
         responseType = Utils.getParameterUpperBound(0, (ParameterizedType) responseType);
         continuationWantsResponse = true;
+      } else if (getRawType(responseType) == Unit.class) {
+        continuationBodyNullable = true;
       } else {
         // TODO figure out if type is nullable or not
         // Metadata metadata = method.getDeclaringClass().getAnnotation(Metadata.class)


### PR DESCRIPTION
### Problem to solve
When making a request and you are expecting a 204, you have to use `Response<Unit>` for your return type, otherwise a `KotlinNullPointerException` is thrown.  Error handling with `Response<Unit>` requires checking `isSuccessful` whereas error handling with a data model uses a try catch block since an `HttpException` is thrown on error.  It would be nice to have the option to use try catch error handling for calls that are expecting a 204 without any workarounds.

This does not work for nullable types, only strictly `Unit`.

### Description
- checks if the raw return type is `Unit`.  If it is, set `continuationBodyNullable` to true so that the function `KotlinExtensions.awaitNullable` is used instead of `KotlinExtensions.await`
- added unit tests for this case