### PR TITLE
Allowing Unit and nullable return types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
   ext.deps = [
       'kotlinStdLib': "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
       'kotlinCoroutines': 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2',
+      'kotlinMetaData': 'org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0',
       'okhttp': "com.squareup.okhttp3:okhttp:${versions.okhttp}",
       'mockwebserver': "com.squareup.okhttp3:mockwebserver:${versions.okhttp}",
       'junit': 'junit:junit:4.13',

--- a/retrofit/build.gradle
+++ b/retrofit/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   compileOnly deps.android
   compileOnly deps.kotlinStdLib
   compileOnly deps.kotlinCoroutines
+  compileOnly deps.kotlinMetaData
 
   compileOnly deps.animalSnifferAnnotations
   compileOnly deps.findBugsAnnotations

--- a/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import javax.annotation.Nullable;
+import kotlin.Unit;
 import kotlin.coroutines.Continuation;
 import okhttp3.ResponseBody;
 
@@ -50,6 +51,8 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
         // Unwrap the actual body type from Response<T>.
         responseType = Utils.getParameterUpperBound(0, (ParameterizedType) responseType);
         continuationWantsResponse = true;
+      } else if (getRawType(responseType) == Unit.class) {
+        continuationBodyNullable = true;
       } else {
         // TODO figure out if type is nullable or not
         // Metadata metadata = method.getDeclaringClass().getAnnotation(Metadata.class)

--- a/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
@@ -51,13 +51,9 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
         // Unwrap the actual body type from Response<T>.
         responseType = Utils.getParameterUpperBound(0, (ParameterizedType) responseType);
         continuationWantsResponse = true;
-      } else if (getRawType(responseType) == Unit.class) {
+      } else if (getRawType(responseType) == Unit.class
+          || MetadataKotlinExtensionsKt.isReturnTypeNullable(method)) {
         continuationBodyNullable = true;
-      } else {
-        // TODO figure out if type is nullable or not
-        // Metadata metadata = method.getDeclaringClass().getAnnotation(Metadata.class)
-        // Find the entry for method
-        // Determine if return type is nullable or not
       }
 
       adapterType = new Utils.ParameterizedTypeImpl(null, Call.class, responseType);

--- a/retrofit/src/main/java/retrofit2/MetadataKotlinExtensions.kt
+++ b/retrofit/src/main/java/retrofit2/MetadataKotlinExtensions.kt
@@ -1,0 +1,128 @@
+package retrofit2
+
+import kotlinx.metadata.Flag.Type.IS_NULLABLE
+import kotlinx.metadata.KmFunction
+import kotlinx.metadata.jvm.KotlinClassHeader
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlinx.metadata.jvm.signature
+import java.lang.reflect.Method
+
+fun Method.isReturnTypeNullable(): Boolean {
+  val kotlinClassMetadata = declaringClass.getAnnotation(Metadata::class.java)?.let { metadata ->
+      KotlinClassMetadata.read(
+          KotlinClassHeader(
+              metadata.kind,
+              metadata.metadataVersion,
+              metadata.bytecodeVersion,
+              metadata.data1,
+              metadata.data2,
+              metadata.extraString,
+              metadata.packageName,
+              metadata.extraInt
+          )
+      )
+  }
+
+
+  if (kotlinClassMetadata is KotlinClassMetadata.Class) {
+    val kmClass = kotlinClassMetadata.toKmClass()
+    for (function in kmClass.functions) {
+      if (function.equalsMethod(this)) {
+        if (IS_NULLABLE.invoke(function.returnType.flags)) {
+          return true
+        }
+        break
+      }
+    }
+  }
+  return false
+}
+
+private fun KmFunction.equalsMethod(method: Method): Boolean {
+  if (name != method.name) {
+    return false
+  }
+
+  val parameters = getParametersTypeNameList()
+
+  if (parameters.size != method.parameterTypes.size) {
+    return false
+  }
+
+  parameters.zip(method.parameterTypes.map { it.name }).forEach { pair ->
+    if (pair.first != pair.second) {
+      return false
+    }
+  }
+
+  return true
+}
+
+private fun KmFunction.getParametersTypeNameList(): List<String> {
+  val parametersTypeNameList = mutableListOf<String>()
+
+  signature
+    ?.desc
+    ?.substringAfter('(')
+    ?.substringBefore(')')?.let { parametersString ->
+      var index = 0
+      while (index < parametersString.length) {
+        when (parametersString[index]) {
+            TypeSignatures.BYTE -> parametersTypeNameList.add(TypeNames.BYTE)
+            TypeSignatures.CHAR -> parametersTypeNameList.add(TypeNames.CHAR)
+            TypeSignatures.DOUBLE -> parametersTypeNameList.add(TypeNames.DOUBLE)
+            TypeSignatures.FLOAT -> parametersTypeNameList.add(TypeNames.FLOAT)
+            TypeSignatures.INT -> parametersTypeNameList.add(TypeNames.INT)
+            TypeSignatures.LONG -> parametersTypeNameList.add(TypeNames.LONG)
+            TypeSignatures.SHORT -> parametersTypeNameList.add(TypeNames.SHORT)
+            TypeSignatures.BOOLEAN -> parametersTypeNameList.add(TypeNames.BOOLEAN)
+            TypeSignatures.CLASS_REFERENCE -> {
+                val endOfClassReferenceIndex = parametersString.indexOf(';', startIndex = index)
+                parametersTypeNameList.add(
+                    parametersString.substring(
+                        startIndex = index + 1,
+                        endIndex = endOfClassReferenceIndex
+                    ).replace('/', '.')
+                )
+                index = endOfClassReferenceIndex
+            }
+            TypeSignatures.ARRAY_REFERENCE -> {
+                val endOfClassReferenceIndex = parametersString.indexOf(';', startIndex = index)
+                parametersTypeNameList.add(
+                    parametersString.substring(
+                        startIndex = index,
+                        endIndex = endOfClassReferenceIndex + 1
+                    ).replace('/', '.')
+                )
+                index = endOfClassReferenceIndex
+            }
+        }
+        index++
+      }
+    }
+  return parametersTypeNameList
+}
+
+object TypeSignatures {
+  const val BYTE = 'B'
+  const val CHAR = 'C'
+  const val DOUBLE = 'D'
+  const val FLOAT = 'F'
+  const val INT = 'I'
+  const val LONG = 'J'
+  const val SHORT = 'S'
+  const val BOOLEAN = 'Z'
+  const val CLASS_REFERENCE = 'L'
+  const val ARRAY_REFERENCE = '['
+}
+
+object TypeNames {
+  const val BYTE = "byte"
+  const val CHAR = "char"
+  const val DOUBLE = "double"
+  const val FLOAT = "float"
+  const val INT = "int"
+  const val LONG = "long"
+  const val SHORT = "short"
+  const val BOOLEAN = "boolean"
+}

--- a/retrofit/src/test/java/retrofit2/KotlinSuspendTest.kt
+++ b/retrofit/src/test/java/retrofit2/KotlinSuspendTest.kt
@@ -16,7 +16,6 @@
 package retrofit2
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
@@ -29,7 +28,6 @@ import okhttp3.mockwebserver.SocketPolicy.NO_RESPONSE
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import retrofit2.helpers.ToStringConverterFactory
@@ -200,7 +198,6 @@ class KotlinSuspendTest {
     }
   }
 
-  @Ignore("Not working yet")
   @Test fun bodyNullable() {
     val retrofit = Retrofit.Builder()
         .baseUrl(server.url("/"))

--- a/retrofit/src/test/java/retrofit2/MetaDataUtilsTest.kt
+++ b/retrofit/src/test/java/retrofit2/MetaDataUtilsTest.kt
@@ -1,0 +1,71 @@
+package retrofit2
+
+import org.junit.Test
+
+class MetaDataUtilsTest {
+
+  interface TestFunctionsNonNull {
+    fun unit()
+    fun string(): String
+    fun int(): Int
+    fun any(): Any
+    fun params(
+        byte: Byte,
+        char: Char,
+        double: Double,
+        float: Float,
+        int: Int,
+        long: Long,
+        short: Short,
+        boolean: Boolean,
+        array: Array<Int>,
+        arrayComplex: Array<TestClassComplex<String, TestClassComplex<Int, Float>>>,
+        clazz: TestClass,
+        clazzComplex: TestClassComplex<String, TestClassComplex<Int, Float>>
+    ): String
+    fun parameterized(): TestClassComplex<String, TestClassComplex<String, Int>>
+  }
+
+  interface TestFunctionsNullable {
+    fun string(): String?
+    fun int(): Int?
+    fun any(): Any?
+    fun params(
+        byte: Byte,
+        char: Char,
+        double: Double,
+        float: Float,
+        int: Int,
+        long: Long,
+        short: Short,
+        boolean: Boolean,
+        array: Array<Int>,
+        arrayComplex: Array<TestClassComplex<String, TestClassComplex<Int, Float>>>,
+        clazz: TestClass,
+        clazzComplex: TestClassComplex<String, TestClassComplex<Int, Float>>
+    ): String?
+    fun parameterized(): TestClassComplex<String, TestClassComplex<String, Int>>?
+  }
+
+  class TestClass
+
+  class TestClassComplex<A, B>
+
+  @Test
+  fun testNonNull() {
+    TestFunctionsNonNull::class.java.declaredMethods.forEach { method ->
+      val isReturnTypeNullable = method.isReturnTypeNullable()
+      println("NonNull ${method.name}: ${!isReturnTypeNullable}")
+      assert(!isReturnTypeNullable)
+    }
+  }
+
+  @Test
+  fun testNullable() {
+    TestFunctionsNullable::class.java.declaredMethods.forEach { method ->
+      val isReturnTypeNullable = method.isReturnTypeNullable()
+      println("Nullable ${method.name}: $isReturnTypeNullable")
+      assert(isReturnTypeNullable)
+    }
+  }
+}


### PR DESCRIPTION
This PR contains the changes from https://github.com/square/retrofit/pull/3468 
The purpose is the same as https://github.com/square/retrofit/pull/3468 except it allows nullable return types as well as `Unit`.

Not sure if adding the dependency is okay...

### Description
- Added the kotlinx metadata library for parsing kotlin metadata
- checks if the raw return type is Unit. If it is, set continuationBodyNullable to true so that the function KotlinExtensions.awaitNullable is used instead of KotlinExtensions.await
- checks if the return type is nullable by parsing kotlin meta data
  - When parsing the meta data, we find the correct function by checking the `KmFunction` name and parameters (derived from the `signature.desc`) and comparing those to the `Method` name and `parameterTypes`
- Added unit tests for the new code
- Removed the `@Ignore` annotation above the unit test `fun bodyNullable()`