### PR TITLE
Support custom requestbuilder interceptors

### DIFF
--- a/retrofit/src/main/java/retrofit2/RequestBuilderInterceptor.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilderInterceptor.java
@@ -1,0 +1,20 @@
+package retrofit2;
+
+import okhttp3.Request;
+
+/**
+ * Intercepts a {@link Request.Builder} just before it is built into an actual {@link Request}. Interceptors
+ * can be {@linkplain Retrofit.Builder#addRequestBuilderInterceptor(RequestBuilderInterceptor) added}
+ * to the {@link Retrofit} instance.
+ */
+public interface RequestBuilderInterceptor {
+
+    /**
+     * Intercepts the {@code requestBuilder} with the provided {@code invocation}. The {@code invocation}
+     * is used to access all method annotations, parameter annotations and method arguments. Use this
+     * method to provide your own modifications on the {@code requestBuilder} just before it's built into
+     * a {@link Request}.
+     */
+    void intercept(Request.Builder requestBuilder, Invocation invocation);
+
+}

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -126,7 +126,10 @@ final class RequestFactory {
     List<Object> argumentList = new ArrayList<>(argumentCount);
     for (int p = 0; p < argumentCount; p++) {
       argumentList.add(args[p]);
-      handlers[p].apply(requestBuilder, args[p]);
+      ParameterHandler<Object> handler = handlers[p];
+      if (handler != null) {
+        handlers[p].apply(requestBuilder, args[p]);
+      }
     }
 
     return requestBuilder.get().tag(Invocation.class, new Invocation(method, argumentList)).build();
@@ -347,7 +350,9 @@ final class RequestFactory {
           } catch (NoClassDefFoundError ignored) {
           }
         }
-        throw parameterError(method, p, "No Retrofit annotation found.");
+        if (annotations == null || annotations.length == 0) {
+          throw parameterError(method, p, "No annotation found.");
+        }
       }
 
       return result;

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -128,7 +128,7 @@ final class RequestFactory {
       argumentList.add(args[p]);
       ParameterHandler<Object> handler = handlers[p];
       if (handler != null) {
-        handlers[p].apply(requestBuilder, args[p]);
+        handler.apply(requestBuilder, args[p]);
       }
     }
 

--- a/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package retrofit2;
 
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.lang.annotation.Retention;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.net.URI;
@@ -3250,6 +3252,24 @@ public final class RequestFactoryTest {
               "@Tag type java.util.List is duplicate of parameter #1 and would always overwrite its value. (parameter #2)\n"
                   + "    for method Example.method");
     }
+  }
+
+  @Retention(RUNTIME)
+  @interface CustomAnnotation {}
+
+  @Test
+  public void parameterWithCustomAnnotation() {
+    class Example {
+      @GET("/") //
+      Call<ResponseBody> method(@CustomAnnotation String a) {
+        return null;
+      }
+    }
+    Request request = buildRequest(Example.class, "CustomArgument");
+    assertThat(request.url().toString()).isEqualTo("http://example.com/");
+    Invocation invocation = request.tag(Invocation.class);
+    assertThat(invocation.arguments().get(0)).isEqualTo("CustomArgument");
+    assertThat(invocation.method().getParameterAnnotations()[0][0]).isInstanceOf(CustomAnnotation.class);
   }
 
   private static void assertBody(RequestBody body, String expected) {

--- a/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
@@ -465,7 +465,7 @@ public final class RequestFactoryTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessage(
-              "No Retrofit annotation found. (parameter #1)\n    for method Example.method");
+              "No annotation found. (parameter #1)\n    for method Example.method");
     }
   }
 


### PR DESCRIPTION
**What**
Support custom RequestBuilder interceptors, along with the possibility to add custom parameter annotations (see [other PR](https://github.com/square/retrofit/pull/3464)). The RequestBuilderInterceptor is called just before Retrofit creates an okhttp3.Request and the `okhttp3.Request.Builder` and `retrofit.Invocation` are provided.

**Why**
This RequestBuilderInterceptor allows developers full freedom to mutate and alter the okhttp request using their own custom annotations (both method and parameter annotations) via the Invocation class.

My first intuition was to add support for custom ParameterHandlers, but with that, you still can't modify the request based on method arguments. Also, to implement correct support for custom ParameterHandlers, the retrofit.RequestBuilder would need to be public and a lot of methods needed to be added for it to be usable. It would basically become a copy of the okhttp3.Request.Builder. For my personal usecase I actually need access to both the method and parameter annotations when mutating the request.

**How**
Retrofit keeps track of a list of RequestBuilderInterceptors. 
These interceptors are provided to the RequestFactory.
When the Request is created as a last step the RequestBuilderInterceptors are called.