### PR TITLE
Add platform module for publishing BOM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
           java-version: 14
 
       - name: Upload Artifacts
-        run: ./gradlew uploadArchives
+        run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,8 @@ buildscript {
 }
 
 subprojects {
+  if (project.name == 'retrofit-bom') return
+
   repositories {
     mavenCentral()
     google()
@@ -142,6 +144,96 @@ subprojects {
   tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile).configureEach { task ->
     task.kotlinOptions {
       jvmTarget = '1.8'
+    }
+  }
+}
+
+def nonPublishedModule(project) {
+  return (project.name == 'android-test'
+          || project.name == 'robovm-test'
+          || project.name == 'test-helpers')
+}
+
+subprojects { subproject ->
+  if (nonPublishedModule(subproject) || !subproject.hasProperty('POM_ARTIFACT_ID')) return
+
+  apply plugin: 'maven-publish'
+  apply plugin: 'signing'
+
+  afterEvaluate {
+    def versionName = subproject.property('VERSION_NAME')
+    def isReleaseBuild = !versionName.contains('SNAPSHOT')
+    def bom = plugins.hasPlugin('java-platform')
+
+    publishing {
+      if (!bom) {
+        java {
+          withJavadocJar()
+          withSourcesJar()
+        }
+
+        tasks.withType(Javadoc).configureEach {
+          exclude("**/internal/*")
+          if (JavaVersion.current().isJava8Compatible()) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+          }
+        }
+      }
+
+      publications {
+        create('maven', MavenPublication) {
+          groupId = subproject.property('GROUP')
+          artifactId = subproject.property('POM_ARTIFACT_ID')
+          version = versionName
+
+          if (bom) {
+            from components.javaPlatform
+          } else {
+            from components.java
+          }
+
+          pom {
+            name.set(subproject.findProperty('POM_NAME'))
+            description.set(subproject.findProperty('POM_DESCRIPTION'))
+            url.set(subproject.findProperty('POM_URL'))
+            scm {
+              url.set(subproject.findProperty('POM_SCM_URL'))
+              connection.set(subproject.findProperty('POM_SCM_CONNECTION'))
+              developerConnection.set(subproject.findProperty('POM_SCM_DEV_CONNECTION'))
+            }
+            licenses {
+              license {
+                name.set(subproject.findProperty('POM_LICENCE_NAME'))
+                url.set(subproject.findProperty('POM_LICENCE_URL'))
+                distribution.set(subproject.findProperty('POM_LICENCE_DIST'))
+              }
+            }
+            developers {
+              developer {
+                id.set(subproject.findProperty('POM_DEVELOPER_ID'))
+                name.set(subproject.findProperty('POM_DEVELOPER_NAME'))
+              }
+            }
+          }
+        }
+      }
+
+      repositories {
+        maven {
+          def releaseRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+          def snapshotRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+          url = isReleaseBuild ? releaseRepoUrl : snapshotRepoUrl
+          credentials {
+            username = subproject.findProperty('SONATYPE_NEXUS_USERNAME')
+            password = subproject.findProperty('SONATYPE_NEXUS_PASSWORD')
+          }
+        }
+      }
+    }
+
+    signing {
+      required { isReleaseBuild && gradle.taskGraph.hasTask("publish") }
+      sign(publishing.publications.maven)
     }
   }
 }

--- a/retrofit-adapters/guava/build.gradle
+++ b/retrofit-adapters/guava/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-adapters/java8/build.gradle
+++ b/retrofit-adapters/java8/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-adapters/rxjava/build.gradle
+++ b/retrofit-adapters/rxjava/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-adapters/rxjava2/build.gradle
+++ b/retrofit-adapters/rxjava2/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-adapters/rxjava3/build.gradle
+++ b/retrofit-adapters/rxjava3/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-adapters/scala/build.gradle
+++ b/retrofit-adapters/scala/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-bom/build.gradle
+++ b/retrofit-bom/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+  id 'java-platform'
+}
+
+dependencies {
+  constraints {
+    rootProject.subprojects { subproject ->
+      subproject.plugins.withId('maven-publish') {
+        api(subproject)
+      }
+    }
+  }
+}

--- a/retrofit-bom/gradle.properties
+++ b/retrofit-bom/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=retrofit-bom
+POM_NAME=Retrofit BOM
+POM_DESCRIPTION=A BOM for managing Retrofit dependencies.

--- a/retrofit-converters/gson/build.gradle
+++ b/retrofit-converters/gson/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-converters/guava/build.gradle
+++ b/retrofit-converters/guava/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-converters/jackson/build.gradle
+++ b/retrofit-converters/jackson/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-converters/java8/build.gradle
+++ b/retrofit-converters/java8/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-converters/jaxb/build.gradle
+++ b/retrofit-converters/jaxb/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-converters/moshi/build.gradle
+++ b/retrofit-converters/moshi/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-converters/protobuf/build.gradle
+++ b/retrofit-converters/protobuf/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 apply plugin: 'com.google.protobuf'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-converters/scalars/build.gradle
+++ b/retrofit-converters/scalars/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-converters/simplexml/build.gradle
+++ b/retrofit-converters/simplexml/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-converters/wire/build.gradle
+++ b/retrofit-converters/wire/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java-library'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit-mock/build.gradle
+++ b/retrofit-mock/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api project(':retrofit')

--- a/retrofit/build.gradle
+++ b/retrofit/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
   api deps.okhttp

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include ':retrofit'
+include ':retrofit-bom'
 include ':retrofit:android-test'
 include ':retrofit:robovm-test'
 include ':retrofit:test-helpers'


### PR DESCRIPTION
[#3231](https://github.com/square/retrofit/issues/3231).

I've updated all subprojects to use the `maven-publish` plugin so the platform module can use the `POM_ARTIFACT_ID` of each subproject as opposed to project name when generating the BOM and its dependencies. 

I tried to keep existing properties and functionality from the previous maven publish intact (e.g. excluding directories named `internal` and suppressing doclint warnings). Let me know if this isn't ideal.