### PR TITLE
Giving @Multipart more flexibility to set the type of Multipart

### DIFF
--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -72,7 +72,8 @@ final class RequestBuilder {
       @Nullable MediaType contentType,
       boolean hasBody,
       boolean isFormEncoded,
-      boolean isMultipart) {
+      boolean isMultipart,
+      String multipartType) {
     this.method = method;
     this.baseUrl = baseUrl;
     this.relativeUrl = relativeUrl;
@@ -92,7 +93,7 @@ final class RequestBuilder {
     } else if (isMultipart) {
       // Will be set to 'body' in 'build'.
       multipartBuilder = new MultipartBody.Builder();
-      multipartBuilder.setType(MultipartBody.FORM);
+      multipartBuilder.setType(MediaType.get(multipartType));
     }
   }
 

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -76,6 +76,7 @@ final class RequestFactory {
   private final boolean hasBody;
   private final boolean isFormEncoded;
   private final boolean isMultipart;
+  private final String multipartType;
   private final ParameterHandler<?>[] parameterHandlers;
   final boolean isKotlinSuspendFunction;
 
@@ -89,6 +90,7 @@ final class RequestFactory {
     hasBody = builder.hasBody;
     isFormEncoded = builder.isFormEncoded;
     isMultipart = builder.isMultipart;
+    multipartType = builder.multipartType;
     parameterHandlers = builder.parameterHandlers;
     isKotlinSuspendFunction = builder.isKotlinSuspendFunction;
   }
@@ -116,7 +118,8 @@ final class RequestFactory {
             contentType,
             hasBody,
             isFormEncoded,
-            isMultipart);
+            isMultipart,
+            multipartType);
 
     if (isKotlinSuspendFunction) {
       // The Continuation is the last parameter and the handlers array contains null at that index.
@@ -161,6 +164,7 @@ final class RequestFactory {
     boolean hasBody;
     boolean isFormEncoded;
     boolean isMultipart;
+    String multipartType;
     @Nullable String relativeUrl;
     @Nullable Headers headers;
     @Nullable MediaType contentType;
@@ -251,6 +255,7 @@ final class RequestFactory {
           throw methodError(method, "Only one encoding annotation is allowed.");
         }
         isMultipart = true;
+        multipartType = ((Multipart) annotation).type();
       } else if (annotation instanceof FormUrlEncoded) {
         if (isMultipart) {
           throw methodError(method, "Only one encoding annotation is allowed.");

--- a/retrofit/src/main/java/retrofit2/http/Multipart.java
+++ b/retrofit/src/main/java/retrofit2/http/Multipart.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import okhttp3.HttpUrl;
+
 /**
  * Denotes that the request body is multi-part. Parts should be declared as parameters and annotated
  * with {@link Part @Part}.
@@ -29,4 +31,10 @@ import java.lang.annotation.Target;
 @Documented
 @Target(METHOD)
 @Retention(RUNTIME)
-public @interface Multipart {}
+public @interface Multipart {
+    /**
+     * Sets the type(MediaType) on MultipartBody. When calling the
+     */
+
+    String type() default "multipart/form-data";
+}


### PR DESCRIPTION
I had created this issue #3493 and I hope that I am helping people configure the multipart, giving them more flexibility and power.

This commit allow that the value passed by type on @Multipart sets the ContentType present in the RequestBody.