### PR TITLE
POC of logging api result

### DIFF
--- a/retrofit/src/main/java/retrofit2/EmptyLogger.java
+++ b/retrofit/src/main/java/retrofit2/EmptyLogger.java
@@ -1,0 +1,9 @@
+package retrofit2;
+
+public class EmptyLogger implements ObjectLogger {
+
+    @Override
+    public void log(Object obj) {
+
+    }
+}

--- a/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
@@ -148,9 +148,8 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
 
   @Override
   final @Nullable ReturnT invoke(Object[] args) {
-    Call<ResponseT> call = new OkHttpCall<>(requestFactory, args, callFactory, responseConverter);
+    Call<ResponseT> call = new OkHttpCall<>(requestFactory, args, callFactory, responseConverter, logger);
     ReturnT result = adapt(call, args);
-    logger.log(result);
     return result;
   }
 

--- a/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.logging.Logger;
+
 import javax.annotation.Nullable;
 import kotlin.coroutines.Continuation;
 import okhttp3.ResponseBody;
@@ -83,10 +85,10 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
 
     Converter<ResponseBody, ResponseT> responseConverter =
         createResponseConverter(retrofit, method, responseType);
-
+    ObjectLogger logger = retrofit.logger;
     okhttp3.Call.Factory callFactory = retrofit.callFactory;
     if (!isKotlinSuspendFunction) {
-      return new CallAdapted<>(requestFactory, callFactory, responseConverter, callAdapter);
+      return new CallAdapted<>(requestFactory, callFactory, responseConverter, callAdapter, logger);
     } else if (continuationWantsResponse) {
       //noinspection unchecked Kotlin compiler guarantees ReturnT to be Object.
       return (HttpServiceMethod<ResponseT, ReturnT>)
@@ -94,7 +96,7 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
               requestFactory,
               callFactory,
               responseConverter,
-              (CallAdapter<ResponseT, Call<ResponseT>>) callAdapter);
+              (CallAdapter<ResponseT, Call<ResponseT>>) callAdapter, logger);
     } else {
       //noinspection unchecked Kotlin compiler guarantees ReturnT to be Object.
       return (HttpServiceMethod<ResponseT, ReturnT>)
@@ -103,6 +105,7 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
               callFactory,
               responseConverter,
               (CallAdapter<ResponseT, Call<ResponseT>>) callAdapter,
+              logger,
               continuationBodyNullable);
     }
   }
@@ -130,20 +133,25 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
   private final RequestFactory requestFactory;
   private final okhttp3.Call.Factory callFactory;
   private final Converter<ResponseBody, ResponseT> responseConverter;
+  private final ObjectLogger logger;
 
   HttpServiceMethod(
       RequestFactory requestFactory,
       okhttp3.Call.Factory callFactory,
-      Converter<ResponseBody, ResponseT> responseConverter) {
+      Converter<ResponseBody, ResponseT> responseConverter,
+      ObjectLogger logger) {
     this.requestFactory = requestFactory;
     this.callFactory = callFactory;
     this.responseConverter = responseConverter;
+    this.logger = logger;
   }
 
   @Override
   final @Nullable ReturnT invoke(Object[] args) {
     Call<ResponseT> call = new OkHttpCall<>(requestFactory, args, callFactory, responseConverter);
-    return adapt(call, args);
+    ReturnT result = adapt(call, args);
+    logger.log(result);
+    return result;
   }
 
   protected abstract @Nullable ReturnT adapt(Call<ResponseT> call, Object[] args);
@@ -155,8 +163,9 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
         RequestFactory requestFactory,
         okhttp3.Call.Factory callFactory,
         Converter<ResponseBody, ResponseT> responseConverter,
-        CallAdapter<ResponseT, ReturnT> callAdapter) {
-      super(requestFactory, callFactory, responseConverter);
+        CallAdapter<ResponseT, ReturnT> callAdapter,
+        ObjectLogger logger) {
+      super(requestFactory, callFactory, responseConverter, logger);
       this.callAdapter = callAdapter;
     }
 
@@ -173,8 +182,10 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
         RequestFactory requestFactory,
         okhttp3.Call.Factory callFactory,
         Converter<ResponseBody, ResponseT> responseConverter,
-        CallAdapter<ResponseT, Call<ResponseT>> callAdapter) {
-      super(requestFactory, callFactory, responseConverter);
+        CallAdapter<ResponseT, Call<ResponseT>> callAdapter,
+        ObjectLogger logger
+        ) {
+      super(requestFactory, callFactory, responseConverter, logger);
       this.callAdapter = callAdapter;
     }
 
@@ -204,8 +215,9 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
         okhttp3.Call.Factory callFactory,
         Converter<ResponseBody, ResponseT> responseConverter,
         CallAdapter<ResponseT, Call<ResponseT>> callAdapter,
+        ObjectLogger logger,
         boolean isNullable) {
-      super(requestFactory, callFactory, responseConverter);
+      super(requestFactory, callFactory, responseConverter, logger);
       this.callAdapter = callAdapter;
       this.isNullable = isNullable;
     }

--- a/retrofit/src/main/java/retrofit2/ObjectLogger.java
+++ b/retrofit/src/main/java/retrofit2/ObjectLogger.java
@@ -1,0 +1,6 @@
+package retrofit2;
+
+public interface ObjectLogger {
+
+  void log(Object obj);
+}

--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -35,6 +35,7 @@ final class OkHttpCall<T> implements Call<T> {
   private final Object[] args;
   private final okhttp3.Call.Factory callFactory;
   private final Converter<ResponseBody, T> responseConverter;
+  private final ObjectLogger logger;
 
   private volatile boolean canceled;
 
@@ -51,17 +52,19 @@ final class OkHttpCall<T> implements Call<T> {
       RequestFactory requestFactory,
       Object[] args,
       okhttp3.Call.Factory callFactory,
-      Converter<ResponseBody, T> responseConverter) {
+      Converter<ResponseBody, T> responseConverter,
+      ObjectLogger logger) {
     this.requestFactory = requestFactory;
     this.args = args;
     this.callFactory = callFactory;
     this.responseConverter = responseConverter;
+    this.logger = logger;
   }
 
   @SuppressWarnings("CloneDoesntCallSuperClone") // We are a final type & this saves clearing state.
   @Override
   public OkHttpCall<T> clone() {
-    return new OkHttpCall<>(requestFactory, args, callFactory, responseConverter);
+    return new OkHttpCall<>(requestFactory, args, callFactory, responseConverter, logger);
   }
 
   @Override
@@ -151,6 +154,9 @@ final class OkHttpCall<T> implements Call<T> {
             Response<T> response;
             try {
               response = parseResponse(rawResponse);
+              if (response.body() != null) {
+                logger.log(response.body());
+              }
             } catch (Throwable e) {
               throwIfFatal(e);
               callFailure(e);

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -15,8 +15,6 @@
  */
 package retrofit2;
 
-import android.os.Build;
-
 import static java.util.Collections.unmodifiableList;
 
 import java.lang.annotation.Annotation;

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -15,6 +15,8 @@
  */
 package retrofit2;
 
+import android.os.Build;
+
 import static java.util.Collections.unmodifiableList;
 
 import java.lang.annotation.Annotation;
@@ -72,6 +74,7 @@ public final class Retrofit {
   final List<CallAdapter.Factory> callAdapterFactories;
   final @Nullable Executor callbackExecutor;
   final boolean validateEagerly;
+  final ObjectLogger logger;
 
   Retrofit(
       okhttp3.Call.Factory callFactory,
@@ -79,12 +82,14 @@ public final class Retrofit {
       List<Converter.Factory> converterFactories,
       List<CallAdapter.Factory> callAdapterFactories,
       @Nullable Executor callbackExecutor,
+      ObjectLogger logger,
       boolean validateEagerly) {
     this.callFactory = callFactory;
     this.baseUrl = baseUrl;
     this.converterFactories = converterFactories; // Copy+unmodifiable at call site.
     this.callAdapterFactories = callAdapterFactories; // Copy+unmodifiable at call site.
     this.callbackExecutor = callbackExecutor;
+    this.logger = logger;
     this.validateEagerly = validateEagerly;
   }
 
@@ -431,6 +436,7 @@ public final class Retrofit {
     private final List<Converter.Factory> converterFactories = new ArrayList<>();
     private final List<CallAdapter.Factory> callAdapterFactories = new ArrayList<>();
     private @Nullable Executor callbackExecutor;
+    private @Nullable ObjectLogger logger;
     private boolean validateEagerly;
 
     Builder(Platform platform) {
@@ -581,6 +587,11 @@ public final class Retrofit {
       return this;
     }
 
+    public Builder setObjectLogger(ObjectLogger logger) {
+      this.logger = logger;
+      return this;
+    }
+
     /**
      * The executor on which {@link Callback} methods are invoked when returning {@link Call} from
      * your service method.
@@ -648,12 +659,18 @@ public final class Retrofit {
       converterFactories.addAll(this.converterFactories);
       converterFactories.addAll(platform.defaultConverterFactories());
 
+      ObjectLogger logger = this.logger;
+      if (logger == null) {
+        logger = new EmptyLogger();
+      }
+
       return new Retrofit(
           callFactory,
           baseUrl,
           unmodifiableList(converterFactories),
           unmodifiableList(callAdapterFactories),
           callbackExecutor,
+          logger,
           validateEagerly);
     }
   }


### PR DESCRIPTION
We need a high level logging of api result above okhtttp logging.
Since some api call is binary like protobuf, it will be good if retrofit can provide a feature to enable object level of logging like the poc pr here.
