### PR TITLE
Bump jackson-databind to 2.10.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
       'reactiveStreams': 'org.reactivestreams:reactive-streams:1.0.3',
       'scalaLibrary': 'org.scala-lang:scala-library:2.13.1',
       'gson': 'com.google.code.gson:gson:2.8.5',
-      'jacksonDatabind': 'com.fasterxml.jackson.core:jackson-databind:2.10.1',
+      'jacksonDatabind': 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1',
       'jaxbApi': "javax.xml.bind:jaxb-api:${versions.jaxb}",
       'jaxbImpl': "org.glassfish.jaxb:jaxb-runtime:${versions.jaxb}",
       'moshi': 'com.squareup.moshi:moshi:1.8.0',


### PR DESCRIPTION
`jackson-databind` issue [#2589](https://github.com/FasterXML/jackson-databind/issues/2589) was assigned a vuln id [CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649).

The issue was fixed in `jackson-databind` version 2.11, and backported to versions 2.10.5.1 and 2.9.10.7.

This PR bumps `jackson-databind` from 2.10.1 to 2.10.5.1