### PR TITLE
HttpException no longer extends RuntimeException

### DIFF
--- a/retrofit/src/main/java/retrofit2/HttpException.java
+++ b/retrofit/src/main/java/retrofit2/HttpException.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 /** Exception for an unexpected, non-2xx HTTP response. */
-public class HttpException extends RuntimeException {
+public class HttpException extends Exception {
   private static String getMessage(Response<?> response) {
     Objects.requireNonNull(response, "response == null");
     return "HTTP " + response.code() + " " + response.message();


### PR DESCRIPTION
I don't see a reason why HttpException has to be a RuntimeException. To me the HttpException looks like an exception that should be handled in any app that uses this library and therefore shouldn't be a RuntimeException.