### PR TITLE
Added @IgnoreParameter meta annotation

### DIFF
--- a/retrofit/src/main/java/retrofit2/IgnoreParameter.java
+++ b/retrofit/src/main/java/retrofit2/IgnoreParameter.java
@@ -1,0 +1,19 @@
+package retrofit2;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Use this meta-annotation on an annotation you want to use on a service method parameter to cause
+ * retrofit to ignore the parameter when processing a request.
+ */
+@Documented
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface IgnoreParameter {
+}

--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -446,4 +446,13 @@ abstract class ParameterHandler<T> {
       builder.addTag(cls, value);
     }
   }
+
+  static final class NoOp<T> extends ParameterHandler<T> {
+
+    @Override
+    void apply(RequestBuilder builder, @org.jetbrains.annotations.Nullable T value) throws IOException {
+      // do nothing
+    }
+  }
+
 }

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -803,9 +803,15 @@ final class RequestFactory {
         }
 
         return new ParameterHandler.Tag<>(tagType);
+      } else if (shouldIgnoreParameter(annotation)) {
+        return new ParameterHandler.NoOp<>();
       }
 
-      return null; // Not a Retrofit annotation.
+      return null; // No ParameterHandler for annotation.
+    }
+
+    private boolean shouldIgnoreParameter(Annotation annotation){
+      return annotation.getClass().isAnnotationPresent(IgnoreParameter.class);
     }
 
     private void validateResolvableType(int p, Type type) {


### PR DESCRIPTION
This is an attempt to add the custom parameter annotations ability requested #2890 in a way that is not intrusive to the existing Retrofit API surface. 

I added an `@IgnoreParameter` meta annotation that can be applied to any custom parameter annotation that then causes Retrofit to ignore it during processing. The developer is then free to handle the annotation in a custom request interceptor if they so choose. 

This approach preserves the behavior of any existing non Retrofit managed parameters causing Retrofit to throw an exception when building the client.

Example Usage
```java
@IgnoreParameter
@Target(PARAMETER)
@Retention(RUNTIME)
public @interface CustomParam { }
```

```java
public interface ExampleClient {
   @GET
   Call<Object> test(@CustomParam String myParam);
}
```

The biggest downside to this method is that it requires just-in-time handling of any custom annotations in your interceptor which is not ideal but not worse than being unable to do it in the first place in my opinion.

I'm also not satisfied with the name. `@IgnoreParameter` seems a little clunky so I'm open to suggestions.