### PR TITLE
Add keep rule to retain generic signature of Call

### DIFF
--- a/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -5,6 +5,9 @@
 # Retrofit does reflection on method and parameter annotations.
 -keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
 
+# Keep annotation default values (e.g., retrofit2.http.Field.encoded).
+-keepattributes AnnotationDefault
+
 # Retain service method parameters when optimizing.
 -keepclassmembers,allowshrinking,allowobfuscation interface * {
     @retrofit2.http.* <methods>;
@@ -27,3 +30,6 @@
 # and replaces all potential values with null. Explicitly keeping the interfaces prevents this.
 -if interface * { @retrofit2.http.* <methods>; }
 -keep,allowobfuscation interface <1>
+
+# Keep generic signature of Call (R8 full mode strips signatures from non-kept items).
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call


### PR DESCRIPTION
R8 version 3.0 started to remove generic signatures from items that are not matched by a `-keep` rule in full mode (see also https://r8.googlesource.com/r8/+/744d742137a82656b8ee27513f975e0528aecd78). The motivation for this change is to avoid that all generic signatures are retained in programs, when only a few are typically required for reflection.

This change adds a rule that causes the generic signature of `retrofit2.Call` to be retained.

Related resources:
- https://github.com/chrisbanes/tivi/commit/9720aa34f6c8b9e5260129ab6d05b44e84d3721c
- https://issuetracker.google.com/issues/188703877

Closes #3580