### PR TITLE
Add proguard config for R8 to keep type information for RxJava stuff

### DIFF
--- a/retrofit-adapters/rxjava2/src/main/resources/META-INF/proguard/retrofit2-rxjava2.pro
+++ b/retrofit-adapters/rxjava2/src/main/resources/META-INF/proguard/retrofit2-rxjava2.pro
@@ -1,0 +1,5 @@
+# Keep generic signature of RxJava2 (R8 full mode strips signatures from non-kept items).
+-keep,allowobfuscation,allowshrinking class io.reactivex.Single
+-keep,allowobfuscation,allowshrinking class io.reactivex.Flowable
+-keep,allowobfuscation,allowshrinking class io.reactivex.Observable
+-keep,allowobfuscation,allowshrinking class io.reactivex.Completable

--- a/retrofit-adapters/rxjava3/src/main/resources/META-INF/proguard/retrofit2-rxjava3.pro
+++ b/retrofit-adapters/rxjava3/src/main/resources/META-INF/proguard/retrofit2-rxjava3.pro
@@ -1,0 +1,5 @@
+# Keep generic signature of RxJava3 (R8 full mode strips signatures from non-kept items).
+-keep,allowobfuscation,allowshrinking class io.reactivex.rxjava3.core.Single
+-keep,allowobfuscation,allowshrinking class io.reactivex.rxjava3.core.Flowable
+-keep,allowobfuscation,allowshrinking class io.reactivex.rxjava3.core.Observable
+-keep,allowobfuscation,allowshrinking class io.reactivex.rxjava3.core.Completable


### PR DESCRIPTION
The problem is similar to: https://issuetracker.google.com/issues/188703877
And the solution is similar to #3563

I tested only the case with Single of RxJava2. But other classes should work