### PR TITLE
Display method parameter names in error messages if available

### DIFF
--- a/retrofit-converters/scalars/src/test/java/retrofit2/converter/scalars/ScalarsConverterFactoryTest.java
+++ b/retrofit-converters/scalars/src/test/java/retrofit2/converter/scalars/ScalarsConverterFactoryTest.java
@@ -143,7 +143,7 @@ public final class ScalarsConverterFactoryTest {
       assertThat(e)
           .hasMessage(
               ""
-                  + "Unable to create @Body converter for class java.lang.Object (parameter #1)\n"
+                  + "Unable to create @Body converter for class java.lang.Object (parameter 'body')\n"
                   + "    for method Service.object");
       assertThat(e.getCause())
           .hasMessage(

--- a/retrofit/build.gradle
+++ b/retrofit/build.gradle
@@ -21,6 +21,10 @@ dependencies {
   testImplementation deps.kotlinCoroutines
 }
 
+tasks.withType(JavaCompile) {
+  options.compilerArgs << '-parameters'
+}
+
 jar {
   manifest {
     attributes  'Automatic-Module-Name': 'retrofit2'

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -797,8 +797,8 @@ final class RequestFactory {
                 p,
                 "@Tag type "
                     + tagType.getName()
-                    + " is duplicate of parameter #"
-                    + (i + 1)
+                    + " is duplicate of "
+                    + Platform.get().describeMethodParameter(method, i)
                     + " and would always overwrite its value.");
           }
         }

--- a/retrofit/src/main/java/retrofit2/Utils.java
+++ b/retrofit/src/main/java/retrofit2/Utils.java
@@ -58,11 +58,13 @@ final class Utils {
 
   static RuntimeException parameterError(
       Method method, Throwable cause, int p, String message, Object... args) {
-    return methodError(method, cause, message + " (parameter #" + (p + 1) + ")", args);
+    String paramDesc = Platform.get().describeMethodParameter(method, p);
+    return methodError(method, cause, message + " (" + paramDesc + ")", args);
   }
 
   static RuntimeException parameterError(Method method, int p, String message, Object... args) {
-    return methodError(method, message + " (parameter #" + (p + 1) + ")", args);
+    String paramDesc = Platform.get().describeMethodParameter(method, p);
+    return methodError(method, message + " (" + paramDesc + ")", args);
   }
 
   static Class<?> getRawType(Type type) {

--- a/retrofit/src/test/java/retrofit2/MethodParamReflectionTest.java
+++ b/retrofit/src/test/java/retrofit2/MethodParamReflectionTest.java
@@ -1,0 +1,61 @@
+package retrofit2;
+
+import org.junit.Test;
+
+import okhttp3.ResponseBody;
+import retrofit2.http.GET;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class MethodParamReflectionTest {
+
+    interface Example {
+        @GET("/") //
+        Call<ResponseBody> method(String theFirstParameter);
+    }
+
+    @Test
+    public void paramIndexIsUsedWithoutParamReflection() {
+
+        // TODO: Inject a Platform where method param reflection is unavailable
+        Retrofit retrofit =  new Retrofit.Builder()
+                .baseUrl("http://example.com/")
+                .callFactory(request -> {
+                    throw new UnsupportedOperationException("Not implemented");
+                })
+                .validateEagerly(true)
+                .build();
+
+        try {
+            retrofit.create(Example.class);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertThat(e)
+                    .hasMessage(
+                            "No Retrofit annotation found. (parameter #1)\n    for method Example.method");
+        }
+    }
+
+    @Test
+    public void paramNameIsUsedWithParamReflection() {
+
+        // TODO: Inject a Platform where method param reflection is available
+        Retrofit retrofit =  new Retrofit.Builder()
+                .baseUrl("http://example.com/")
+                .callFactory(request -> {
+                    throw new UnsupportedOperationException("Not implemented");
+                })
+                .validateEagerly(true)
+                .build();
+
+        try {
+            retrofit.create(Example.class);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertThat(e)
+                    .hasMessage(
+                            "No Retrofit annotation found. (parameter 'theFirstParameter')\n    for method Example.method");
+        }
+    }
+}

--- a/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
@@ -156,7 +156,7 @@ public final class RequestFactoryTest {
       assertThat(e)
           .hasMessage(
               "@Path parameter name must match \\{([a-zA-Z][a-zA-Z0-9_-]*)\\}."
-                  + " Found: hey! (parameter #1)\n    for method Example.method");
+                  + " Found: hey! (parameter 'thing')\n    for method Example.method");
     }
   }
 
@@ -193,7 +193,7 @@ public final class RequestFactoryTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessage(
-              "Multiple Retrofit annotations found, only one allowed. (parameter #1)\n    for method Example.method");
+              "Multiple Retrofit annotations found, only one allowed. (parameter 'o')\n    for method Example.method");
     }
   }
 
@@ -263,7 +263,7 @@ public final class RequestFactoryTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessage(
-              "@Part parameters can only be used with multipart encoding. (parameter #1)\n    for method Example.method");
+              "@Part parameters can only be used with multipart encoding. (parameter 'a')\n    for method Example.method");
     }
   }
 
@@ -281,7 +281,7 @@ public final class RequestFactoryTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessage(
-              "@PartMap parameters can only be used with multipart encoding. (parameter #1)\n    for method Example.method");
+              "@PartMap parameters can only be used with multipart encoding. (parameter 'params')\n    for method Example.method");
     }
   }
 
@@ -337,7 +337,7 @@ public final class RequestFactoryTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessage(
-              "@Field parameters can only be used with form encoding. (parameter #1)\n    for method Example.method");
+              "@Field parameters can only be used with form encoding. (parameter 'a')\n    for method Example.method");
     }
   }
 
@@ -355,7 +355,7 @@ public final class RequestFactoryTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessage(
-              "@FieldMap parameters can only be used with form encoding. (parameter #1)\n    for method Example.method");
+              "@FieldMap parameters can only be used with form encoding. (parameter 'a')\n    for method Example.method");
     }
   }
 
@@ -447,7 +447,7 @@ public final class RequestFactoryTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessage(
-              "URL \"/{a}\" does not contain \"{b}\". (parameter #2)\n    for method Example.method");
+              "URL \"/{a}\" does not contain \"{b}\". (parameter 'b')\n    for method Example.method");
     }
   }
 
@@ -465,7 +465,7 @@ public final class RequestFactoryTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessage(
-              "No Retrofit annotation found. (parameter #1)\n    for method Example.method");
+              "No Retrofit annotation found. (parameter 'a')\n    for method Example.method");
     }
   }
 
@@ -500,7 +500,7 @@ public final class RequestFactoryTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessage(
-              "@QueryMap parameter type must be Map. (parameter #1)\n    for method Example.method");
+              "@QueryMap parameter type must be Map. (parameter 'a')\n    for method Example.method");
     }
   }
 
@@ -536,7 +536,7 @@ public final class RequestFactoryTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessage("Query map was null (parameter #1)\n" + "    for method Example.method");
+          .hasMessage("Query map was null (parameter 'a')\n" + "    for method Example.method");
     }
   }
 
@@ -559,7 +559,7 @@ public final class RequestFactoryTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessage(
-              "Query map contained null key. (parameter #1)\n" + "    for method Example.method");
+              "Query map contained null key. (parameter 'a')\n" + "    for method Example.method");
     }
   }
 

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -619,7 +619,7 @@ public final class RetrofitTest {
       assertThat(e)
           .hasMessage(
               ""
-                  + "Unable to create @Body converter for class java.lang.String (parameter #1)\n"
+                  + "Unable to create @Body converter for class java.lang.String (parameter 'body')\n"
                   + "    for method CallMethod.disallowed");
       assertThat(e.getCause())
           .hasMessage(
@@ -782,7 +782,7 @@ public final class RetrofitTest {
       assertThat(e)
           .hasMessage(
               "Parameter type must not include a type variable or wildcard: "
-                  + "T (parameter #1)\n    for method UnresolvableParameterType.typeVariable");
+                  + "T (parameter 'body')\n    for method UnresolvableParameterType.typeVariable");
     }
     try {
       example.typeVariableUpperBound(null);
@@ -791,7 +791,7 @@ public final class RetrofitTest {
       assertThat(e)
           .hasMessage(
               "Parameter type must not include a type variable or wildcard: "
-                  + "T (parameter #1)\n    for method UnresolvableParameterType.typeVariableUpperBound");
+                  + "T (parameter 'body')\n    for method UnresolvableParameterType.typeVariableUpperBound");
     }
     try {
       example.crazy(null);
@@ -800,7 +800,7 @@ public final class RetrofitTest {
       assertThat(e)
           .hasMessage(
               "Parameter type must not include a type variable or wildcard: "
-                  + "java.util.List<java.util.Map<java.lang.String, java.util.Set<T[]>>> (parameter #1)\n"
+                  + "java.util.List<java.util.Map<java.lang.String, java.util.Set<T[]>>> (parameter 'body')\n"
                   + "    for method UnresolvableParameterType.crazy");
     }
     try {
@@ -810,7 +810,7 @@ public final class RetrofitTest {
       assertThat(e)
           .hasMessage(
               "Parameter type must not include a type variable or wildcard: "
-                  + "java.util.List<?> (parameter #1)\n    for method UnresolvableParameterType.wildcard");
+                  + "java.util.List<?> (parameter 'body')\n    for method UnresolvableParameterType.wildcard");
     }
     try {
       example.wildcardUpperBound(null);
@@ -819,7 +819,7 @@ public final class RetrofitTest {
       assertThat(e)
           .hasMessage(
               "Parameter type must not include a type variable or wildcard: "
-                  + "java.util.List<? extends okhttp3.RequestBody> (parameter #1)\n"
+                  + "java.util.List<? extends okhttp3.RequestBody> (parameter 'body')\n"
                   + "    for method UnresolvableParameterType.wildcardUpperBound");
     }
   }


### PR DESCRIPTION
If we have Java 8+, `java.lang.reflect.Parameter.getName()` can enable clearer error messages that use the parameter's name instead of its index, eg:

    Body parameter value must not be null. (parameter 'body') for method Example.method

instead of

    Body parameter value must not be null. (parameter #1) for method Example.method

This is a bit rough currently; I was looking for feedback before I fix the rest of the tests, and I need to work out how to inject a specific `Platform` instance in MethodParamReflectionTest, and maybe make `Platform.hasMethodParamReflection` cleaner.

Also anyone who's better at Gradle than me, I could use help with enabling that javac `-parameters` option only for the test source set, see retrofit/build.gradle