### PR TITLE
Add support for Unit response type in HEAD method requests.

### DIFF
--- a/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
@@ -16,6 +16,7 @@
 package retrofit2;
 
 import static retrofit2.Utils.getRawType;
+import static retrofit2.Utils.isUnitAvailable;
 import static retrofit2.Utils.methodError;
 
 import java.lang.annotation.Annotation;
@@ -77,9 +78,10 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
     if (responseType == Response.class) {
       throw methodError(method, "Response must include generic type (e.g., Response<String>)");
     }
-    if (requestFactory.httpMethod.equals("HEAD")
-        && !Void.class.equals(responseType)
-        && !Unit.class.equals(responseType)) {
+    if (!Void.class.equals(responseType) && !isUnitAvailable()) {
+      throw methodError(method, "HEAD method must use Void as response type.");
+    }
+    if (!Unit.class.equals(responseType)) {
       throw methodError(method, "HEAD method must use Void or Unit as response type.");
     }
 

--- a/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
@@ -78,11 +78,13 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
     if (responseType == Response.class) {
       throw methodError(method, "Response must include generic type (e.g., Response<String>)");
     }
-    if (!Void.class.equals(responseType) && !isUnitAvailable()) {
-      throw methodError(method, "HEAD method must use Void as response type.");
-    }
-    if (!Unit.class.equals(responseType)) {
-      throw methodError(method, "HEAD method must use Void or Unit as response type.");
+    if (requestFactory.httpMethod.equals("HEAD")) {
+      if (!Void.class.equals(responseType) && !isUnitAvailable()) {
+        throw methodError(method, "HEAD method must use Void as response type.");
+      }
+      if (!Unit.class.equals(responseType)) {
+        throw methodError(method, "HEAD method must use Void or Unit as response type.");
+      }
     }
 
     Converter<ResponseBody, ResponseT> responseConverter =

--- a/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import javax.annotation.Nullable;
+import kotlin.Unit;
 import kotlin.coroutines.Continuation;
 import okhttp3.ResponseBody;
 
@@ -76,9 +77,10 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
     if (responseType == Response.class) {
       throw methodError(method, "Response must include generic type (e.g., Response<String>)");
     }
-    // TODO support Unit for Kotlin?
-    if (requestFactory.httpMethod.equals("HEAD") && !Void.class.equals(responseType)) {
-      throw methodError(method, "HEAD method must use Void as response type.");
+    if (requestFactory.httpMethod.equals("HEAD")
+        && !Void.class.equals(responseType)
+        && !Unit.class.equals(responseType)) {
+      throw methodError(method, "HEAD method must use Void or Unit as response type.");
     }
 
     Converter<ResponseBody, ResponseT> responseConverter =

--- a/retrofit/src/main/java/retrofit2/Utils.java
+++ b/retrofit/src/main/java/retrofit2/Utils.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import javax.annotation.Nullable;
+import kotlin.Unit;
 import okhttp3.ResponseBody;
 import okio.Buffer;
 
@@ -317,6 +318,15 @@ final class Utils {
       }
     }
     return false;
+  }
+
+  static boolean isUnitAvailable() {
+    try {
+      final Class<?> ignored = Unit.class;
+      return true;
+    } catch (final NoClassDefFoundError ignored) {
+      return false;
+    }
   }
 
   static ResponseBody buffer(final ResponseBody body) throws IOException {

--- a/retrofit/src/test/java/retrofit2/KotlinUnitTest.java
+++ b/retrofit/src/test/java/retrofit2/KotlinUnitTest.java
@@ -25,23 +25,39 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import retrofit2.http.GET;
+import retrofit2.http.HEAD;
 
 public final class KotlinUnitTest {
   @Rule public final MockWebServer server = new MockWebServer();
 
   interface Service {
     @GET("/")
-    Call<Unit> empty();
+    Call<Unit> get();
+
+    @HEAD("/")
+    Call<Unit> head();
   }
 
   @Test
-  public void unitOnClasspath() throws IOException {
+  public void getWithUnitOnClasspath() throws IOException {
     Retrofit retrofit = new Retrofit.Builder().baseUrl(server.url("/")).build();
     Service example = retrofit.create(Service.class);
 
     server.enqueue(new MockResponse().setBody("Hi"));
 
-    Response<Unit> response = example.empty().execute();
+    Response<Unit> response = example.get().execute();
+    assertThat(response.isSuccessful()).isTrue();
+    assertThat(response.body()).isSameAs(Unit.INSTANCE);
+  }
+
+  @Test
+  public void headWithUnitOnClasspath() throws IOException {
+    Retrofit retrofit = new Retrofit.Builder().baseUrl(server.url("/")).build();
+    Service example = retrofit.create(Service.class);
+
+    server.enqueue(new MockResponse().setBody("Hi"));
+
+    Response<Unit> response = example.head().execute();
     assertThat(response.isSuccessful()).isTrue();
     assertThat(response.body()).isSameAs(Unit.INSTANCE);
   }


### PR DESCRIPTION
This adds support for `Unit` (additionally to preexisting `Void` support) response types for HEAD method requests.