### PR TITLE
Update gson to its latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
       'rxjava3': 'io.reactivex.rxjava3:rxjava:3.1.1',
       'reactiveStreams': 'org.reactivestreams:reactive-streams:1.0.3',
       'scalaLibrary': 'org.scala-lang:scala-library:2.13.6',
-      'gson': 'com.google.code.gson:gson:2.8.7',
+      'gson': 'com.google.code.gson:gson:2.8.9',
       'jacksonDatabind': 'com.fasterxml.jackson.core:jackson-databind:2.12.4',
       'jaxbApi': "javax.xml.bind:jaxb-api:${versions.jaxb}",
       'jaxbImpl': "org.glassfish.jaxb:jaxb-runtime:${versions.jaxb}",


### PR DESCRIPTION
**What is the purpose of this PR?**

We noticed that using Snyk that our CI would fail due to the following warning raised by Snyk saying the current version gson that Retrofit uses is a high severity issue.

There are temporary ways to get around this with Snyk, but the permanent solution would be for Retrofit to upgrade to the latest version of gson to resolve this issue. 

- The issue raised in the gson repository https://github.com/google/gson/pull/1991

- Fixed in this release https://github.com/google/gson/releases/tag/gson-parent-2.8.9
 
- Snyks warning https://snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327

Closes #3652 
