### PR TITLE
Allow headers with non-ascii values

### DIFF
--- a/retrofit/src/main/java/retrofit2/ParameterHandler.java
+++ b/retrofit/src/main/java/retrofit2/ParameterHandler.java
@@ -75,10 +75,12 @@ abstract class ParameterHandler<T> {
   static final class Header<T> extends ParameterHandler<T> {
     private final String name;
     private final Converter<T, String> valueConverter;
+    private final boolean allowUnsafeNonAsciiValues;
 
-    Header(String name, Converter<T, String> valueConverter) {
+    Header(String name, Converter<T, String> valueConverter, boolean allowUnsafeNonAsciiValues) {
       this.name = Objects.requireNonNull(name, "name == null");
       this.valueConverter = valueConverter;
+      this.allowUnsafeNonAsciiValues = allowUnsafeNonAsciiValues;
     }
 
     @Override
@@ -88,7 +90,7 @@ abstract class ParameterHandler<T> {
       String headerValue = valueConverter.convert(value);
       if (headerValue == null) return; // Skip converted but null values.
 
-      builder.addHeader(name, headerValue);
+      builder.addHeader(name, headerValue, allowUnsafeNonAsciiValues);
     }
   }
 
@@ -208,11 +210,17 @@ abstract class ParameterHandler<T> {
     private final Method method;
     private final int p;
     private final Converter<T, String> valueConverter;
+    private final boolean allowUnsafeNonAsciiValues;
 
-    HeaderMap(Method method, int p, Converter<T, String> valueConverter) {
+    HeaderMap(
+        Method method,
+        int p,
+        Converter<T, String> valueConverter,
+        boolean allowUnsafeNonAsciiValues) {
       this.method = method;
       this.p = p;
       this.valueConverter = valueConverter;
+      this.allowUnsafeNonAsciiValues = allowUnsafeNonAsciiValues;
     }
 
     @Override
@@ -231,7 +239,8 @@ abstract class ParameterHandler<T> {
           throw Utils.parameterError(
               method, p, "Header map contained null value for key '" + headerName + "'.");
         }
-        builder.addHeader(headerName, valueConverter.convert(headerValue));
+        builder.addHeader(
+            headerName, valueConverter.convert(headerValue), allowUnsafeNonAsciiValues);
       }
     }
   }

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -100,13 +100,15 @@ final class RequestBuilder {
     this.relativeUrl = relativeUrl.toString();
   }
 
-  void addHeader(String name, String value) {
+  void addHeader(String name, String value, boolean allowUnsafeNonAsciiValues) {
     if ("Content-Type".equalsIgnoreCase(name)) {
       try {
         contentType = MediaType.get(value);
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException("Malformed content type: " + value, e);
       }
+    } else if (allowUnsafeNonAsciiValues) {
+      headersBuilder.addUnsafeNonAscii(name, value);
     } else {
       headersBuilder.add(name, value);
     }

--- a/retrofit/src/main/java/retrofit2/http/Header.java
+++ b/retrofit/src/main/java/retrofit2/http/Header.java
@@ -33,6 +33,14 @@ import java.lang.annotation.Target;
  * Header parameters may be {@code null} which will omit them from the request. Passing a {@link
  * java.util.List List} or array will result in a header for each non-{@code null} item.
  *
+ * <p>Parameter keys and values only allows ascii values by default. Specify {@link
+ * #allowUnsafeNonAsciiValues() allowUnsafeNonAsciiValues=true} to change this behavior.
+ *
+ * <pre><code>
+ * &#64;GET("/")
+ * Call&lt;ResponseBody&gt; foo(@Header("Accept-Language", allowUnsafeNonAsciiValues=true) String lang);
+ * </code></pre>
+ *
  * <p><strong>Note:</strong> Headers do not overwrite each other. All headers with the same name
  * will be included in the request.
  *
@@ -43,5 +51,12 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Target(PARAMETER)
 public @interface Header {
+
+  /** The query parameter name. */
   String value();
+
+  /**
+   * Specifies whether the parameter {@linkplain #value() name} and value are already URL encoded.
+   */
+  boolean allowUnsafeNonAsciiValues() default false;
 }

--- a/retrofit/src/main/java/retrofit2/http/HeaderMap.java
+++ b/retrofit/src/main/java/retrofit2/http/HeaderMap.java
@@ -45,10 +45,20 @@ import retrofit2.Retrofit;
  * foo.list(ImmutableMap.of("Accept", "text/plain", "Accept-Charset", "utf-8"));
  * </pre>
  *
+ * <p>Map keys and values representing parameter values allow only ascii values by default.
+ * Specify {@link #allowUnsafeNonAsciiValues() allowUnsafeNonAsciiValues=true} to change this behavior.
+ *
+ * <pre>
+ * &#64;GET("/search")
+ * void list(@HeaderMap(allowUnsafeNonAsciiValues=true) Map&lt;String, String&gt; headers);
+ *
  * @see Header
  * @see Headers
  */
 @Documented
 @Target(PARAMETER)
 @Retention(RUNTIME)
-public @interface HeaderMap {}
+public @interface HeaderMap {
+  /** Specifies whether the parameter values are allowed with unsafe non ascii values. */
+  boolean allowUnsafeNonAsciiValues() default false;
+}

--- a/retrofit/src/main/java/retrofit2/http/Headers.java
+++ b/retrofit/src/main/java/retrofit2/http/Headers.java
@@ -38,8 +38,13 @@ import java.lang.annotation.Target;
  * ...
  * </code></pre>
  *
- * <strong>Note:</strong> Headers do not overwrite each other. All headers with the same name will
- * be included in the request.
+ * <p>Parameter keys and values only allows ascii values by default. Specify {@link
+ * #allowUnsafeNonAsciiValues() allowUnsafeNonAsciiValues=true} to change this behavior.
+ *
+ * <p>&#64;Headers({ "X-Foo: Bar", "X-Ping: Pong" }, allowUnsafeNonAsciiValues=true) &#64;GET("/")
+ *
+ * <p><strong>Note:</strong> Headers do not overwrite each other. All headers with the same name
+ * will be included in the request.
  *
  * @see Header
  * @see HeaderMap
@@ -48,5 +53,12 @@ import java.lang.annotation.Target;
 @Target(METHOD)
 @Retention(RUNTIME)
 public @interface Headers {
+
+  /** The query parameter name. */
   String[] value();
+
+  /**
+   * Specifies whether the parameter {@linkplain #value() name} and value are already URL encoded.
+   */
+  boolean allowUnsafeNonAsciiValues() default false;
 }


### PR DESCRIPTION
Okhttp allows sending non-ASCII characters in headers but retrofit doesn't have the provision to allow them via annotations.
This PR request adds the possibility to allow non-ASCII characters via all Header annotations.
Affected Annotations:
1. Header
2. Headers
3. HeaderMap

Closes #3662