### PR TITLE
Exposes scalar converter internals for extension

### DIFF
--- a/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarRequestBodyConverter.java
+++ b/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarRequestBodyConverter.java
@@ -20,9 +20,9 @@ import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import retrofit2.Converter;
 
-final class ScalarRequestBodyConverter<T> implements Converter<T, RequestBody> {
+public final class ScalarRequestBodyConverter<T> implements Converter<T, RequestBody> {
   static final ScalarRequestBodyConverter<Object> INSTANCE = new ScalarRequestBodyConverter<>();
-  private static final MediaType MEDIA_TYPE = MediaType.get("text/plain; charset=UTF-8");
+  static final MediaType MEDIA_TYPE = MediaType.get("text/plain; charset=UTF-8");
 
   private ScalarRequestBodyConverter() {}
 

--- a/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarResponseBodyConverters.java
+++ b/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarResponseBodyConverters.java
@@ -19,10 +19,10 @@ import java.io.IOException;
 import okhttp3.ResponseBody;
 import retrofit2.Converter;
 
-final class ScalarResponseBodyConverters {
-  private ScalarResponseBodyConverters() {}
+public class ScalarResponseBodyConverters {
+  protected ScalarResponseBodyConverters() {}
 
-  static final class StringResponseBodyConverter implements Converter<ResponseBody, String> {
+  public static final class StringResponseBodyConverter implements Converter<ResponseBody, String> {
     static final StringResponseBodyConverter INSTANCE = new StringResponseBodyConverter();
 
     @Override
@@ -31,7 +31,7 @@ final class ScalarResponseBodyConverters {
     }
   }
 
-  static final class BooleanResponseBodyConverter implements Converter<ResponseBody, Boolean> {
+  public static final class BooleanResponseBodyConverter implements Converter<ResponseBody, Boolean> {
     static final BooleanResponseBodyConverter INSTANCE = new BooleanResponseBodyConverter();
 
     @Override
@@ -40,7 +40,7 @@ final class ScalarResponseBodyConverters {
     }
   }
 
-  static final class ByteResponseBodyConverter implements Converter<ResponseBody, Byte> {
+  public static final class ByteResponseBodyConverter implements Converter<ResponseBody, Byte> {
     static final ByteResponseBodyConverter INSTANCE = new ByteResponseBodyConverter();
 
     @Override
@@ -49,7 +49,7 @@ final class ScalarResponseBodyConverters {
     }
   }
 
-  static final class CharacterResponseBodyConverter implements Converter<ResponseBody, Character> {
+  public static final class CharacterResponseBodyConverter implements Converter<ResponseBody, Character> {
     static final CharacterResponseBodyConverter INSTANCE = new CharacterResponseBodyConverter();
 
     @Override
@@ -63,7 +63,7 @@ final class ScalarResponseBodyConverters {
     }
   }
 
-  static final class DoubleResponseBodyConverter implements Converter<ResponseBody, Double> {
+  public static final class DoubleResponseBodyConverter implements Converter<ResponseBody, Double> {
     static final DoubleResponseBodyConverter INSTANCE = new DoubleResponseBodyConverter();
 
     @Override
@@ -72,7 +72,7 @@ final class ScalarResponseBodyConverters {
     }
   }
 
-  static final class FloatResponseBodyConverter implements Converter<ResponseBody, Float> {
+  public static final class FloatResponseBodyConverter implements Converter<ResponseBody, Float> {
     static final FloatResponseBodyConverter INSTANCE = new FloatResponseBodyConverter();
 
     @Override
@@ -81,7 +81,7 @@ final class ScalarResponseBodyConverters {
     }
   }
 
-  static final class IntegerResponseBodyConverter implements Converter<ResponseBody, Integer> {
+  public static final class IntegerResponseBodyConverter implements Converter<ResponseBody, Integer> {
     static final IntegerResponseBodyConverter INSTANCE = new IntegerResponseBodyConverter();
 
     @Override
@@ -90,7 +90,7 @@ final class ScalarResponseBodyConverters {
     }
   }
 
-  static final class LongResponseBodyConverter implements Converter<ResponseBody, Long> {
+  public static final class LongResponseBodyConverter implements Converter<ResponseBody, Long> {
     static final LongResponseBodyConverter INSTANCE = new LongResponseBodyConverter();
 
     @Override
@@ -99,7 +99,7 @@ final class ScalarResponseBodyConverters {
     }
   }
 
-  static final class ShortResponseBodyConverter implements Converter<ResponseBody, Short> {
+  public static final class ShortResponseBodyConverter implements Converter<ResponseBody, Short> {
     static final ShortResponseBodyConverter INSTANCE = new ShortResponseBodyConverter();
 
     @Override

--- a/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarsConverterFactory.java
+++ b/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarsConverterFactory.java
@@ -41,7 +41,7 @@ public class ScalarsConverterFactory extends Converter.Factory {
     return new ScalarsConverterFactory();
   }
 
-  private ScalarsConverterFactory() {}
+  protected ScalarsConverterFactory() {}
 
   @Override
   public @Nullable Converter<?, RequestBody> requestBodyConverter(

--- a/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarsConverterFactory.java
+++ b/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarsConverterFactory.java
@@ -36,7 +36,7 @@ import retrofit2.converter.scalars.ScalarResponseBodyConverters.StringResponseBo
  * A {@linkplain Converter.Factory converter} for strings and both primitives and their boxed types
  * to {@code text/plain} bodies.
  */
-public final class ScalarsConverterFactory extends Converter.Factory {
+public class ScalarsConverterFactory extends Converter.Factory {
   public static ScalarsConverterFactory create() {
     return new ScalarsConverterFactory();
   }


### PR DESCRIPTION
This pull request exposes scalar converter internals so that they could be extended. Common scenario is to force preference of scalar converter using marker annotations when there are multiple converters available in the retrofit instance. For example

```java
import java.lang.annotation.Documented;
import java.lang.annotation.Retention;
import java.lang.annotation.Target;

import static java.lang.annotation.ElementType.METHOD;
import static java.lang.annotation.RetentionPolicy.RUNTIME;

@Documented
@Target(METHOD)
@Retention(RUNTIME)
public @interface ScalarResponse {
}

public interface RetrofitInterface {
    @GET("")
    @ScalarResponse
    Call<String> getText();
}

public class ConditionalScalarConverterFactory extends retrofit2.converter.scalars.ScalarsConverterFactory {
    public static ConditionalScalarResponseFactory create() {
        return new ConditionalScalarResponseFactory();
    }
    public Converter<?, RequestBody> requestBodyConverter(
            Type type,
            Annotation[] parameterAnnotations,
            Annotation[] methodAnnotations,
            Retrofit retrofit) {
        return null;
    }
     @Override
     public Converter<ResponseBody, ?> responseBodyConverter(
      Type type, Annotation[] annotations, Retrofit retrofit) {
        for (Annotation methodAnnotation : annotations) {
            if (methodAnnotation.annotationType().equals(ScalarResponse.class)) {
                  return super.responseBodyConverter(type, annotations, retrofit);
            }
        }
    }
}

// somewhere in code which builds retrofit

Retrofit retrofitInterface = new Retrofit.Builder()
        .baseUrl(baseurl)
        .validateEagerly(true)
        .addConverterFactory(ConditionalScalarResponseFactory.create())
        .addConverterFactory(someOtherFactory) // another factory that overlaps with scalars factory
        .build();

```

Without this change I would need to copy over entire scalars converter module into my codebase and later maintain it in case original changes.