### PR TITLE
Adopt vanniktech maven publish 0.18.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
           java-version: 14
 
       - name: Upload Artifacts
-        run: ./gradlew uploadArchives
+        run: ./gradlew publish
         env:
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
Follow up commit for #3671, as `uploadArchives` task was removed from `vanniktech maven publish 0.18.0` to lead to publishing failure.