### PR TITLE
Prevent Kotlin callers from creating services with a nullable class type

### DIFF
--- a/retrofit/src/main/java/retrofit2/KotlinExtensions.kt
+++ b/retrofit/src/main/java/retrofit2/KotlinExtensions.kt
@@ -26,7 +26,7 @@ import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-inline fun <reified T> Retrofit.create(): T = create(T::class.java)
+inline fun <reified T: Any> Retrofit.create(): T = create(T::class.java)
 
 suspend fun <T : Any> Call<T>.await(): T {
   return suspendCancellableCoroutine { continuation ->


### PR DESCRIPTION
[Everything is non-null](https://github.com/square/retrofit/blob/master/retrofit/src/main/java/retrofit2/internal/EverythingIsNonNull.java) so Kotlin users shouldn't be able to pass in a nullable class type into the Kotlin `create()` extension function.

I have signed the CLA. Hopefully I used all the correct verbiage here in my commit message and PR description.