### PR TITLE
Run tests on each major JDK version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,23 +8,6 @@ env:
 jobs:
   jvm:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        java-version:
-          - 8
-          - 9
-          - 10
-          - 11
-          - 12
-          - 13
-          - 14
-          - 15
-          - 16
-          - 17
-          - 18
-
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1.0.4
@@ -32,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: ${{ matrix.java-version }}
+          java-version: 18
 
       - name: Test
         run: ./gradlew build
@@ -95,7 +78,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 14
+          java-version: 18
 
       - name: Upload Artifacts
         run: ./gradlew publish

--- a/retrofit/build.gradle
+++ b/retrofit/build.gradle
@@ -26,3 +26,26 @@ jar {
     attributes  'Automatic-Module-Name': 'retrofit2'
   }
 }
+
+// Create a test task for each supported JDK.
+(8..17).each { majorVersion ->
+  // Adoptium JDK 9 cannot extract on Linux or Mac OS.
+  if (majorVersion == 9) return
+
+  def jdkTest = tasks.register("testJdk$majorVersion", Test) {
+    javaLauncher = javaToolchains.launcherFor {
+      languageVersion = JavaLanguageVersion.of(majorVersion)
+    }
+
+    description = "Runs the test suite on JDK $majorVersion"
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    // Copy inputs from normal Test task.
+    def testTask = tasks.getByName("test")
+    classpath = testTask.classpath
+    testClassesDirs = testTask.testClassesDirs
+  }
+  tasks.named("check").configure {
+    dependsOn(jdkTest)
+  }
+}


### PR DESCRIPTION
We only need to build on a single JDK (the latest, 18) and target the lowest supported (8).