### PR TITLE
Change old IETF reference link in `FormUrlEncoded` docs

### DIFF
--- a/retrofit/src/main/java/retrofit2/http/FormUrlEncoded.java
+++ b/retrofit/src/main/java/retrofit2/http/FormUrlEncoded.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  *
  * <p>Requests made with this annotation will have {@code application/x-www-form-urlencoded} MIME
  * type. Field names and values will be UTF-8 encoded before being URI-encoded in accordance to <a
- * href="http://tools.ietf.org/html/rfc3986">RFC-3986</a>.
+ * href="https://datatracker.ietf.org/doc/html/rfc3986">RFC-3986</a>.
  */
 @Documented
 @Target(METHOD)


### PR DESCRIPTION
Old link will throw 404, so it could be replaced with new working one