### PR TITLE
Add ability to set base url per service

### DIFF
--- a/retrofit/kotlin-test/src/test/java/retrofit2/KotlinRequestFactoryTest.java
+++ b/retrofit/kotlin-test/src/test/java/retrofit2/KotlinRequestFactoryTest.java
@@ -3,6 +3,8 @@ package retrofit2;
 import kotlin.Unit;
 import okhttp3.Request;
 import org.junit.Test;
+
+import retrofit2.http.BaseUrl;
 import retrofit2.http.HEAD;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,17 +13,34 @@ import static retrofit2.TestingUtils.buildRequest;
 public final class KotlinRequestFactoryTest {
   @Test
   public void headUnit() {
-    class Example {
+    Request request = buildRequest(Remote.class);
+    assertThat(request.method()).isEqualTo("HEAD");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.url().toString()).isEqualTo("http://example.com/foo/bar/");
+    assertThat(request.body()).isNull();
+  }
+
+  @Test
+  public void overrideBaseUrl() {
+    @BaseUrl("http://example2.com/")
+    class Remote2 {
       @HEAD("/foo/bar/")
       Call<Unit> method() {
         return null;
       }
     }
 
-    Request request = buildRequest(Example.class);
+    Request request = buildRequest(Remote2.class);
     assertThat(request.method()).isEqualTo("HEAD");
     assertThat(request.headers().size()).isZero();
-    assertThat(request.url().toString()).isEqualTo("http://example.com/foo/bar/");
+    assertThat(request.url().toString()).isEqualTo("http://example2.com/foo/bar/");
     assertThat(request.body()).isNull();
+  }
+
+  static class Remote {
+    @HEAD("/foo/bar/")
+    Call<Unit> method() {
+      return null;
+    }
   }
 }

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -163,7 +163,7 @@ public final class Retrofit {
                 Platform platform = Platform.get();
                 return platform.isDefaultMethod(method)
                     ? platform.invokeDefaultMethod(method, service, proxy, args)
-                    : loadServiceMethod(method).invoke(args);
+                    : loadServiceMethod(service, method).invoke(args);
               }
             });
   }
@@ -192,20 +192,20 @@ public final class Retrofit {
       Platform platform = Platform.get();
       for (Method method : service.getDeclaredMethods()) {
         if (!platform.isDefaultMethod(method) && !Modifier.isStatic(method.getModifiers())) {
-          loadServiceMethod(method);
+          loadServiceMethod(service, method);
         }
       }
     }
   }
 
-  ServiceMethod<?> loadServiceMethod(Method method) {
+  ServiceMethod<?> loadServiceMethod(Class<?> service, Method method) {
     ServiceMethod<?> result = serviceMethodCache.get(method);
     if (result != null) return result;
 
     synchronized (serviceMethodCache) {
       result = serviceMethodCache.get(method);
       if (result == null) {
-        result = ServiceMethod.parseAnnotations(this, method);
+        result = ServiceMethod.parseAnnotations(this, service, method);
         serviceMethodCache.put(method, result);
       }
     }

--- a/retrofit/src/main/java/retrofit2/ServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/ServiceMethod.java
@@ -22,8 +22,8 @@ import java.lang.reflect.Type;
 import javax.annotation.Nullable;
 
 abstract class ServiceMethod<T> {
-  static <T> ServiceMethod<T> parseAnnotations(Retrofit retrofit, Method method) {
-    RequestFactory requestFactory = RequestFactory.parseAnnotations(retrofit, method);
+  static <T> ServiceMethod<T> parseAnnotations(Retrofit retrofit, Class<?> service, Method method) {
+    RequestFactory requestFactory = RequestFactory.parseAnnotations(retrofit, service, method);
 
     Type returnType = method.getGenericReturnType();
     if (Utils.hasUnresolvableType(returnType)) {

--- a/retrofit/src/main/java/retrofit2/http/BaseUrl.java
+++ b/retrofit/src/main/java/retrofit2/http/BaseUrl.java
@@ -1,0 +1,22 @@
+package retrofit2.http;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import retrofit2.Retrofit;
+
+/**
+ * Use this annotation to override base url per service.
+ * By doing this you can use service per remote with one {@link Retrofit Retrofit} instance
+ *
+ */
+@Documented
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface BaseUrl {
+  String value();
+}

--- a/retrofit/test-helpers/src/main/java/retrofit2/TestingUtils.java
+++ b/retrofit/test-helpers/src/main/java/retrofit2/TestingUtils.java
@@ -21,7 +21,7 @@ import okhttp3.Request;
 import retrofit2.helpers.ToStringConverterFactory;
 
 final class TestingUtils {
-  static <T> Request buildRequest(Class<T> cls, Retrofit.Builder builder, Object... args) {
+  static <T> Request buildRequest(Class<T> serviceClass, Retrofit.Builder builder, Object... args) {
     okhttp3.Call.Factory callFactory =
       request -> {
         throw new UnsupportedOperationException("Not implemented");
@@ -29,9 +29,9 @@ final class TestingUtils {
 
     Retrofit retrofit = builder.callFactory(callFactory).build();
 
-    Method method = onlyMethod(cls);
+    Method method = onlyMethod(serviceClass);
     try {
-      return RequestFactory.parseAnnotations(retrofit, method).create(args);
+      return RequestFactory.parseAnnotations(retrofit, serviceClass, method).create(args);
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
@@ -39,13 +39,13 @@ final class TestingUtils {
     }
   }
 
-  static <T> Request buildRequest(Class<T> cls, Object... args) {
+  static <T> Request buildRequest(Class<T> serviceClass, Object... args) {
     Retrofit.Builder retrofitBuilder =
       new Retrofit.Builder()
         .baseUrl("http://example.com/")
         .addConverterFactory(new ToStringConverterFactory());
 
-    return buildRequest(cls, retrofitBuilder, args);
+    return buildRequest(serviceClass, retrofitBuilder, args);
   }
 
   static Method onlyMethod(Class c) {

--- a/samples/src/main/java/com/example/retrofit/MultiRemotes.java
+++ b/samples/src/main/java/com/example/retrofit/MultiRemotes.java
@@ -1,0 +1,51 @@
+package com.example.retrofit;
+
+import java.io.IOException;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.http.BaseUrl;
+import retrofit2.http.GET;
+
+public final class MultiRemotes {
+
+  public interface Remote {
+    @GET("robots.txt")
+    Call<ResponseBody> robots();
+  }
+
+  @BaseUrl("https://www.google.com/")
+  public interface Remote1 {
+    @GET("robots.txt")
+    Call<ResponseBody> robots();
+  }
+
+  @BaseUrl("https://www.facebook.com/")
+  public interface Remote2 {
+    @GET("robots.txt")
+    Call<ResponseBody> robots();
+  }
+
+  @SuppressWarnings("UnusedVariable")
+  public static void main(String... args) throws IOException {
+    Retrofit retrofit =
+      new Retrofit.Builder().baseUrl("http://www.github.com/").build();
+
+    Remote remote = retrofit.create(Remote.class);
+    Response<ResponseBody> response = remote.robots().execute();
+    System.out.println("Response from: " + response.raw().request().url());
+    System.out.println(response.body().string());
+
+    Remote1 remote1 = retrofit.create(Remote1.class);
+    Response<ResponseBody> response1 = remote1.robots().execute();
+    System.out.println("Response from: " + response1.raw().request().url());
+    System.out.println(response1.body().string());
+
+    Remote2 remote2 = retrofit.create(Remote2.class);
+    Response<ResponseBody> response2 = remote2.robots().execute();
+    System.out.println("Response from: " + response2.raw().request().url());
+    System.out.println(response2.body().string());
+  }
+}


### PR DESCRIPTION
I found this feature - https://github.com/square/retrofit/issues/2180#issuecomment-327833876 to be useful in android apps.
For example, when backend team decided to move and maybe refactor their code to other remote. And it's not one day change, so android app need to use two base urls - old one and new one. 
It can be done with prepending base url per each request for new service or use 2 retrofit instances. 
I'd not consider 2nd solution at all because it's not memory efficient + service creation pattern is error prone - you can accidentally create service from wrong retrofit instance.
1st solution works, but it requires lot of base url duplicates.

From other side this feature can be used in proxy servers, that use multiple remotes to fetch/operate.

PS.: I didn't completely understood from linked comment if you consider these use cases as valid, so please, accept my apologies if I missed something from this long v3 thread. 
But I don't see any pitfalls in changes made to support this feature, so I created this PR 😄 