### PR TITLE
build(deps): bump jackson from 2.12.4 to 2.14.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ rxjava3 = { module = "io.reactivex.rxjava3:rxjava", version = "3.1.1" }
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version = "1.0.3" }
 scalaLibrary = { module = "org.scala-lang:scala-library", version = "2.13.6" }
 gson = { module = "com.google.code.gson:gson", version = "2.9.0" }
-jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.12.4" }
+jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.14.2" }
 jaxbApi = { module = "javax.xml.bind:jaxb-api", version.ref = "jaxb" }
 jaxbImpl = { module = "org.glassfish.jaxb:jaxb-runtime", version.ref = "jaxb" }
 jaxb3Api = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version.ref = "jaxb3" }


### PR DESCRIPTION
Fixes 

> CVE-2020-25649 7.5 Improper Restriction of XML External Entity Reference vulnerability pending CVSS allocation
> CVE-2021-20190 8.1 Deserialization of Untrusted Data vulnerability pending CVSS allocation
> CVE-2020-10650 8.1 Deserialization of Untrusted Data vulnerability with high severity found
> Cxced0c06c-935c 5.9 Uncontrolled Resource Consumption vulnerability pending CVSS allocation
> CVE-2020-36518 7.5 Out-of-bounds Write vulnerability pending CVSS allocation
> CVE-2022-42003 7.5 Deserialization of Untrusted Data vulnerability pending CVSS allocation
> CVE-2022-42004 7.5 Deserialization of Untrusted Data vulnerability pending CVSS allocation