### PR TITLE
Add support for Kotlin's Result

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,8 @@ androidxTestRunner = { module = "androidx.test:runner", version = "1.4.0" }
 rxjava = { module = "io.reactivex:rxjava", version = "1.3.8" }
 rxjava2 = { module = "io.reactivex.rxjava2:rxjava", version = "2.2.21" }
 rxjava3 = { module = "io.reactivex.rxjava3:rxjava", version = "3.1.6" }
+rxjavaAdapter = { module = "com.squareup.retrofit2:adapter-rxjava2", version = "2.9.0"}
+rxjavaAdapter2 = { module = "com.squareup.retrofit2:converter-gson", version = "2.9.0"}
 reactiveStreams = { module = "org.reactivestreams:reactive-streams", version = "1.0.4" }
 scalaLibrary = { module = "org.scala-lang:scala-library", version = "2.13.10" }
 gson = { module = "com.google.code.gson:gson", version = "2.10.1" }

--- a/retrofit/kotlin-test/build.gradle
+++ b/retrofit/kotlin-test/build.gradle
@@ -8,4 +8,6 @@ dependencies {
   testImplementation libs.mockwebserver
   testImplementation libs.kotlinStdLib
   testImplementation libs.kotlinCoroutines
+  testImplementation libs.rxjavaAdapter
+  testImplementation libs.rxjavaAdapter2
 }

--- a/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
@@ -23,6 +23,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import javax.annotation.Nullable;
+
+import kotlin.Result;
 import kotlin.Unit;
 import kotlin.coroutines.Continuation;
 import okhttp3.ResponseBody;
@@ -52,15 +54,19 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
         // Unwrap the actual body type from Response<T>.
         responseType = Utils.getParameterUpperBound(0, (ParameterizedType) responseType);
         continuationWantsResponse = true;
+        adapterType = new Utils.ParameterizedTypeImpl(null, Call.class, responseType);
       } else {
+        if ((getRawType(responseType).isAssignableFrom(Result.class))) {
+          adapterType = responseType;
+        } else {
+          adapterType = new Utils.ParameterizedTypeImpl(null, Call.class, responseType);
+        }
         continuationIsUnit = Utils.isUnit(responseType);
         // TODO figure out if type is nullable or not
         // Metadata metadata = method.getDeclaringClass().getAnnotation(Metadata.class)
         // Find the entry for method
         // Determine if return type is nullable or not
       }
-
-      adapterType = new Utils.ParameterizedTypeImpl(null, Call.class, responseType);
       annotations = SkipCallbackExecutorImpl.ensurePresent(annotations);
     } else {
       adapterType = method.getGenericReturnType();

--- a/retrofit/src/main/java/retrofit2/ResultCallAdapterFactory.kt
+++ b/retrofit/src/main/java/retrofit2/ResultCallAdapterFactory.kt
@@ -1,0 +1,88 @@
+package retrofit2
+
+import java.io.IOException
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import okhttp3.Request
+import okio.Timeout
+
+class ResultCallAdapterFactory : CallAdapter.Factory() {
+  override fun get(
+    returnType: Type,
+    annotations: Array<Annotation>,
+    retrofit: Retrofit
+  ): CallAdapter<*, *>? {
+    if (getRawType(returnType) != Result::class.java) {
+      return null
+    }
+
+    check(returnType is ParameterizedType) {
+      "Result must have a generic type (e.g., Result<T>)"
+    }
+
+    val responseType = getParameterUpperBound(0, returnType)
+    return ResultCallAdapter<Any>(responseType)
+  }
+}
+
+class ResultCallAdapter<T>(
+  private val responseType: Type
+) : CallAdapter<T, Call<Result<T>>> {
+
+  override fun responseType(): Type {
+    return responseType
+  }
+
+  override fun adapt(call: Call<T>): Call<Result<out T>> {
+    return ResultCall(call)
+  }
+}
+
+class ResultCall<T>(private val delegate: Call<T>) : Call<Result<out T>> {
+
+  override fun enqueue(callback: Callback<Result<T>>) {
+    delegate.enqueue(object : Callback<T> {
+      override fun onResponse(call: Call<T>, response: Response<T>) {
+        val result = if (response.isSuccessful) {
+          Result.success(response.body()!!)
+        } else {
+          Result.failure(HttpException(response))
+        }
+        callback.onResponse(this@ResultCall, Response.success(result))
+      }
+
+      override fun onFailure(call: Call<T>, t: Throwable) {
+        callback.onResponse(this@ResultCall, Response.success(Result.failure(t)))
+      }
+    })
+  }
+
+  override fun execute(): Response<Result<T>> {
+    return try {
+      val response = delegate.execute()
+      val result = if (response.isSuccessful) {
+        Result.success(response.body()!!)
+      } else {
+        Result.failure(IOException("Unexpected error: ${response.errorBody()?.string()}"))
+      }
+      Response.success(result)
+    } catch (e: IOException) {
+      Response.success(Result.failure(e))
+    } catch (e: Exception) {
+      Response.success(Result.failure(e))
+    }
+  }
+  override fun isExecuted(): Boolean = delegate.isExecuted
+
+  override fun clone(): ResultCall<T> = ResultCall(delegate.clone())
+
+  override fun isCanceled(): Boolean = delegate.isCanceled
+
+  override fun cancel() = delegate.cancel()
+
+  override fun request(): Request = delegate.request()
+
+  override fun timeout(): Timeout = delegate.timeout()
+}
+
+


### PR DESCRIPTION
add the ResultCallAdapter to return [Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/) to wrap the outcome (success/failure) of a retrofit call, instead of returning a value or throwing an exception. #3558 

like

@GET("me")
suspend fun getUser(): Result<User>

all the testcase in Kotlin-test package and  retrofit-adapter moudle's test case has been passed