### PR TITLE
Add keep rule for keeping generic signature of return types

### DIFF
--- a/retrofit-adapters/guava/src/main/resources/META-INF/proguard/retrofit2-guava-adapter.pro
+++ b/retrofit-adapters/guava/src/main/resources/META-INF/proguard/retrofit2-guava-adapter.pro
@@ -1,2 +1,0 @@
-# Keep generic signature of ListenableFuture (R8 full mode strips signatures from non-kept items).
--keep,allowobfuscation,allowshrinking class com.google.common.util.concurrent.ListenableFuture

--- a/retrofit-adapters/rxjava/src/main/resources/META-INF/proguard/retrofit2-rxjava-adapter.pro
+++ b/retrofit-adapters/rxjava/src/main/resources/META-INF/proguard/retrofit2-rxjava-adapter.pro
@@ -1,3 +1,0 @@
-# Keep generic signature of RxJava (R8 full mode strips signatures from non-kept items).
--keep,allowobfuscation,allowshrinking class rx.Single
--keep,allowobfuscation,allowshrinking class rx.Observable

--- a/retrofit-adapters/rxjava2/src/main/resources/META-INF/proguard/retrofit2-rxjava2-adapter.pro
+++ b/retrofit-adapters/rxjava2/src/main/resources/META-INF/proguard/retrofit2-rxjava2-adapter.pro
@@ -1,5 +1,0 @@
-# Keep generic signature of RxJava2 (R8 full mode strips signatures from non-kept items).
--keep,allowobfuscation,allowshrinking class io.reactivex.Flowable
--keep,allowobfuscation,allowshrinking class io.reactivex.Maybe
--keep,allowobfuscation,allowshrinking class io.reactivex.Observable
--keep,allowobfuscation,allowshrinking class io.reactivex.Single

--- a/retrofit-adapters/rxjava3/src/main/resources/META-INF/proguard/retrofit2-rxjava3-adapter.pro
+++ b/retrofit-adapters/rxjava3/src/main/resources/META-INF/proguard/retrofit2-rxjava3-adapter.pro
@@ -1,5 +1,0 @@
-# Keep generic signature of RxJava3 (R8 full mode strips signatures from non-kept items).
--keep,allowobfuscation,allowshrinking class io.reactivex.rxjava3.core.Flowable
--keep,allowobfuscation,allowshrinking class io.reactivex.rxjava3.core.Maybe
--keep,allowobfuscation,allowshrinking class io.reactivex.rxjava3.core.Observable
--keep,allowobfuscation,allowshrinking class io.reactivex.rxjava3.core.Single

--- a/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -35,11 +35,11 @@
 -if interface * { @retrofit2.http.* <methods>; }
 -keep,allowobfuscation interface * extends <1>
 
-# Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
--keep,allowobfuscation,allowshrinking interface retrofit2.Call
--keep,allowobfuscation,allowshrinking class retrofit2.Response
-
 # With R8 full mode generic signatures are stripped for classes that are not
 # kept. Suspend functions are wrapped in continuations where the type argument
 # is used.
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# R8 full mode strips generic signatures from return types if not kept.
+-if interface * { @retrofit2.http.* public *** *(...); }
+-keep,allowoptimization,allowshrinking,allowobfuscation class <3>


### PR DESCRIPTION
The additional rule generalises keeping the generic signature of return type of service methods. The rule effectively fixes an issue with RxJava3 Observables as reported in b/280277628.