### PR TITLE
Add proguard config for R8 to keep type information for generic signatures of retrofit2.Response

### DIFF
--- a/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -43,3 +43,6 @@
 # R8 full mode strips generic signatures from return types if not kept.
 -if interface * { @retrofit2.http.* public *** *(...); }
 -keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+
+# R8 full mode strips generic signatures from return types if not kept.
+-keep,allowobfuscation,allowshrinking class retrofit2.Response

--- a/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -44,5 +44,5 @@
 -if interface * { @retrofit2.http.* public *** *(...); }
 -keep,allowoptimization,allowshrinking,allowobfuscation class <3>
 
-# R8 full mode strips generic signatures from return types if not kept.
+# With R8 full mode generic signatures are stripped for classes that are not kept.
 -keep,allowobfuscation,allowshrinking class retrofit2.Response


### PR DESCRIPTION
This rule is needed with R8 full mode for interfaces such as in the example below, as R8 strips generic signatures of `Response`.

Follow up of #3596.

```kotlin
interface WebApi {
    @GET("/api/data")
    fun getData(): Single<Response<MyData>>

    @GET("/api/data")
    suspend fun getDataSuspending(): Response<MyData>
}
```