### PR TITLE
Capture `Throwable` subtypes in suspend functions

### DIFF
--- a/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
+++ b/retrofit/src/main/java/retrofit2/HttpServiceMethod.java
@@ -243,7 +243,10 @@ abstract class HttpServiceMethod<ResponseT, ReturnT> extends ServiceMethod<Retur
         } else {
           return KotlinExtensions.await(call, continuation);
         }
-      } catch (Exception e) {
+      } catch (VirtualMachineError | ThreadDeath | LinkageError e) {
+        // Do not attempt to capture fatal throwables. This list is derived RxJava's `throwIfFatal`.
+        throw e;
+      } catch (Throwable e) {
         return KotlinExtensions.suspendAndThrow(e, continuation);
       }
     }

--- a/retrofit/src/main/java/retrofit2/KotlinExtensions.kt
+++ b/retrofit/src/main/java/retrofit2/KotlinExtensions.kt
@@ -116,7 +116,7 @@ suspend fun <T> Call<T>.awaitResponse(): Response<T> {
  * The implementation is derived from:
  * https://github.com/Kotlin/kotlinx.coroutines/pull/1667#issuecomment-556106349
  */
-internal suspend fun Exception.suspendAndThrow(): Nothing {
+internal suspend fun Throwable.suspendAndThrow(): Nothing {
   suspendCoroutineUninterceptedOrReturn<Nothing> { continuation ->
     Dispatchers.Default.dispatch(continuation.context) {
       continuation.intercepted().resumeWithException(this@suspendAndThrow)


### PR DESCRIPTION
These will otherwise trigger undeclared throwable exceptions from the proxy.

Closes #3804