### PR TITLE
Close open return points of the response and response body

### DIFF
--- a/retrofit/src/main/java/retrofit2/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit2/OkHttpCall.java
@@ -234,8 +234,11 @@ final class OkHttpCall<T> implements Call<T> {
     }
 
     if (code == 204 || code == 205) {
-      rawBody.close();
-      return Response.success(null, rawResponse);
+      try {
+        return Response.success(null, rawResponse);
+      } finally {
+        rawBody.close();
+      }
     }
 
     ExceptionCatchingResponseBody catchingBody = new ExceptionCatchingResponseBody(rawBody);
@@ -245,6 +248,7 @@ final class OkHttpCall<T> implements Call<T> {
     } catch (RuntimeException e) {
       // If the underlying source threw an exception, propagate that rather than indicating it was
       // a runtime exception.
+      catchingBody.close();
       catchingBody.throwIfCaught();
       throw e;
     }


### PR DESCRIPTION
We receive the following logs from our services. This pull request fixes the issue. I'm aware that `retrofit2.CallTest#responseBodyStreams` test fails but I think we should refactor it too.
```
java.lang.Throwable: response.body().close()
	at okhttp3.internal.platform.Platform.getStackTraceForCloseable(Platform.kt:145)
	at okhttp3.internal.connection.RealCall.callStart(RealCall.kt:170)
	at okhttp3.internal.connection.RealCall.execute(RealCall.kt:151)
	at retrofit2.OkHttpCall.execute(OkHttpCall.java:204)
	at retrofit2.adapter.rxjava3.CallExecuteObservable.subscribeActual(CallExecuteObservable.java:46)
	at io.reactivex.rxjava3.core.Observable.subscribe(Observable.java:13262)
	at retrofit2.adapter.rxjava3.BodyObservable.subscribeActual(BodyObservable.java:35)
	at io.reactivex.rxjava3.core.Observable.subscribe(Observable.java:13262)
	at io.reactivex.rxjava3.core.Observable.blockingFirst(Observable.java:5453)
```
Closes #3956 