### PR TITLE
feat(converters): change Converter.convert to throw ConversionException instead of IOException

### DIFF
--- a/retrofit-adapters/guava/src/main/java/retrofit2/adapter/guava/HttpException.java
+++ b/retrofit-adapters/guava/src/main/java/retrofit2/adapter/guava/HttpException.java
@@ -17,7 +17,9 @@ package retrofit2.adapter.guava;
 
 import retrofit2.Response;
 
-/** @deprecated Use {@link retrofit2.HttpException}. */
+/**
+ * @deprecated Use {@link retrofit2.HttpException}.
+ */
 @Deprecated
 public final class HttpException extends retrofit2.HttpException {
   public HttpException(Response<?> response) {

--- a/retrofit-adapters/guava/src/test/java/retrofit2/adapter/guava/StringConverterFactory.java
+++ b/retrofit-adapters/guava/src/test/java/retrofit2/adapter/guava/StringConverterFactory.java
@@ -15,11 +15,13 @@
  */
 package retrofit2.adapter.guava;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
@@ -27,7 +29,13 @@ final class StringConverterFactory extends Converter.Factory {
   @Override
   public Converter<ResponseBody, String> responseBodyConverter(
       Type type, Annotation[] annotations, Retrofit retrofit) {
-    return ResponseBody::string;
+    return (ResponseBody responseBody) -> {
+      try {
+        return responseBody.string();
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
+    };
   }
 
   @Override

--- a/retrofit-adapters/java8/src/main/java/retrofit2/adapter/java8/HttpException.java
+++ b/retrofit-adapters/java8/src/main/java/retrofit2/adapter/java8/HttpException.java
@@ -17,7 +17,9 @@ package retrofit2.adapter.java8;
 
 import retrofit2.Response;
 
-/** @deprecated Use {@link retrofit2.HttpException}. */
+/**
+ * @deprecated Use {@link retrofit2.HttpException}.
+ */
 @Deprecated
 public final class HttpException extends retrofit2.HttpException {
   public HttpException(Response<?> response) {

--- a/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/StringConverterFactory.java
+++ b/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/StringConverterFactory.java
@@ -15,11 +15,13 @@
  */
 package retrofit2.adapter.java8;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
@@ -27,7 +29,13 @@ final class StringConverterFactory extends Converter.Factory {
   @Override
   public Converter<ResponseBody, String> responseBodyConverter(
       Type type, Annotation[] annotations, Retrofit retrofit) {
-    return ResponseBody::string;
+    return (ResponseBody responseBody) -> {
+      try {
+        return responseBody.string();
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
+    };
   }
 
   @Override

--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/BodyOnSubscribe.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/BodyOnSubscribe.java
@@ -39,6 +39,7 @@ final class BodyOnSubscribe<T> implements OnSubscribe<T> {
 
   private static class BodySubscriber<R> extends Subscriber<Response<R>> {
     private final Subscriber<? super R> subscriber;
+
     /** Indicates whether a terminal event has been sent to {@link #subscriber}. */
     private boolean subscriberTerminated;
 

--- a/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/HttpException.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/HttpException.java
@@ -2,7 +2,9 @@ package retrofit2.adapter.rxjava;
 
 import retrofit2.Response;
 
-/** @deprecated Use {@link retrofit2.HttpException}. */
+/**
+ * @deprecated Use {@link retrofit2.HttpException}.
+ */
 @Deprecated
 public final class HttpException extends retrofit2.HttpException {
   public HttpException(Response<?> response) {

--- a/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/StringConverterFactory.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/StringConverterFactory.java
@@ -15,11 +15,13 @@
  */
 package retrofit2.adapter.rxjava;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
@@ -27,7 +29,13 @@ final class StringConverterFactory extends Converter.Factory {
   @Override
   public Converter<ResponseBody, String> responseBodyConverter(
       Type type, Annotation[] annotations, Retrofit retrofit) {
-    return ResponseBody::string;
+    return (ResponseBody responseBody) -> {
+      try {
+        return responseBody.string();
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
+    };
   }
 
   @Override

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/HttpException.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/HttpException.java
@@ -17,7 +17,9 @@ package retrofit2.adapter.rxjava2;
 
 import retrofit2.Response;
 
-/** @deprecated Use {@link retrofit2.HttpException}. */
+/**
+ * @deprecated Use {@link retrofit2.HttpException}.
+ */
 @Deprecated
 public final class HttpException extends retrofit2.HttpException {
   public HttpException(Response<?> response) {

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/StringConverterFactory.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/StringConverterFactory.java
@@ -15,11 +15,13 @@
  */
 package retrofit2.adapter.rxjava2;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
@@ -27,7 +29,13 @@ final class StringConverterFactory extends Converter.Factory {
   @Override
   public Converter<ResponseBody, String> responseBodyConverter(
       Type type, Annotation[] annotations, Retrofit retrofit) {
-    return ResponseBody::string;
+    return (ResponseBody responseBody) -> {
+      try {
+        return responseBody.string();
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
+    };
   }
 
   @Override

--- a/retrofit-adapters/rxjava3/src/main/java/retrofit2/adapter/rxjava3/HttpException.java
+++ b/retrofit-adapters/rxjava3/src/main/java/retrofit2/adapter/rxjava3/HttpException.java
@@ -17,7 +17,9 @@ package retrofit2.adapter.rxjava3;
 
 import retrofit2.Response;
 
-/** @deprecated Use {@link retrofit2.HttpException}. */
+/**
+ * @deprecated Use {@link retrofit2.HttpException}.
+ */
 @Deprecated
 public final class HttpException extends retrofit2.HttpException {
   public HttpException(Response<?> response) {

--- a/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/StringConverterFactory.java
+++ b/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/StringConverterFactory.java
@@ -15,11 +15,13 @@
  */
 package retrofit2.adapter.rxjava3;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
@@ -27,7 +29,13 @@ final class StringConverterFactory extends Converter.Factory {
   @Override
   public Converter<ResponseBody, String> responseBodyConverter(
       Type type, Annotation[] annotations, Retrofit retrofit) {
-    return ResponseBody::string;
+    return (ResponseBody responseBody) -> {
+      try {
+        return responseBody.string();
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
+    };
   }
 
   @Override

--- a/retrofit-adapters/scala/src/test/java/retrofit2/adapter/scala/StringConverterFactory.java
+++ b/retrofit-adapters/scala/src/test/java/retrofit2/adapter/scala/StringConverterFactory.java
@@ -15,11 +15,13 @@
  */
 package retrofit2.adapter.scala;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
@@ -27,7 +29,13 @@ final class StringConverterFactory extends Converter.Factory {
   @Override
   public Converter<ResponseBody, String> responseBodyConverter(
       Type type, Annotation[] annotations, Retrofit retrofit) {
-    return ResponseBody::string;
+    return (ResponseBody responseBody) -> {
+      try {
+        return responseBody.string();
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
+    };
   }
 
   @Override

--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonRequestBodyConverter.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonRequestBodyConverter.java
@@ -26,6 +26,7 @@ import java.io.Writer;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okio.Buffer;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class GsonRequestBodyConverter<T> implements Converter<T, RequestBody> {
@@ -40,12 +41,16 @@ final class GsonRequestBodyConverter<T> implements Converter<T, RequestBody> {
   }
 
   @Override
-  public RequestBody convert(T value) throws IOException {
-    Buffer buffer = new Buffer();
-    Writer writer = new OutputStreamWriter(buffer.outputStream(), UTF_8);
-    JsonWriter jsonWriter = gson.newJsonWriter(writer);
-    adapter.write(jsonWriter, value);
-    jsonWriter.close();
-    return RequestBody.create(MEDIA_TYPE, buffer.readByteString());
+  public RequestBody convert(T value) throws ConversionException {
+    try {
+      Buffer buffer = new Buffer();
+      Writer writer = new OutputStreamWriter(buffer.outputStream(), UTF_8);
+      JsonWriter jsonWriter = gson.newJsonWriter(writer);
+      adapter.write(jsonWriter, value);
+      jsonWriter.close();
+      return RequestBody.create(MEDIA_TYPE, buffer.readByteString());
+    } catch (IOException e) {
+      throw new ConversionException(e);
+    }
   }
 }

--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonResponseBodyConverter.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonResponseBodyConverter.java
@@ -22,6 +22,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import java.io.IOException;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class GsonResponseBodyConverter<T> implements Converter<ResponseBody, T> {
@@ -34,7 +35,7 @@ final class GsonResponseBodyConverter<T> implements Converter<ResponseBody, T> {
   }
 
   @Override
-  public T convert(ResponseBody value) throws IOException {
+  public T convert(ResponseBody value) throws ConversionException {
     JsonReader jsonReader = gson.newJsonReader(value.charStream());
     try {
       T result = adapter.read(jsonReader);
@@ -42,6 +43,8 @@ final class GsonResponseBodyConverter<T> implements Converter<ResponseBody, T> {
         throw new JsonIOException("JSON document was not fully consumed.");
       }
       return result;
+    } catch (IOException e) {
+      throw new ConversionException(e);
     } finally {
       value.close();
     }

--- a/retrofit-converters/guava/src/main/java/retrofit/converter/guava/OptionalConverter.java
+++ b/retrofit-converters/guava/src/main/java/retrofit/converter/guava/OptionalConverter.java
@@ -16,8 +16,8 @@
 package retrofit.converter.guava;
 
 import com.google.common.base.Optional;
-import java.io.IOException;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class OptionalConverter<T> implements Converter<ResponseBody, Optional<T>> {
@@ -28,7 +28,7 @@ final class OptionalConverter<T> implements Converter<ResponseBody, Optional<T>>
   }
 
   @Override
-  public Optional<T> convert(ResponseBody value) throws IOException {
+  public Optional<T> convert(ResponseBody value) throws ConversionException {
     return Optional.fromNullable(delegate.convert(value));
   }
 }

--- a/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonRequestBodyConverter.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonRequestBodyConverter.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.IOException;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class JacksonRequestBodyConverter<T> implements Converter<T, RequestBody> {
@@ -31,8 +32,12 @@ final class JacksonRequestBodyConverter<T> implements Converter<T, RequestBody> 
   }
 
   @Override
-  public RequestBody convert(T value) throws IOException {
-    byte[] bytes = adapter.writeValueAsBytes(value);
-    return RequestBody.create(MEDIA_TYPE, bytes);
+  public RequestBody convert(T value) throws ConversionException {
+    try {
+      byte[] bytes = adapter.writeValueAsBytes(value);
+      return RequestBody.create(MEDIA_TYPE, bytes);
+    } catch (IOException e) {
+      throw new ConversionException(e);
+    }
   }
 }

--- a/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonResponseBodyConverter.java
+++ b/retrofit-converters/jackson/src/main/java/retrofit2/converter/jackson/JacksonResponseBodyConverter.java
@@ -18,6 +18,7 @@ package retrofit2.converter.jackson;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class JacksonResponseBodyConverter<T> implements Converter<ResponseBody, T> {
@@ -28,9 +29,11 @@ final class JacksonResponseBodyConverter<T> implements Converter<ResponseBody, T
   }
 
   @Override
-  public T convert(ResponseBody value) throws IOException {
+  public T convert(ResponseBody value) throws ConversionException {
     try {
       return adapter.readValue(value.charStream());
+    } catch (IOException e) {
+      throw new ConversionException(e);
     } finally {
       value.close();
     }

--- a/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbRequestConverter.java
+++ b/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbRequestConverter.java
@@ -15,15 +15,16 @@
  */
 package retrofit2.converter.jaxb;
 
-import java.io.IOException;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.MarshalException;
 import javax.xml.bind.Marshaller;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import okhttp3.RequestBody;
 import okio.Buffer;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class JaxbRequestConverter<T> implements Converter<T, RequestBody> {
@@ -37,7 +38,7 @@ final class JaxbRequestConverter<T> implements Converter<T, RequestBody> {
   }
 
   @Override
-  public RequestBody convert(final T value) throws IOException {
+  public RequestBody convert(final T value) throws ConversionException {
     Buffer buffer = new Buffer();
     try {
       Marshaller marshaller = context.createMarshaller();
@@ -46,6 +47,8 @@ final class JaxbRequestConverter<T> implements Converter<T, RequestBody> {
           xmlOutputFactory.createXMLStreamWriter(
               buffer.outputStream(), JaxbConverterFactory.XML.charset().name());
       marshaller.marshal(value, xmlWriter);
+    } catch (MarshalException e) {
+      throw new ConversionException(e);
     } catch (JAXBException | XMLStreamException e) {
       throw new RuntimeException(e);
     }

--- a/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbResponseConverter.java
+++ b/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbResponseConverter.java
@@ -15,14 +15,15 @@
  */
 package retrofit2.converter.jaxb;
 
-import java.io.IOException;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.UnmarshalException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class JaxbResponseConverter<T> implements Converter<ResponseBody, T> {
@@ -40,11 +41,13 @@ final class JaxbResponseConverter<T> implements Converter<ResponseBody, T> {
   }
 
   @Override
-  public T convert(ResponseBody value) throws IOException {
+  public T convert(ResponseBody value) throws ConversionException {
     try {
       Unmarshaller unmarshaller = context.createUnmarshaller();
       XMLStreamReader streamReader = xmlInputFactory.createXMLStreamReader(value.charStream());
       return unmarshaller.unmarshal(streamReader, type).getValue();
+    } catch (UnmarshalException e) {
+      throw new ConversionException(e);
     } catch (JAXBException | XMLStreamException e) {
       throw new RuntimeException(e);
     } finally {

--- a/retrofit-converters/jaxb/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
+++ b/retrofit-converters/jaxb/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import java.util.Collections;
 import javax.xml.bind.JAXBContext;
+import javax.xml.bind.UnmarshalException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -129,6 +130,7 @@ public final class JaxbConverterFactoryTest {
 
     Call<Contact> call = service.getXml();
     RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
   }
 
@@ -171,6 +173,7 @@ public final class JaxbConverterFactoryTest {
 
     Call<Contact> call = service.getXml();
     RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);
   }
@@ -198,6 +201,7 @@ public final class JaxbConverterFactoryTest {
 
     Call<Contact> call = service.getXml();
     RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);
   }

--- a/retrofit-converters/jaxb/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
+++ b/retrofit-converters/jaxb/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
@@ -15,8 +15,8 @@
  */
 package retrofit2.converter.jaxb;
 
-import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import java.util.Collections;
 import javax.xml.bind.JAXBContext;
@@ -128,12 +128,8 @@ public final class JaxbConverterFactoryTest {
     server.enqueue(new MockResponse().setBody("This is not XML"));
 
     Call<Contact> call = service.getXml();
-    try {
-      call.execute();
-      fail();
-    } catch (RuntimeException expected) {
-      assertThat(expected).hasMessageContaining("ParseError");
-    }
+    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasMessageContaining("ParseError");
   }
 
   @Test
@@ -174,14 +170,8 @@ public final class JaxbConverterFactoryTest {
     server.enqueue(new MockResponse().setBody("hello"));
 
     Call<Contact> call = service.getXml();
-    try {
-      Response<Contact> response = call.execute();
-      response.body();
-      fail();
-    } catch (RuntimeException expected) {
-      assertThat(expected).hasMessageContaining("ParseError");
-    }
-
+    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);
   }
 
@@ -207,14 +197,8 @@ public final class JaxbConverterFactoryTest {
                     + "<!ENTITY secret \"hello\">"));
 
     Call<Contact> call = service.getXml();
-    try {
-      Response<Contact> response = call.execute();
-      response.body();
-      fail();
-    } catch (RuntimeException expected) {
-      assertThat(expected).hasMessageContaining("ParseError");
-    }
-
+    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);
   }
 }

--- a/retrofit-converters/jaxb/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
+++ b/retrofit-converters/jaxb/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import retrofit2.Call;
+import retrofit2.ConversionException;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.http.Body;
@@ -129,7 +130,7 @@ public final class JaxbConverterFactoryTest {
     server.enqueue(new MockResponse().setBody("This is not XML"));
 
     Call<Contact> call = service.getXml();
-    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    ConversionException expected = catchThrowableOfType(call::execute, ConversionException.class);
     assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
   }
@@ -172,7 +173,7 @@ public final class JaxbConverterFactoryTest {
     server.enqueue(new MockResponse().setBody("hello"));
 
     Call<Contact> call = service.getXml();
-    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    ConversionException expected = catchThrowableOfType(call::execute, ConversionException.class);
     assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);
@@ -200,7 +201,7 @@ public final class JaxbConverterFactoryTest {
                     + "<!ENTITY secret \"hello\">"));
 
     Call<Contact> call = service.getXml();
-    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    ConversionException expected = catchThrowableOfType(call::execute, ConversionException.class);
     assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);

--- a/retrofit-converters/jaxb3/src/main/java/retrofit2/converter/jaxb/JaxbRequestConverter.java
+++ b/retrofit-converters/jaxb3/src/main/java/retrofit2/converter/jaxb/JaxbRequestConverter.java
@@ -17,13 +17,14 @@ package retrofit2.converter.jaxb;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.MarshalException;
 import jakarta.xml.bind.Marshaller;
-import java.io.IOException;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import okhttp3.RequestBody;
 import okio.Buffer;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class JaxbRequestConverter<T> implements Converter<T, RequestBody> {
@@ -37,7 +38,7 @@ final class JaxbRequestConverter<T> implements Converter<T, RequestBody> {
   }
 
   @Override
-  public RequestBody convert(final T value) throws IOException {
+  public RequestBody convert(final T value) throws ConversionException {
     Buffer buffer = new Buffer();
     try {
       Marshaller marshaller = context.createMarshaller();
@@ -46,6 +47,8 @@ final class JaxbRequestConverter<T> implements Converter<T, RequestBody> {
           xmlOutputFactory.createXMLStreamWriter(
               buffer.outputStream(), JaxbConverterFactory.XML.charset().name());
       marshaller.marshal(value, xmlWriter);
+    } catch (MarshalException e) {
+      throw new ConversionException(e);
     } catch (JAXBException | XMLStreamException e) {
       throw new RuntimeException(e);
     }

--- a/retrofit-converters/jaxb3/src/main/java/retrofit2/converter/jaxb/JaxbResponseConverter.java
+++ b/retrofit-converters/jaxb3/src/main/java/retrofit2/converter/jaxb/JaxbResponseConverter.java
@@ -17,12 +17,13 @@ package retrofit2.converter.jaxb;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.UnmarshalException;
 import jakarta.xml.bind.Unmarshaller;
-import java.io.IOException;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class JaxbResponseConverter<T> implements Converter<ResponseBody, T> {
@@ -40,11 +41,13 @@ final class JaxbResponseConverter<T> implements Converter<ResponseBody, T> {
   }
 
   @Override
-  public T convert(ResponseBody value) throws IOException {
+  public T convert(ResponseBody value) throws ConversionException {
     try {
       Unmarshaller unmarshaller = context.createUnmarshaller();
       XMLStreamReader streamReader = xmlInputFactory.createXMLStreamReader(value.charStream());
       return unmarshaller.unmarshal(streamReader, type).getValue();
+    } catch (UnmarshalException e) {
+      throw new ConversionException(e);
     } catch (JAXBException | XMLStreamException e) {
       throw new RuntimeException(e);
     } finally {

--- a/retrofit-converters/jaxb3/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
+++ b/retrofit-converters/jaxb3/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.UnmarshalException;
 import java.util.Collections;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -129,6 +130,7 @@ public final class JaxbConverterFactoryTest {
 
     Call<Contact> call = service.getXml();
     RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
   }
 
@@ -171,6 +173,7 @@ public final class JaxbConverterFactoryTest {
 
     Call<Contact> call = service.getXml();
     RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);
   }
@@ -198,6 +201,7 @@ public final class JaxbConverterFactoryTest {
 
     Call<Contact> call = service.getXml();
     RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);
   }

--- a/retrofit-converters/jaxb3/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
+++ b/retrofit-converters/jaxb3/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
@@ -15,8 +15,8 @@
  */
 package retrofit2.converter.jaxb;
 
-import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import jakarta.xml.bind.JAXBContext;
 import java.util.Collections;
@@ -128,12 +128,8 @@ public final class JaxbConverterFactoryTest {
     server.enqueue(new MockResponse().setBody("This is not XML"));
 
     Call<Contact> call = service.getXml();
-    try {
-      call.execute();
-      fail();
-    } catch (RuntimeException expected) {
-      assertThat(expected).hasMessageContaining("ParseError");
-    }
+    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasMessageContaining("ParseError");
   }
 
   @Test
@@ -174,14 +170,8 @@ public final class JaxbConverterFactoryTest {
     server.enqueue(new MockResponse().setBody("hello"));
 
     Call<Contact> call = service.getXml();
-    try {
-      Response<Contact> response = call.execute();
-      response.body();
-      fail();
-    } catch (RuntimeException expected) {
-      assertThat(expected).hasMessageContaining("ParseError");
-    }
-
+    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);
   }
 
@@ -207,14 +197,8 @@ public final class JaxbConverterFactoryTest {
                     + "<!ENTITY secret \"hello\">"));
 
     Call<Contact> call = service.getXml();
-    try {
-      Response<Contact> response = call.execute();
-      response.body();
-      fail();
-    } catch (RuntimeException expected) {
-      assertThat(expected).hasMessageContaining("ParseError");
-    }
-
+    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);
   }
 }

--- a/retrofit-converters/jaxb3/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
+++ b/retrofit-converters/jaxb3/src/test/java/retrofit2/converter/jaxb/JaxbConverterFactoryTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import retrofit2.Call;
+import retrofit2.ConversionException;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.http.Body;
@@ -129,7 +130,7 @@ public final class JaxbConverterFactoryTest {
     server.enqueue(new MockResponse().setBody("This is not XML"));
 
     Call<Contact> call = service.getXml();
-    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    ConversionException expected = catchThrowableOfType(call::execute, ConversionException.class);
     assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
   }
@@ -172,7 +173,7 @@ public final class JaxbConverterFactoryTest {
     server.enqueue(new MockResponse().setBody("hello"));
 
     Call<Contact> call = service.getXml();
-    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    ConversionException expected = catchThrowableOfType(call::execute, ConversionException.class);
     assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);
@@ -200,7 +201,7 @@ public final class JaxbConverterFactoryTest {
                     + "<!ENTITY secret \"hello\">"));
 
     Call<Contact> call = service.getXml();
-    RuntimeException expected = catchThrowableOfType(call::execute, RuntimeException.class);
+    ConversionException expected = catchThrowableOfType(call::execute, ConversionException.class);
     assertThat(expected).hasCauseInstanceOf(UnmarshalException.class);
     assertThat(expected).hasMessageContaining("ParseError");
     assertThat(server.getRequestCount()).isEqualTo(1);

--- a/retrofit-converters/moshi/src/main/java/retrofit2/converter/moshi/MoshiRequestBodyConverter.java
+++ b/retrofit-converters/moshi/src/main/java/retrofit2/converter/moshi/MoshiRequestBodyConverter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okio.Buffer;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class MoshiRequestBodyConverter<T> implements Converter<T, RequestBody> {
@@ -33,10 +34,14 @@ final class MoshiRequestBodyConverter<T> implements Converter<T, RequestBody> {
   }
 
   @Override
-  public RequestBody convert(T value) throws IOException {
+  public RequestBody convert(T value) throws ConversionException {
     Buffer buffer = new Buffer();
     JsonWriter writer = JsonWriter.of(buffer);
-    adapter.toJson(writer, value);
+    try {
+      adapter.toJson(writer, value);
+    } catch (IOException e) {
+      throw new ConversionException(e);
+    }
     return RequestBody.create(MEDIA_TYPE, buffer.readByteString());
   }
 }

--- a/retrofit-converters/moshi/src/main/java/retrofit2/converter/moshi/MoshiResponseBodyConverter.java
+++ b/retrofit-converters/moshi/src/main/java/retrofit2/converter/moshi/MoshiResponseBodyConverter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import okhttp3.ResponseBody;
 import okio.BufferedSource;
 import okio.ByteString;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class MoshiResponseBodyConverter<T> implements Converter<ResponseBody, T> {
@@ -34,7 +35,7 @@ final class MoshiResponseBodyConverter<T> implements Converter<ResponseBody, T> 
   }
 
   @Override
-  public T convert(ResponseBody value) throws IOException {
+  public T convert(ResponseBody value) throws ConversionException {
     BufferedSource source = value.source();
     try {
       // Moshi has no document-level API so the responsibility of BOM skipping falls to whatever
@@ -48,6 +49,8 @@ final class MoshiResponseBodyConverter<T> implements Converter<ResponseBody, T> 
         throw new JsonDataException("JSON document was not fully consumed.");
       }
       return result;
+    } catch (IOException e) {
+      throw new ConversionException(e);
     } finally {
       value.close();
     }

--- a/retrofit-converters/moshi/src/test/java/retrofit2/converter/moshi/MoshiConverterFactoryTest.java
+++ b/retrofit-converters/moshi/src/test/java/retrofit2/converter/moshi/MoshiConverterFactoryTest.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import retrofit2.Call;
+import retrofit2.ConversionException;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.http.Body;
@@ -235,8 +236,10 @@ public final class MoshiConverterFactoryTest {
     server.enqueue(malformedResponse);
 
     Call<AnImplementation> call = service.anImplementation(new AnImplementation("value"));
-    IOException e = catchThrowableOfType(call::execute, IOException.class);
-    assertThat(e)
+    ConversionException e = catchThrowableOfType(call::execute, ConversionException.class);
+    assertThat(e).hasCauseInstanceOf(IOException.class);
+    IOException ioException = (IOException) e.getCause();
+    assertThat(ioException)
         .hasMessage("Use JsonReader.setLenient(true) to accept malformed JSON at path $.theName");
 
     Call<AnImplementation> call2 = serviceLenient.anImplementation(new AnImplementation("value"));

--- a/retrofit-converters/moshi/src/test/java/retrofit2/converter/moshi/MoshiConverterFactoryTest.java
+++ b/retrofit-converters/moshi/src/test/java/retrofit2/converter/moshi/MoshiConverterFactoryTest.java
@@ -236,9 +236,8 @@ public final class MoshiConverterFactoryTest {
 
     Call<AnImplementation> call = service.anImplementation(new AnImplementation("value"));
     IOException e = catchThrowableOfType(call::execute, IOException.class);
-    assertEquals(
-        e.getMessage(),
-        "Use JsonReader.setLenient(true) to accept malformed JSON at path $.theName");
+    assertThat(e)
+        .hasMessage("Use JsonReader.setLenient(true) to accept malformed JSON at path $.theName");
 
     Call<AnImplementation> call2 = serviceLenient.anImplementation(new AnImplementation("value"));
     Response<AnImplementation> response = call2.execute();

--- a/retrofit-converters/moshi/src/test/java/retrofit2/converter/moshi/MoshiConverterFactoryTest.java
+++ b/retrofit-converters/moshi/src/test/java/retrofit2/converter/moshi/MoshiConverterFactoryTest.java
@@ -17,8 +17,8 @@ package retrofit2.converter.moshi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import com.squareup.moshi.FromJson;
 import com.squareup.moshi.JsonDataException;
@@ -235,14 +235,10 @@ public final class MoshiConverterFactoryTest {
     server.enqueue(malformedResponse);
 
     Call<AnImplementation> call = service.anImplementation(new AnImplementation("value"));
-    try {
-      call.execute();
-      fail();
-    } catch (IOException e) {
-      assertEquals(
-          e.getMessage(),
-          "Use JsonReader.setLenient(true) to accept malformed JSON at path $.theName");
-    }
+    IOException e = catchThrowableOfType(call::execute, IOException.class);
+    assertEquals(
+        e.getMessage(),
+        "Use JsonReader.setLenient(true) to accept malformed JSON at path $.theName");
 
     Call<AnImplementation> call2 = serviceLenient.anImplementation(new AnImplementation("value"));
     Response<AnImplementation> response = call2.execute();
@@ -264,12 +260,8 @@ public final class MoshiConverterFactoryTest {
     server.enqueue(new MockResponse().setBody("{\"taco\":\"delicious\"}"));
 
     Call<AnImplementation> call = serviceFailOnUnknown.anImplementation(new AnImplementation(null));
-    try {
-      call.execute();
-      fail();
-    } catch (JsonDataException e) {
-      assertThat(e).hasMessage("Cannot skip unexpected NAME at $.taco");
-    }
+    JsonDataException e = catchThrowableOfType(call::execute, JsonDataException.class);
+    assertThat(e).hasMessage("Cannot skip unexpected NAME at $.taco");
   }
 
   @Test
@@ -295,11 +287,7 @@ public final class MoshiConverterFactoryTest {
     server.enqueue(malformedResponse);
 
     Call<AnImplementation> call = service.anImplementation(new AnImplementation("value"));
-    try {
-      call.execute();
-      fail();
-    } catch (IOException expected) {
-    }
+    assertThat(catchThrowableOfType(call::execute, IOException.class)).isNotNull();
   }
 
   @Test
@@ -307,11 +295,7 @@ public final class MoshiConverterFactoryTest {
     server.enqueue(new MockResponse().setBody("{\"theName\":\"value\"}"));
 
     Call<Value> call = service.value();
-    try {
-      call.execute();
-      fail();
-    } catch (JsonDataException e) {
-      assertThat(e).hasMessage("JSON document was not fully consumed.");
-    }
+    JsonDataException e = catchThrowableOfType(call::execute, JsonDataException.class);
+    assertThat(e).hasMessage("JSON document was not fully consumed.");
   }
 }

--- a/retrofit-converters/protobuf/src/main/java/retrofit2/converter/protobuf/ProtoRequestBodyConverter.java
+++ b/retrofit-converters/protobuf/src/main/java/retrofit2/converter/protobuf/ProtoRequestBodyConverter.java
@@ -16,16 +16,16 @@
 package retrofit2.converter.protobuf;
 
 import com.google.protobuf.MessageLite;
-import java.io.IOException;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class ProtoRequestBodyConverter<T extends MessageLite> implements Converter<T, RequestBody> {
   private static final MediaType MEDIA_TYPE = MediaType.get("application/x-protobuf");
 
   @Override
-  public RequestBody convert(T value) throws IOException {
+  public RequestBody convert(T value) throws ConversionException {
     byte[] bytes = value.toByteArray();
     return RequestBody.create(MEDIA_TYPE, bytes);
   }

--- a/retrofit-converters/protobuf/src/main/java/retrofit2/converter/protobuf/ProtoResponseBodyConverter.java
+++ b/retrofit-converters/protobuf/src/main/java/retrofit2/converter/protobuf/ProtoResponseBodyConverter.java
@@ -19,9 +19,9 @@ import com.google.protobuf.ExtensionRegistryLite;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.Parser;
-import java.io.IOException;
 import javax.annotation.Nullable;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class ProtoResponseBodyConverter<T extends MessageLite>
@@ -35,13 +35,13 @@ final class ProtoResponseBodyConverter<T extends MessageLite>
   }
 
   @Override
-  public T convert(ResponseBody value) throws IOException {
+  public T convert(ResponseBody value) throws ConversionException {
     try {
       return registry == null
           ? parser.parseFrom(value.byteStream())
           : parser.parseFrom(value.byteStream(), registry);
     } catch (InvalidProtocolBufferException e) {
-      throw new RuntimeException(e); // Despite extending IOException, this is data mismatch.
+      throw new ConversionException(e); // Despite extending IOException, this is data mismatch.
     } finally {
       value.close();
     }

--- a/retrofit-converters/protobuf/src/test/java/retrofit2/converter/protobuf/ProtoConverterFactoryTest.java
+++ b/retrofit-converters/protobuf/src/test/java/retrofit2/converter/protobuf/ProtoConverterFactoryTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import retrofit2.Call;
+import retrofit2.ConversionException;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.http.Body;
@@ -176,7 +177,7 @@ public final class ProtoConverterFactoryTest {
     server.enqueue(new MockResponse().setBody(new Buffer().write(encoded)));
 
     Call<?> call = service.get();
-    RuntimeException e = catchThrowableOfType(call::execute, RuntimeException.class);
+    ConversionException e = catchThrowableOfType(call::execute, ConversionException.class);
     assertThat(e.getCause())
         .isInstanceOf(InvalidProtocolBufferException.class)
         .hasMessageContaining("input ended unexpectedly");

--- a/retrofit-converters/protobuf/src/test/java/retrofit2/converter/protobuf/ProtoConverterFactoryTest.java
+++ b/retrofit-converters/protobuf/src/test/java/retrofit2/converter/protobuf/ProtoConverterFactoryTest.java
@@ -16,6 +16,7 @@
 package retrofit2.converter.protobuf;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.junit.Assert.fail;
 import static retrofit2.converter.protobuf.PhoneProtos.Phone;
 
@@ -175,13 +176,9 @@ public final class ProtoConverterFactoryTest {
     server.enqueue(new MockResponse().setBody(new Buffer().write(encoded)));
 
     Call<?> call = service.get();
-    try {
-      call.execute();
-      fail();
-    } catch (RuntimeException e) {
-      assertThat(e.getCause())
-          .isInstanceOf(InvalidProtocolBufferException.class)
-          .hasMessageContaining("input ended unexpectedly");
-    }
+    RuntimeException e = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(e.getCause())
+        .isInstanceOf(InvalidProtocolBufferException.class)
+        .hasMessageContaining("input ended unexpectedly");
   }
 }

--- a/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarRequestBodyConverter.java
+++ b/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarRequestBodyConverter.java
@@ -15,9 +15,9 @@
  */
 package retrofit2.converter.scalars;
 
-import java.io.IOException;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class ScalarRequestBodyConverter<T> implements Converter<T, RequestBody> {
@@ -27,7 +27,7 @@ final class ScalarRequestBodyConverter<T> implements Converter<T, RequestBody> {
   private ScalarRequestBodyConverter() {}
 
   @Override
-  public RequestBody convert(T value) throws IOException {
+  public RequestBody convert(T value) throws ConversionException {
     return RequestBody.create(MEDIA_TYPE, String.valueOf(value));
   }
 }

--- a/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarResponseBodyConverters.java
+++ b/retrofit-converters/scalars/src/main/java/retrofit2/converter/scalars/ScalarResponseBodyConverters.java
@@ -17,6 +17,7 @@ package retrofit2.converter.scalars;
 
 import java.io.IOException;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class ScalarResponseBodyConverters {
@@ -26,8 +27,12 @@ final class ScalarResponseBodyConverters {
     static final StringResponseBodyConverter INSTANCE = new StringResponseBodyConverter();
 
     @Override
-    public String convert(ResponseBody value) throws IOException {
-      return value.string();
+    public String convert(ResponseBody value) throws ConversionException {
+      try {
+        return value.string();
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
     }
   }
 
@@ -35,8 +40,12 @@ final class ScalarResponseBodyConverters {
     static final BooleanResponseBodyConverter INSTANCE = new BooleanResponseBodyConverter();
 
     @Override
-    public Boolean convert(ResponseBody value) throws IOException {
-      return Boolean.valueOf(value.string());
+    public Boolean convert(ResponseBody value) throws ConversionException {
+      try {
+        return Boolean.valueOf(value.string());
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
     }
   }
 
@@ -44,8 +53,12 @@ final class ScalarResponseBodyConverters {
     static final ByteResponseBodyConverter INSTANCE = new ByteResponseBodyConverter();
 
     @Override
-    public Byte convert(ResponseBody value) throws IOException {
-      return Byte.valueOf(value.string());
+    public Byte convert(ResponseBody value) throws ConversionException {
+      try {
+        return Byte.valueOf(value.string());
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
     }
   }
 
@@ -53,10 +66,15 @@ final class ScalarResponseBodyConverters {
     static final CharacterResponseBodyConverter INSTANCE = new CharacterResponseBodyConverter();
 
     @Override
-    public Character convert(ResponseBody value) throws IOException {
-      String body = value.string();
+    public Character convert(ResponseBody value) throws ConversionException {
+      String body;
+      try {
+        body = value.string();
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
       if (body.length() != 1) {
-        throw new IOException(
+        throw new ConversionException(
             "Expected body of length 1 for Character conversion but was " + body.length());
       }
       return body.charAt(0);
@@ -67,8 +85,12 @@ final class ScalarResponseBodyConverters {
     static final DoubleResponseBodyConverter INSTANCE = new DoubleResponseBodyConverter();
 
     @Override
-    public Double convert(ResponseBody value) throws IOException {
-      return Double.valueOf(value.string());
+    public Double convert(ResponseBody value) throws ConversionException {
+      try {
+        return Double.valueOf(value.string());
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
     }
   }
 
@@ -76,8 +98,12 @@ final class ScalarResponseBodyConverters {
     static final FloatResponseBodyConverter INSTANCE = new FloatResponseBodyConverter();
 
     @Override
-    public Float convert(ResponseBody value) throws IOException {
-      return Float.valueOf(value.string());
+    public Float convert(ResponseBody value) throws ConversionException {
+      try {
+        return Float.valueOf(value.string());
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
     }
   }
 
@@ -85,8 +111,12 @@ final class ScalarResponseBodyConverters {
     static final IntegerResponseBodyConverter INSTANCE = new IntegerResponseBodyConverter();
 
     @Override
-    public Integer convert(ResponseBody value) throws IOException {
-      return Integer.valueOf(value.string());
+    public Integer convert(ResponseBody value) throws ConversionException {
+      try {
+        return Integer.valueOf(value.string());
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
     }
   }
 
@@ -94,8 +124,12 @@ final class ScalarResponseBodyConverters {
     static final LongResponseBodyConverter INSTANCE = new LongResponseBodyConverter();
 
     @Override
-    public Long convert(ResponseBody value) throws IOException {
-      return Long.valueOf(value.string());
+    public Long convert(ResponseBody value) throws ConversionException {
+      try {
+        return Long.valueOf(value.string());
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
     }
   }
 
@@ -103,8 +137,12 @@ final class ScalarResponseBodyConverters {
     static final ShortResponseBodyConverter INSTANCE = new ShortResponseBodyConverter();
 
     @Override
-    public Short convert(ResponseBody value) throws IOException {
-      return Short.valueOf(value.string());
+    public Short convert(ResponseBody value) throws ConversionException {
+      try {
+        return Short.valueOf(value.string());
+      } catch (IOException e) {
+        throw new ConversionException(e);
+      }
     }
   }
 }

--- a/retrofit-converters/simplexml/src/main/java/retrofit2/converter/simplexml/SimpleXmlRequestBodyConverter.java
+++ b/retrofit-converters/simplexml/src/main/java/retrofit2/converter/simplexml/SimpleXmlRequestBodyConverter.java
@@ -21,6 +21,7 @@ import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okio.Buffer;
 import org.simpleframework.xml.Serializer;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class SimpleXmlRequestBodyConverter<T> implements Converter<T, RequestBody> {
@@ -34,14 +35,16 @@ final class SimpleXmlRequestBodyConverter<T> implements Converter<T, RequestBody
   }
 
   @Override
-  public RequestBody convert(T value) throws IOException {
+  public RequestBody convert(T value) throws ConversionException {
     Buffer buffer = new Buffer();
     try {
       OutputStreamWriter osw = new OutputStreamWriter(buffer.outputStream(), CHARSET);
       serializer.write(value, osw);
       osw.flush();
-    } catch (RuntimeException | IOException e) {
+    } catch (RuntimeException e) {
       throw e;
+    } catch (IOException e) {
+      throw new ConversionException(e);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/retrofit-converters/simplexml/src/main/java/retrofit2/converter/simplexml/SimpleXmlResponseBodyConverter.java
+++ b/retrofit-converters/simplexml/src/main/java/retrofit2/converter/simplexml/SimpleXmlResponseBodyConverter.java
@@ -18,6 +18,7 @@ package retrofit2.converter.simplexml;
 import java.io.IOException;
 import okhttp3.ResponseBody;
 import org.simpleframework.xml.Serializer;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class SimpleXmlResponseBodyConverter<T> implements Converter<ResponseBody, T> {
@@ -32,15 +33,17 @@ final class SimpleXmlResponseBodyConverter<T> implements Converter<ResponseBody,
   }
 
   @Override
-  public T convert(ResponseBody value) throws IOException {
+  public T convert(ResponseBody value) throws ConversionException {
     try {
       T read = serializer.read(cls, value.charStream(), strict);
       if (read == null) {
-        throw new IllegalStateException("Could not deserialize body as " + cls);
+        throw new ConversionException("Could not deserialize body as " + cls);
       }
       return read;
-    } catch (RuntimeException | IOException e) {
+    } catch (RuntimeException e) {
       throw e;
+    } catch (IOException e) {
+      throw new ConversionException(e);
     } catch (Exception e) {
       throw new RuntimeException(e);
     } finally {

--- a/retrofit-converters/simplexml/src/test/java/retrofit2/converter/simplexml/SimpleXmlConverterFactoryTest.java
+++ b/retrofit-converters/simplexml/src/test/java/retrofit2/converter/simplexml/SimpleXmlConverterFactoryTest.java
@@ -34,6 +34,7 @@ import org.simpleframework.xml.stream.Format;
 import org.simpleframework.xml.stream.HyphenStyle;
 import org.simpleframework.xml.stream.Verbosity;
 import retrofit2.Call;
+import retrofit2.ConversionException;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.http.Body;
@@ -127,7 +128,9 @@ public class SimpleXmlConverterFactoryTest {
             .setBody("<my-object><message>hello world</message><count>10</count></my-object>"));
 
     Call<?> call = service.wrongClass();
-    RuntimeException e = catchThrowableOfType(call::execute, RuntimeException.class);
-    assertThat(e).hasMessage("Could not deserialize body as class java.lang.String");
+    ConversionException e = catchThrowableOfType(call::execute, ConversionException.class);
+    assertThat(e).hasCauseInstanceOf(IOException.class);
+    IOException ioException = (IOException) e.getCause();
+    assertThat(ioException).hasMessage("Could not deserialize body as class java.lang.String");
   }
 }

--- a/retrofit-converters/simplexml/src/test/java/retrofit2/converter/simplexml/SimpleXmlConverterFactoryTest.java
+++ b/retrofit-converters/simplexml/src/test/java/retrofit2/converter/simplexml/SimpleXmlConverterFactoryTest.java
@@ -16,6 +16,7 @@
 package retrofit2.converter.simplexml;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -126,11 +127,7 @@ public class SimpleXmlConverterFactoryTest {
             .setBody("<my-object><message>hello world</message><count>10</count></my-object>"));
 
     Call<?> call = service.wrongClass();
-    try {
-      call.execute();
-      fail();
-    } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Could not deserialize body as class java.lang.String");
-    }
+    RuntimeException e = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(e).hasMessage("Could not deserialize body as class java.lang.String");
   }
 }

--- a/retrofit-converters/wire/src/main/java/retrofit2/converter/wire/WireRequestBodyConverter.java
+++ b/retrofit-converters/wire/src/main/java/retrofit2/converter/wire/WireRequestBodyConverter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okio.Buffer;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class WireRequestBodyConverter<T extends Message<T, ?>> implements Converter<T, RequestBody> {
@@ -33,9 +34,13 @@ final class WireRequestBodyConverter<T extends Message<T, ?>> implements Convert
   }
 
   @Override
-  public RequestBody convert(T value) throws IOException {
+  public RequestBody convert(T value) throws ConversionException {
     Buffer buffer = new Buffer();
-    adapter.encode(buffer, value);
+    try {
+      adapter.encode(buffer, value);
+    } catch (IOException e) {
+      throw new ConversionException(e);
+    }
     return RequestBody.create(MEDIA_TYPE, buffer.snapshot());
   }
 }

--- a/retrofit-converters/wire/src/main/java/retrofit2/converter/wire/WireResponseBodyConverter.java
+++ b/retrofit-converters/wire/src/main/java/retrofit2/converter/wire/WireResponseBodyConverter.java
@@ -19,6 +19,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import java.io.IOException;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 
 final class WireResponseBodyConverter<T extends Message<T, ?>>
@@ -30,9 +31,11 @@ final class WireResponseBodyConverter<T extends Message<T, ?>>
   }
 
   @Override
-  public T convert(ResponseBody value) throws IOException {
+  public T convert(ResponseBody value) throws ConversionException {
     try {
       return adapter.decode(value.source());
+    } catch (IOException e) {
+      throw new ConversionException(e);
     } finally {
       value.close();
     }

--- a/retrofit-converters/wire/src/test/java/retrofit2/converter/wire/WireConverterFactoryTest.java
+++ b/retrofit-converters/wire/src/test/java/retrofit2/converter/wire/WireConverterFactoryTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import retrofit2.Call;
+import retrofit2.ConversionException;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.http.Body;
@@ -147,6 +148,7 @@ public final class WireConverterFactoryTest {
     server.enqueue(new MockResponse().setBody(new Buffer().write(encoded)));
 
     Call<?> call = service.get();
-    assertThat(catchThrowableOfType(call::execute, EOFException.class)).isNotNull();
+    assertThat(catchThrowableOfType(call::execute, ConversionException.class))
+        .hasCauseInstanceOf(EOFException.class);
   }
 }

--- a/retrofit-converters/wire/src/test/java/retrofit2/converter/wire/WireConverterFactoryTest.java
+++ b/retrofit-converters/wire/src/test/java/retrofit2/converter/wire/WireConverterFactoryTest.java
@@ -16,6 +16,7 @@
 package retrofit2.converter.wire;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.junit.Assert.fail;
 
 import java.io.EOFException;
@@ -146,10 +147,6 @@ public final class WireConverterFactoryTest {
     server.enqueue(new MockResponse().setBody(new Buffer().write(encoded)));
 
     Call<?> call = service.get();
-    try {
-      call.execute();
-      fail();
-    } catch (EOFException ignored) {
-    }
+    assertThat(catchThrowableOfType(call::execute, EOFException.class)).isNotNull();
   }
 }

--- a/retrofit-mock/src/main/java/retrofit2/mock/BehaviorDelegate.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/BehaviorDelegate.java
@@ -151,6 +151,7 @@ public final class BehaviorDelegate<T> {
 
   static class ServiceMethodAdapterInfo {
     final boolean isSuspend;
+
     /**
      * Whether the suspend function return type was {@code Response<T>}. Only meaningful if {@link
      * #isSuspend} is true.

--- a/retrofit/src/main/java/retrofit2/BuiltInConverters.java
+++ b/retrofit/src/main/java/retrofit2/BuiltInConverters.java
@@ -99,10 +99,12 @@ final class BuiltInConverters extends Converter.Factory {
     static final BufferingResponseBodyConverter INSTANCE = new BufferingResponseBodyConverter();
 
     @Override
-    public ResponseBody convert(ResponseBody value) throws IOException {
+    public ResponseBody convert(ResponseBody value) throws ConversionException {
       try {
         // Buffer the entire body to avoid future I/O.
         return Utils.buffer(value);
+      } catch (IOException e) {
+        throw new ConversionException(e);
       } finally {
         value.close();
       }

--- a/retrofit/src/main/java/retrofit2/ConversionException.java
+++ b/retrofit/src/main/java/retrofit2/ConversionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Square, Inc.
+ * Copyright (C) 2023 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package retrofit.converter.java8;
+package retrofit2;
 
-import java.util.Optional;
-import okhttp3.ResponseBody;
-import retrofit2.ConversionException;
-import retrofit2.Converter;
+import java.io.IOException;
 
-final class OptionalConverter<T> implements Converter<ResponseBody, Optional<T>> {
-  private final Converter<ResponseBody, T> delegate;
-
-  OptionalConverter(Converter<ResponseBody, T> delegate) {
-    this.delegate = delegate;
+/** Exception converting an http response body. */
+public class ConversionException extends IOException {
+  public ConversionException(String message, Throwable cause) {
+    super(message, cause);
   }
 
-  @Override
-  public Optional<T> convert(ResponseBody value) throws ConversionException {
-    return Optional.ofNullable(delegate.convert(value));
+  public ConversionException(String message) {
+    super(message);
+  }
+
+  public ConversionException(Throwable cause) {
+    super(cause);
   }
 }

--- a/retrofit/src/main/java/retrofit2/Converter.java
+++ b/retrofit/src/main/java/retrofit2/Converter.java
@@ -15,7 +15,6 @@
  */
 package retrofit2;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -40,7 +39,7 @@ import retrofit2.http.QueryMap;
  */
 public interface Converter<F, T> {
   @Nullable
-  T convert(F value) throws IOException;
+  T convert(F value) throws ConversionException;
 
   /** Creates {@link Converter} instances based on a type and target usage. */
   abstract class Factory {

--- a/retrofit/src/main/java/retrofit2/OptionalConverterFactory.java
+++ b/retrofit/src/main/java/retrofit2/OptionalConverterFactory.java
@@ -16,7 +16,6 @@
 package retrofit2;
 
 import android.annotation.TargetApi;
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -50,7 +49,7 @@ final class OptionalConverterFactory extends Converter.Factory {
     }
 
     @Override
-    public Optional<T> convert(ResponseBody value) throws IOException {
+    public Optional<T> convert(ResponseBody value) throws ConversionException {
       return Optional.ofNullable(delegate.convert(value));
     }
   }

--- a/retrofit/src/main/java/retrofit2/http/HTTP.java
+++ b/retrofit/src/main/java/retrofit2/http/HTTP.java
@@ -47,6 +47,7 @@ import okhttp3.HttpUrl;
 @Retention(RUNTIME)
 public @interface HTTP {
   String method();
+
   /**
    * A relative or absolute path, or full URL of the endpoint. This value is optional if the first
    * parameter of the method is annotated with {@link Url @Url}.

--- a/retrofit/src/main/java/retrofit2/http/Part.java
+++ b/retrofit/src/main/java/retrofit2/http/Part.java
@@ -62,6 +62,7 @@ public @interface Part {
    * okhttp3.MultipartBody.Part}.
    */
   String value() default "";
+
   /** The {@code Content-Transfer-Encoding} of this part. */
   String encoding() default "binary";
 }

--- a/retrofit/src/test/java/retrofit2/CallTest.java
+++ b/retrofit/src/test/java/retrofit2/CallTest.java
@@ -18,8 +18,8 @@ package retrofit2;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static retrofit2.TestingUtils.repeat;
 
 import java.io.IOException;
@@ -187,11 +187,7 @@ public final class CallTest {
     server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
 
     Call<String> call = example.getString();
-    try {
-      call.execute();
-      fail();
-    } catch (IOException ignored) {
-    }
+    assertThat(catchThrowableOfType(call::execute, IOException.class)).isNotNull();
   }
 
   @Test
@@ -250,12 +246,9 @@ public final class CallTest {
     Service example = retrofit.create(Service.class);
 
     Call<String> call = example.postString("Hi");
-    try {
-      call.execute();
-      fail();
-    } catch (UnsupportedOperationException e) {
-      assertThat(e).hasMessage("I am broken!");
-    }
+    UnsupportedOperationException e =
+        catchThrowableOfType(call::execute, UnsupportedOperationException.class);
+    assertThat(e).hasMessage("I am broken!");
   }
 
   @Test
@@ -324,12 +317,9 @@ public final class CallTest {
     server.enqueue(new MockResponse().setBody("Hi"));
 
     Call<String> call = example.postString("Hi");
-    try {
-      call.execute();
-      fail();
-    } catch (UnsupportedOperationException e) {
-      assertThat(e).hasMessage("I am broken!");
-    }
+    UnsupportedOperationException e =
+        catchThrowableOfType(call::execute, UnsupportedOperationException.class);
+    assertThat(e).hasMessage("I am broken!");
   }
 
   @Test
@@ -380,12 +370,8 @@ public final class CallTest {
     server.enqueue(new MockResponse().setBody("Hi"));
 
     Call<String> call = example.getString();
-    try {
-      call.execute();
-      fail();
-    } catch (IOException e) {
-      assertThat(e).hasMessage("cause");
-    }
+    IOException e = catchThrowableOfType(call::execute, IOException.class);
+    assertThat(e).hasMessage("cause");
   }
 
   @Test
@@ -524,12 +510,8 @@ public final class CallTest {
     server.enqueue(new MockResponse());
     Call<String> call = example.getString();
     call.execute();
-    try {
-      call.execute();
-      fail();
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Already executed.");
-    }
+    IllegalStateException e = catchThrowableOfType(call::execute, IllegalStateException.class);
+    assertThat(e).hasMessage("Already executed.");
   }
 
   @Test
@@ -576,12 +558,8 @@ public final class CallTest {
 
     Call<ResponseBody> buffered = example.getBody();
     // When buffering we will detect all socket problems before returning the Response.
-    try {
-      buffered.execute();
-      fail();
-    } catch (IOException e) {
-      assertThat(e).hasMessage("unexpected end of stream");
-    }
+    IOException e = catchThrowableOfType(buffered::execute, IOException.class);
+    assertThat(e).hasMessage("unexpected end of stream");
   }
 
   @Test
@@ -600,12 +578,8 @@ public final class CallTest {
 
     ResponseBody streamedBody = response.body();
     // When streaming we only detect socket problems as the ResponseBody is read.
-    try {
-      streamedBody.string();
-      fail();
-    } catch (IOException e) {
-      assertThat(e).hasMessage("unexpected end of stream");
-    }
+    IOException e = catchThrowableOfType(streamedBody::string, IOException.class);
+    assertThat(e).hasMessage("unexpected end of stream");
   }
 
   @Test
@@ -624,12 +598,8 @@ public final class CallTest {
     ResponseBody rawBody = response.raw().body();
     assertThat(rawBody.contentLength()).isEqualTo(2);
     assertThat(rawBody.contentType().toString()).isEqualTo("text/greeting");
-    try {
-      rawBody.source();
-      fail();
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Cannot read raw response body of a converted body.");
-    }
+    IllegalStateException e = catchThrowableOfType(rawBody::source, IllegalStateException.class);
+    assertThat(e).hasMessage("Cannot read raw response body of a converted body.");
   }
 
   @Test
@@ -706,12 +676,8 @@ public final class CallTest {
     call.cancel();
     assertThat(call.isCanceled()).isTrue();
 
-    try {
-      call.execute();
-      fail();
-    } catch (IOException e) {
-      assertThat(e).hasMessage("Canceled");
-    }
+    IOException e = catchThrowableOfType(call::execute, IOException.class);
+    assertThat(e).hasMessage("Canceled");
   }
 
   @Test
@@ -891,20 +857,12 @@ public final class CallTest {
         };
     Call<String> call = service.postRequestBody(a);
 
-    try {
-      call.request();
-      fail();
-    } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    RuntimeException e = catchThrowableOfType(call::request, RuntimeException.class);
+    assertThat(e).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
 
-    try {
-      call.execute();
-      fail();
-    } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    RuntimeException e2 = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(e2).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
   }
 
@@ -930,20 +888,12 @@ public final class CallTest {
         };
     Call<String> call = service.postRequestBody(a);
 
-    try {
-      call.request();
-      fail();
-    } catch (NonFatalError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    NonFatalError e = catchThrowableOfType(call::request, NonFatalError.class);
+    assertThat(e).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
 
-    try {
-      call.execute();
-      fail();
-    } catch (NonFatalError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    NonFatalError e2 = catchThrowableOfType(call::execute, NonFatalError.class);
+    assertThat(e2).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
   }
 
@@ -998,20 +948,12 @@ public final class CallTest {
         };
     Call<String> call = service.postRequestBody(a);
 
-    try {
-      call.execute();
-      fail();
-    } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    RuntimeException e = catchThrowableOfType(call::execute, RuntimeException.class);
+    assertThat(e).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
 
-    try {
-      call.request();
-      fail();
-    } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    RuntimeException e2 = catchThrowableOfType(call::request, RuntimeException.class);
+    assertThat(e2).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
   }
 
@@ -1037,20 +979,12 @@ public final class CallTest {
         };
     Call<String> call = service.postRequestBody(a);
 
-    try {
-      call.execute();
-      fail();
-    } catch (NonFatalError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    NonFatalError e = catchThrowableOfType(call::execute, NonFatalError.class);
+    assertThat(e).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
 
-    try {
-      call.request();
-      fail();
-    } catch (NonFatalError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    NonFatalError e2 = catchThrowableOfType(call::request, NonFatalError.class);
+    assertThat(e2).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
   }
 
@@ -1116,12 +1050,8 @@ public final class CallTest {
         };
     Call<String> call = service.postRequestBody(a);
 
-    try {
-      call.request();
-      fail();
-    } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    RuntimeException e = catchThrowableOfType(call::request, RuntimeException.class);
+    assertThat(e).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
 
     final CountDownLatch latch = new CountDownLatch(1);
@@ -1163,12 +1093,8 @@ public final class CallTest {
         };
     Call<String> call = service.postRequestBody(a);
 
-    try {
-      call.request();
-      fail();
-    } catch (NonFatalError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    NonFatalError e = catchThrowableOfType(call::request, NonFatalError.class);
+    assertThat(e).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
 
     final CountDownLatch latch = new CountDownLatch(1);
@@ -1264,12 +1190,8 @@ public final class CallTest {
         });
     assertTrue(latch.await(10, SECONDS));
 
-    try {
-      call.request();
-      fail();
-    } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    RuntimeException e = catchThrowableOfType(call::request, RuntimeException.class);
+    assertThat(e).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
   }
 
@@ -1311,12 +1233,8 @@ public final class CallTest {
         });
     assertTrue(latch.await(10, SECONDS));
 
-    try {
-      call.request();
-      fail();
-    } catch (NonFatalError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    NonFatalError e = catchThrowableOfType(call::request, NonFatalError.class);
+    assertThat(e).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
   }
 
@@ -1342,20 +1260,12 @@ public final class CallTest {
         };
     Call<String> call = service.postRequestBody(a);
 
-    try {
-      call.request();
-      fail();
-    } catch (OutOfMemoryError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    OutOfMemoryError e = catchThrowableOfType(call::request, OutOfMemoryError.class);
+    assertThat(e).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
 
-    try {
-      call.request();
-      fail();
-    } catch (OutOfMemoryError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    OutOfMemoryError e2 = catchThrowableOfType(call::request, OutOfMemoryError.class);
+    assertThat(e2).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(2);
   }
 
@@ -1381,31 +1291,28 @@ public final class CallTest {
         };
     Call<String> call = service.postRequestBody(a);
 
-    try {
-      final AtomicBoolean callsFailureSynchronously = new AtomicBoolean();
-      call.enqueue(
-          new Callback<String>() {
-            @Override
-            public void onResponse(Call<String> call, Response<String> response) {}
+    final AtomicBoolean callsFailureSynchronously = new AtomicBoolean();
+    OutOfMemoryError e =
+        catchThrowableOfType(
+            () -> {
+              call.enqueue(
+                  new Callback<String>() {
+                    @Override
+                    public void onResponse(Call<String> call, Response<String> response) {}
 
-            @Override
-            public void onFailure(Call<String> call, Throwable t) {
-              callsFailureSynchronously.set(true); // Will not be called for fatal errors.
-            }
-          });
-      assertThat(callsFailureSynchronously.get()).isFalse();
-      fail();
-    } catch (OutOfMemoryError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+                    @Override
+                    public void onFailure(Call<String> call, Throwable t) {
+                      callsFailureSynchronously.set(true); // Will not be called for fatal errors.
+                    }
+                  });
+              assertThat(callsFailureSynchronously.get()).isFalse();
+            },
+            OutOfMemoryError.class);
+    assertThat(e).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
 
-    try {
-      call.request();
-      fail();
-    } catch (OutOfMemoryError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    OutOfMemoryError e2 = catchThrowableOfType(call::request, OutOfMemoryError.class);
+    assertThat(e2).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(2);
   }
 
@@ -1431,20 +1338,12 @@ public final class CallTest {
         };
     Call<String> call = service.postRequestBody(a);
 
-    try {
-      call.execute();
-      fail();
-    } catch (OutOfMemoryError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    OutOfMemoryError e = catchThrowableOfType(call::execute, OutOfMemoryError.class);
+    assertThat(e).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(1);
 
-    try {
-      call.request();
-      fail();
-    } catch (OutOfMemoryError e) {
-      assertThat(e).hasMessage("Broken!");
-    }
+    OutOfMemoryError e2 = catchThrowableOfType(call::request, OutOfMemoryError.class);
+    assertThat(e2).hasMessage("Broken!");
     assertThat(writeCount.get()).isEqualTo(2);
   }
 
@@ -1461,11 +1360,7 @@ public final class CallTest {
 
     Call<String> call = example.getString();
     call.timeout().timeout(100, TimeUnit.MILLISECONDS);
-    try {
-      call.execute();
-      fail();
-    } catch (InterruptedIOException expected) {
-    }
+    assertThat(catchThrowableOfType(call::execute, InterruptedIOException.class)).isNotNull();
   }
 
   @Test
@@ -1481,11 +1376,7 @@ public final class CallTest {
 
     Call<String> call = example.getString();
     call.timeout().deadline(100, TimeUnit.MILLISECONDS);
-    try {
-      call.execute();
-      fail();
-    } catch (InterruptedIOException expected) {
-    }
+    assertThat(catchThrowableOfType(call::execute, InterruptedIOException.class)).isNotNull();
   }
 
   @Test

--- a/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/src/test/java/retrofit2/RequestFactoryTest.java
@@ -612,7 +612,8 @@ public final class RequestFactoryTest {
   public void headerMapMustBeAMapOrHeaders() {
     class Example {
       @GET("/")
-      Call<ResponseBody> method(@HeaderMap okhttp3.Headers headers, @HeaderMap List<String> headerMap) {
+      Call<ResponseBody> method(
+          @HeaderMap okhttp3.Headers headers, @HeaderMap List<String> headerMap) {
         return null;
       }
     }

--- a/retrofit/test-helpers/src/main/java/retrofit2/TestingUtils.java
+++ b/retrofit/test-helpers/src/main/java/retrofit2/TestingUtils.java
@@ -23,9 +23,9 @@ import retrofit2.helpers.ToStringConverterFactory;
 final class TestingUtils {
   static <T> Request buildRequest(Class<T> cls, Retrofit.Builder builder, Object... args) {
     okhttp3.Call.Factory callFactory =
-      request -> {
-        throw new UnsupportedOperationException("Not implemented");
-      };
+        request -> {
+          throw new UnsupportedOperationException("Not implemented");
+        };
 
     Retrofit retrofit = builder.callFactory(callFactory).build();
 
@@ -41,9 +41,9 @@ final class TestingUtils {
 
   static <T> Request buildRequest(Class<T> cls, Object... args) {
     Retrofit.Builder retrofitBuilder =
-      new Retrofit.Builder()
-        .baseUrl("http://example.com/")
-        .addConverterFactory(new ToStringConverterFactory());
+        new Retrofit.Builder()
+            .baseUrl("http://example.com/")
+            .addConverterFactory(new ToStringConverterFactory());
 
     return buildRequest(cls, retrofitBuilder, args);
   }

--- a/retrofit/test-helpers/src/main/java/retrofit2/helpers/NullObjectConverterFactory.java
+++ b/retrofit/test-helpers/src/main/java/retrofit2/helpers/NullObjectConverterFactory.java
@@ -15,9 +15,9 @@
  */
 package retrofit2.helpers;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
@@ -28,7 +28,7 @@ public final class NullObjectConverterFactory extends Converter.Factory {
       Type type, Annotation[] annotations, Retrofit retrofit) {
     return new Converter<Object, String>() {
       @Override
-      public String convert(Object value) throws IOException {
+      public String convert(Object value) throws ConversionException {
         return null;
       }
     };

--- a/retrofit/test-helpers/src/main/java/retrofit2/helpers/ToStringConverterFactory.java
+++ b/retrofit/test-helpers/src/main/java/retrofit2/helpers/ToStringConverterFactory.java
@@ -15,12 +15,14 @@
  */
 package retrofit2.helpers;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import javax.annotation.Nullable;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
@@ -31,7 +33,13 @@ public class ToStringConverterFactory extends Converter.Factory {
   public @Nullable Converter<ResponseBody, String> responseBodyConverter(
       Type type, Annotation[] annotations, Retrofit retrofit) {
     if (String.class.equals(type)) {
-      return ResponseBody::string;
+      return (ResponseBody responseBody) -> {
+        try {
+          return responseBody.string();
+        } catch (IOException e) {
+          throw new ConversionException(e);
+        }
+      };
     }
     return null;
   }

--- a/samples/src/main/java/com/example/retrofit/Crawler.java
+++ b/samples/src/main/java/com/example/retrofit/Crawler.java
@@ -38,6 +38,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import retrofit2.Call;
 import retrofit2.Callback;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 import retrofit2.Response;
 import retrofit2.Retrofit;
@@ -146,13 +147,17 @@ public final class Crawler {
         };
 
     @Override
-    public Page convert(ResponseBody responseBody) throws IOException {
-      Document document = Jsoup.parse(responseBody.string());
-      List<String> links = new ArrayList<>();
-      for (Element element : document.select("a[href]")) {
-        links.add(element.attr("href"));
+    public Page convert(ResponseBody responseBody) throws ConversionException {
+      try {
+        Document document = Jsoup.parse(responseBody.string());
+        List<String> links = new ArrayList<>();
+        for (Element element : document.select("a[href]")) {
+          links.add(element.attr("href"));
+        }
+        return new Page(document.title(), Collections.unmodifiableList(links));
+      } catch (IOException e) {
+        throw new ConversionException(e);
       }
-      return new Page(document.title(), Collections.unmodifiableList(links));
     }
   }
 }

--- a/samples/src/main/java/com/example/retrofit/ErrorHandlingAdapter.java
+++ b/samples/src/main/java/com/example/retrofit/ErrorHandlingAdapter.java
@@ -38,14 +38,19 @@ public final class ErrorHandlingAdapter {
   interface MyCallback<T> {
     /** Called for [200, 300) responses. */
     void success(Response<T> response);
+
     /** Called for 401 responses. */
     void unauthenticated(Response<?> response);
+
     /** Called for [400, 500) responses, except 401. */
     void clientError(Response<?> response);
+
     /** Called for [500, 600) response. */
     void serverError(Response<?> response);
+
     /** Called for network errors while making the call. */
     void networkError(IOException e);
+
     /** Called for unexpected errors while making the call. */
     void unexpectedError(Throwable t);
   }

--- a/samples/src/main/java/com/example/retrofit/JsonQueryParameters.java
+++ b/samples/src/main/java/com/example/retrofit/JsonQueryParameters.java
@@ -29,6 +29,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
 import retrofit2.Call;
+import retrofit2.ConversionException;
 import retrofit2.Converter;
 import retrofit2.Response;
 import retrofit2.Retrofit;
@@ -71,9 +72,13 @@ public final class JsonQueryParameters {
       }
 
       @Override
-      public String convert(T value) throws IOException {
+      public String convert(T value) throws ConversionException {
         Buffer buffer = new Buffer();
-        delegate.convert(value).writeTo(buffer);
+        try {
+          delegate.convert(value).writeTo(buffer);
+        } catch (IOException e) {
+          throw new ConversionException(e);
+        }
         return buffer.readUtf8();
       }
     }


### PR DESCRIPTION
so callers of Call.execute can distinguish between retryable exceptions (IOException) and non-retryable exceptions (ConversionException).

closes https://github.com/square/retrofit/issues/3972.
