### PR TITLE
Remove the use of toolchains

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,9 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 21
+          java-version: |
+            8
+            21
 
       - uses: gradle/gradle-build-action@v2
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,19 @@ subprojects {
     google()
   }
 
-  tasks.withType(JavaCompile).configureEach { task ->
-    task.options.encoding = 'UTF-8'
+  // This will cover both java-library and kotlin.jvm but not android.library.
+  if (project.path != ':retrofit:robovm-test') {
+    plugins.withId('java') {
+      tasks.withType(JavaCompile).configureEach { task ->
+        task.options.encoding = 'UTF-8'
+        task.options.release = 8
+      }
+    }
   }
 
-  plugins.withType(JavaBasePlugin).configureEach {
-    java.toolchain {
-      languageVersion.set(JavaLanguageVersion.of(8))
+  tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile).configureEach { task ->
+    task.kotlinOptions {
+      jvmTarget = '1.8'
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ scalaLibrary = { module = "org.scala-lang:scala-library", version = "2.13.12" }
 gson = { module = "com.google.code.gson:gson", version = "2.10.1" }
 jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.16.1" }
 jaxbApi = { module = "javax.xml.bind:jaxb-api", version = "2.3.1" }
-jaxbImpl = { module = "org.glassfish.jaxb:jaxb-runtime", version = "4.0.4" }
+jaxbImpl = { module = "org.glassfish.jaxb:jaxb-runtime", version = "2.3.0" }
 jaxb3Api = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version = "3.0.1" }
 jaxb3Impl = { module = "com.sun.xml.bind:jaxb-impl", version = "3.0.2" }
 moshi = { module = "com.squareup.moshi:moshi", version = "1.15.0" }

--- a/retrofit/kotlin-test/src/test/java/retrofit2/KotlinRequestFactoryTest.java
+++ b/retrofit/kotlin-test/src/test/java/retrofit2/KotlinRequestFactoryTest.java
@@ -1,12 +1,12 @@
 package retrofit2;
 
+import static com.google.common.truth.Truth.assertThat;
+import static retrofit2.TestingUtils.buildRequest;
+
 import kotlin.Unit;
 import okhttp3.Request;
 import org.junit.Test;
 import retrofit2.http.HEAD;
-
-import static com.google.common.truth.Truth.assertThat;
-import static retrofit2.TestingUtils.buildRequest;
 
 public final class KotlinRequestFactoryTest {
   @Test

--- a/retrofit/kotlin-test/src/test/java/retrofit2/KotlinSuspendRawTest.java
+++ b/retrofit/kotlin-test/src/test/java/retrofit2/KotlinSuspendRawTest.java
@@ -46,7 +46,8 @@ public final class KotlinSuspendRawTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Response must include generic type (e.g., Response<String>)\n"
                   + "    for method Service.body");
     }

--- a/retrofit/robovm-test/build.gradle
+++ b/retrofit/robovm-test/build.gradle
@@ -14,6 +14,13 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'robovm'
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(8)
+    vendor = JvmVendorSpec.AZUL
+  }
+}
+
 ext.mainClassName = 'retrofit2.RoboVmPlatformTest'
 
 robovm {


### PR DESCRIPTION
There no reason to use JDK 8 to run compilation when all JDKs can cross-compile to that target. Moreover, this actually prevents upgrading error-prone which wants a newer javac than 8.

This is mostly a revert of 72fc72630a3fb10ce8c6ebe200c17d0acf8c05ef