### PR TITLE
Fix CI publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    if: github.repository == 'square/retrofit' && github.ref == 'refs/heads/master'
+    if: github.repository == 'square/retrofit' && github.ref == 'refs/heads/trunk'
     needs:
       - jvm
       - android


### PR DESCRIPTION
GitHub Actions [publishing has been getting skipped](https://github.com/square/retrofit/actions/runs/8332800861) in the main build pipeline because that job specifies the `master` branch ref, and this repo uses `trunk`. 

[The proper release action still seems to be running okay](https://github.com/square/retrofit/actions/runs/8332654420), just not this one.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
