### PR TITLE
Gracefully handle parse failure with locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 **Fixed**
 
- - Nothing yet!
+ - Ensure that exceptions thrown from failure to parse method annotations can be observed by multiple threads/callers. Previously only the first caller would see the actual parsing exception and other callers would get a cryptic `ClassCastException`.
 
 
 ## [2.10.0] - 2024-03-18


### PR DESCRIPTION
Before we would poison the map with the lock object so the second caller would get a weird ClassCastException.

Closes #4113 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
