### PR TITLE
Change Gradle depedency on site to be Kotlin friendly

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -179,7 +179,7 @@ GitHubService service = retrofit.create(GitHubService.class);</pre>
 &lt;/dependency></pre>
               <h4>Gradle</h4>
               <pre class="prettyprint">
-implementation 'com.squareup.retrofit2:retrofit:<span class="version pln"><em>(insert latest version)</em></span>'
+implementation("com.squareup.retrofit2:retrofit:<span class="version pln"><em>(insert latest version)</em></span>")
 </pre>
               <p>Retrofit requires at minimum Java 8+ or Android API 21+.</p>
 


### PR DESCRIPTION
Change the websites Gradle dependency example to be Kotlin friendly for folks who are using Kotlin Gradle script. 