### PR TITLE
Update proguard rule

### DIFF
--- a/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -46,3 +46,4 @@
 
 # With R8 full mode generic signatures are stripped for classes that are not kept.
 -keep,allowobfuscation,allowshrinking class retrofit2.Response
+-keep,allowobfuscation,allowshrinking class retrofit2.Call


### PR DESCRIPTION
I got a crash report for Android application when publish it to Google Play store. It took me several hours of testing on multiple devices and I found out that the cause of the error was a missing rule in the progurad file.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
