### PR TITLE
Bump okhttp to resolve security vulnerabilities

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@
 
 [versions]
 kotlin = "2.1.10"
-okhttp = "3.14.9"
+okhttp = "4.12.0"
 protobuf = "3.25.6"
 robovm = "2.3.14"
 kotlinx-serialization = "1.8.0"


### PR DESCRIPTION
Bump `okhttp3` to resolve security vulnerabilities introduced by its transitive dependency, `okio`: [`okhttp3:3.14.9`](https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/3.14.9) -> [`okio:1.17.2`](https://mvnrepository.com/artifact/com.squareup.okio/okio/1.17.2)

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
