### PR TITLE
Support primitive types for `@Tag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 **Fixed**
 
- - Nothing yet!
+ - Primitive types used with `@Tag` now work by storing the value boxed with the boxed class as the key.
 
 
 ## [2.11.0] - 2024-03-28

--- a/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
@@ -3331,6 +3331,19 @@ public final class RequestFactoryTest {
   }
 
   @Test
+  public void tagPrimitive() {
+    class Example {
+      @GET("/")
+      Call<ResponseBody> method(@Tag long timestamp) {
+        return null;
+      }
+    }
+
+    Request request = buildRequest(Example.class, 42L);
+    assertThat(request.tag(Long.class)).isEqualTo(42L);
+  }
+
+  @Test
   public void tagGeneric() {
     class Example {
       @GET("/")

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -800,7 +800,7 @@ final class RequestFactory {
       } else if (annotation instanceof Tag) {
         validateResolvableType(p, type);
 
-        Class<?> tagType = Utils.getRawType(type);
+        Class<?> tagType = boxIfPrimitive(Utils.getRawType(type));
         for (int i = p - 1; i >= 0; i--) {
           ParameterHandler<?> otherHandler = parameterHandlers[i];
           if (otherHandler instanceof ParameterHandler.Tag

--- a/retrofit/src/main/java/retrofit2/http/Tag.java
+++ b/retrofit/src/main/java/retrofit2/http/Tag.java
@@ -31,7 +31,9 @@ import java.lang.annotation.Target;
  * </code></pre>
  *
  * Tag arguments may be {@code null} which will omit them from the request. Passing a parameterized
- * type such as {@code List<String>} will use the raw type (i.e., {@code List.class}) as the key.
+ * type will use the raw type as the key (e.g., {@code List<String>} uses {@code List.class}).
+ * Primitive types will be boxed and stored using the boxed type
+ * (e.g., {@code long} uses {@code Long.class}).
  * Duplicate tag types are not allowed.
  */
 @Documented


### PR DESCRIPTION
Closes #4332 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
