### PR TITLE
Use parenthesis when invoking OkHttp function

### DIFF
--- a/retrofit/kotlin-test/src/test/java/retrofit2/KotlinSuspendTest.kt
+++ b/retrofit/kotlin-test/src/test/java/retrofit2/KotlinSuspendTest.kt
@@ -254,7 +254,7 @@ class KotlinSuspendTest {
     server.takeRequest()
 
     deferred.cancel()
-    assertTrue(call.isCanceled)
+    assertTrue(call.isCanceled())
   }
 
   @Test fun doesNotUseCallbackExecutor() {


### PR DESCRIPTION
We are compiling against the Java version of OkHttp where this method was synthesized to a property, but if you try and compile against the Kotlin version of OkHttp the parenthesis are required because it is a function.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
