### PR TITLE
Remove `compileOnly` stdlib dependency

### DIFF
--- a/retrofit/build.gradle
+++ b/retrofit/build.gradle
@@ -35,7 +35,6 @@ dependencies {
   api libs.okhttp.client
 
   compileOnly libs.android
-  compileOnly libs.kotlin.stdLib
   compileOnly libs.kotlinx.coroutines
 
   compileOnly libs.animalSnifferAnnotations

--- a/retrofit/gradle.properties
+++ b/retrofit/gradle.properties
@@ -1,5 +1,3 @@
 POM_ARTIFACT_ID=retrofit
 POM_NAME=Retrofit
 POM_DESCRIPTION=A type-safe HTTP client for Android and Java.
-
-kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
OkHttp provides it now, so we can add it.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
