### PR TITLE
Fix external cancels propagation in rxjava2 and rxjava3 adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 **Fixed**
 
- - Nothing yet!
+ - Propagate timeouts and other external cancels in retrofit-adapter for rxjava2 and rxjava3
 
 
 ## [3.0.0] - 2025-05-15

--- a/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/CallEnqueueObservable.java
+++ b/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/CallEnqueueObservable.java
@@ -82,7 +82,7 @@ final class CallEnqueueObservable<T> extends Observable<Response<T>> {
 
     @Override
     public void onFailure(Call<T> call, Throwable t) {
-      if (call.isCanceled()) return;
+      if (disposed) return;
 
       try {
         observer.onError(t);

--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/CancelDisposeTest.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/CancelDisposeTest.java
@@ -21,7 +21,12 @@ import static org.junit.Assert.assertTrue;
 
 import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.observers.TestObserver;
+
+import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockWebServer;
@@ -78,5 +83,15 @@ public final class CancelDisposeTest {
     assertEquals(1, calls.size());
     calls.get(0).cancel();
     assertFalse(disposable.isDisposed());
+  }
+
+  @Test
+  public void cancelSetsError() throws InterruptedException {
+    TestObserver<?> testObserver = service.go().test();
+    List<Call> calls = client.dispatcher().runningCalls();
+    assertEquals(1, calls.size());
+    calls.get(0).cancel();
+    testObserver.await(10, TimeUnit.SECONDS);
+    testObserver.assertError(e -> e instanceof IOException && "Canceled".equals(e.getMessage()));
   }
 }

--- a/retrofit-adapters/rxjava3/src/main/java/retrofit2/adapter/rxjava3/CallEnqueueObservable.java
+++ b/retrofit-adapters/rxjava3/src/main/java/retrofit2/adapter/rxjava3/CallEnqueueObservable.java
@@ -82,7 +82,7 @@ final class CallEnqueueObservable<T> extends Observable<Response<T>> {
 
     @Override
     public void onFailure(Call<T> call, Throwable t) {
-      if (call.isCanceled()) return;
+      if (disposed) return;
 
       try {
         observer.onError(t);

--- a/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/CancelDisposeTest.java
+++ b/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/CancelDisposeTest.java
@@ -21,7 +21,12 @@ import static org.junit.Assert.assertTrue;
 
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.observers.TestObserver;
+
+import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockWebServer;
@@ -78,5 +83,15 @@ public final class CancelDisposeTest {
     assertEquals(1, calls.size());
     calls.get(0).cancel();
     assertFalse(disposable.isDisposed());
+  }
+
+  @Test
+  public void cancelSetsError() throws InterruptedException {
+    TestObserver<?> testObserver = service.go().test();
+    List<Call> calls = client.dispatcher().runningCalls();
+    assertEquals(1, calls.size());
+    calls.get(0).cancel();
+    testObserver.await(10, TimeUnit.SECONDS);
+    testObserver.assertError(e -> e instanceof IOException && "Canceled".equals(e.getMessage()));
   }
 }


### PR DESCRIPTION
Hi! It looks like there is a small bug in `CallEnqueueObservable` - external cancels (like timeouts) are not getting propagated to rxjava making calls stuck. It looks like when a separate "disposed" state was introduced 3f111b7b2c8c0e2ce0c4aa8f27bb94dbb6d7385f a one place in `CallEnqueueObservable.onFailure` was missed (while it was used in analogous place in `catch` inside `CallExecuteObservable`). This PR should fix the issue.

I tested it manually with rxjava3 and added simple tests that fail without the fix. This should resolve #3524.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
