### PR TITLE
Add explicit keep rules for RxJava Result types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 **New**
 
- - Nothing yet!
+ - Add explicit keep rules for RxJava `Result` types.
 
 **Changed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 **New**
 
- - Add explicit keep rules for RxJava `Result` types.
+ - Add explicit keep rules for RxJava `Result` types to prevent their generic information from being removed.
 
 **Changed**
 

--- a/retrofit-adapters/rxjava/src/main/resources/META-INF/proguard/retrofit2-rxjava-adapter.pro
+++ b/retrofit-adapters/rxjava/src/main/resources/META-INF/proguard/retrofit2-rxjava-adapter.pro
@@ -1,0 +1,3 @@
+# Keep generic signature of RxJava (R8 full mode strips signatures from non-kept items).
+# It's necessary to add the explicit rule for Result as it could be used as a nested return type like `Observable<Result<String>>`
+-keep,allowobfuscation,allowshrinking class retrofit2.adapter.rxjava.Result

--- a/retrofit-adapters/rxjava2/src/main/resources/META-INF/proguard/retrofit2-rxjava2-adapter.pro
+++ b/retrofit-adapters/rxjava2/src/main/resources/META-INF/proguard/retrofit2-rxjava2-adapter.pro
@@ -1,0 +1,3 @@
+# Keep generic signature of RxJava2 (R8 full mode strips signatures from non-kept items).
+# It's necessary to add the explicit rule for Result as it could be used as a nested return type like `Observable<Result<String>>`
+-keep,allowobfuscation,allowshrinking class retrofit2.adapter.rxjava2.Result

--- a/retrofit-adapters/rxjava3/src/main/resources/META-INF/proguard/retrofit2-rxjava3-adapter.pro
+++ b/retrofit-adapters/rxjava3/src/main/resources/META-INF/proguard/retrofit2-rxjava3-adapter.pro
@@ -1,0 +1,3 @@
+# Keep generic signature of RxJava3 (R8 full mode strips signatures from non-kept items).
+# It's necessary to add the explicit rule for Result as it could be used as a nested return type like `Observable<Result<String>>`
+-keep,allowobfuscation,allowshrinking class retrofit2.adapter.rxjava3.Result


### PR DESCRIPTION
Some direct generic return types have been covered by #3886. I couldn't find a way to update https://github.com/square/retrofit/blob/ef8d867ffb34b419355a323e11ba89db1904f8c2/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro#L43-L45 to retain the nested generic types.

Closes #4480.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
