### PR TITLE
Add allowoptimization flags for most kept types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **New**
 
  - Add explicit keep rules for RxJava `Result` types to prevent their generic information from being removed.
+ - Add `allowoptimization` flags for most kept types.
 
 **Changed**
 

--- a/retrofit-adapters/rxjava/src/main/resources/META-INF/proguard/retrofit2-rxjava-adapter.pro
+++ b/retrofit-adapters/rxjava/src/main/resources/META-INF/proguard/retrofit2-rxjava-adapter.pro
@@ -1,3 +1,3 @@
 # Keep generic signature of RxJava (R8 full mode strips signatures from non-kept items).
 # It's necessary to add the explicit rule for Result as it could be used as a nested return type like `Observable<Result<String>>`
--keep,allowobfuscation,allowshrinking class retrofit2.adapter.rxjava.Result
+-keep,allowoptimization,allowshrinking,allowobfuscation class retrofit2.adapter.rxjava.Result

--- a/retrofit-adapters/rxjava2/src/main/resources/META-INF/proguard/retrofit2-rxjava2-adapter.pro
+++ b/retrofit-adapters/rxjava2/src/main/resources/META-INF/proguard/retrofit2-rxjava2-adapter.pro
@@ -1,3 +1,3 @@
 # Keep generic signature of RxJava2 (R8 full mode strips signatures from non-kept items).
 # It's necessary to add the explicit rule for Result as it could be used as a nested return type like `Observable<Result<String>>`
--keep,allowobfuscation,allowshrinking class retrofit2.adapter.rxjava2.Result
+-keep,allowoptimization,allowshrinking,allowobfuscation class retrofit2.adapter.rxjava2.Result

--- a/retrofit-adapters/rxjava3/src/main/resources/META-INF/proguard/retrofit2-rxjava3-adapter.pro
+++ b/retrofit-adapters/rxjava3/src/main/resources/META-INF/proguard/retrofit2-rxjava3-adapter.pro
@@ -1,3 +1,3 @@
 # Keep generic signature of RxJava3 (R8 full mode strips signatures from non-kept items).
 # It's necessary to add the explicit rule for Result as it could be used as a nested return type like `Observable<Result<String>>`
--keep,allowobfuscation,allowshrinking class retrofit2.adapter.rxjava3.Result
+-keep,allowoptimization,allowshrinking,allowobfuscation class retrofit2.adapter.rxjava3.Result

--- a/retrofit-converters/guava/src/main/resources/META-INF/proguard/retrofit2-guava-converter.pro
+++ b/retrofit-converters/guava/src/main/resources/META-INF/proguard/retrofit2-guava-converter.pro
@@ -1,2 +1,2 @@
 # Keep generic signature of Optional (R8 full mode strips signatures from non-kept items).
--keep,allowobfuscation,allowshrinking class com.google.common.base.Optional
+-keep,allowoptimization,allowshrinking,allowobfuscation class com.google.common.base.Optional

--- a/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -38,11 +38,11 @@
 # With R8 full mode generic signatures are stripped for classes that are not
 # kept. Suspend functions are wrapped in continuations where the type argument
 # is used.
--keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+-keep,allowoptimization,allowshrinking,allowobfuscation class kotlin.coroutines.Continuation
 
 # R8 full mode strips generic signatures from return types if not kept.
 -if interface * { @retrofit2.http.* public *** *(...); }
 -keep,allowoptimization,allowshrinking,allowobfuscation class <3>
 
 # With R8 full mode generic signatures are stripped for classes that are not kept.
--keep,allowobfuscation,allowshrinking class retrofit2.Response
+-keep,allowoptimization,allowshrinking,allowobfuscation class retrofit2.Response


### PR DESCRIPTION
All kept types but

https://github.com/square/retrofit/blob/dbf9783ba4795dcdc9637336c6f74b05c9e386e2/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro#L31-L32

could be marked with

```proguard
-keep,allowoptimization,allowshrinking,allowobfuscation
```

This change aligns with the new rules added in #3886.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
