### PR TITLE
Fix charset in README example for Retrofit

### DIFF
--- a/retrofit-converters/kotlinx-serialization/README.md
+++ b/retrofit-converters/kotlinx-serialization/README.md
@@ -11,7 +11,7 @@ val retrofit = Retrofit.Builder()
     .baseUrl("https://example.com/")
     .addConverterFactory(
         Json.asConverterFactory(
-            "application/json; charset=UTF8".toMediaType()))
+            "application/json; charset=utf-8".toMediaType()))
     .build()
 ```
 


### PR DESCRIPTION
The correct value for charset is "utf-8". Some systems may tolerate "utf8" but not the all of them.

Sources:

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type#syntax

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
