### PR TITLE
Support QUERY method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Add explicit keep rules for RxJava `Result` types to prevent their generic information from being removed.
  - Add `allowoptimization` flags for most kept types.
  - Add `Invocation.annotationUrl` which returns the original URL from the method annotation.
+ - Support `QUERY` method (annotate your methods with `@QUERY_METHOD`).
 
 **Changed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
  - Add explicit keep rules for RxJava `Result` types to prevent their generic information from being removed.
  - Add `allowoptimization` flags for most kept types.
  - Add `Invocation.annotationUrl` which returns the original URL from the method annotation.
- - Support `QUERY` method (annotate your methods with `@QUERY_METHOD`).
+ - Support `QUERY` method.
 
 **Changed**
 

--- a/retrofit/build.gradle
+++ b/retrofit/build.gradle
@@ -2,25 +2,17 @@ apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.vanniktech.maven.publish'
 
-def addExtraSourceSet(String name) {
-  def sourceSet = sourceSets.create(name) {
-    java.srcDir("src/main/$name")
-  }
-
-  // Propagate dependencies to be visible to this source set.
-  configurations.getByName("${name}Implementation").extendsFrom(configurations.getByName('implementation'))
-  configurations.getByName("${name}Api").extendsFrom(configurations.getByName('api'))
-  configurations.getByName("${name}CompileOnly").extendsFrom(configurations.getByName('compileOnly'))
-
-  return sourceSet
-}
-
 def addMultiReleaseSourceSet(int version) {
-  def name = "java${version}"
-  def sourceSet = addExtraSourceSet(name)
+  def sourceSet = sourceSets.create("java$version")
+  sourceSet.java.srcDir("src/main/java$version")
+
+  // Propagate dependencies to be visible to this version's source set.
+  configurations.getByName("java${version}Implementation").extendsFrom(configurations.getByName('implementation'))
+  configurations.getByName("java${version}Api").extendsFrom(configurations.getByName('api'))
+  configurations.getByName("java${version}CompileOnly").extendsFrom(configurations.getByName('compileOnly'))
 
   // Allow types in the main source set to be visible to this version's source set.
-  dependencies.add("${name}Implementation", sourceSets.getByName("main").output)
+  dependencies.add("java${version}Implementation", sourceSets.getByName("main").output)
 
   tasks.named("compileJava${version}Java", JavaCompile) {
     javaCompiler = javaToolchains.compilerFor {
@@ -39,17 +31,22 @@ def addMultiReleaseSourceSet(int version) {
 addMultiReleaseSourceSet(14)
 addMultiReleaseSourceSet(16)
 
-def extra = addExtraSourceSet('extra')
+def extra = sourceSets.create('extra') {
+  java.srcDir('src/main/extra')
+}
 
 dependencies {
   api libs.okhttp.client
+  api extra.output
 
-  compileOnly extra.output
   compileOnly libs.android
   compileOnly libs.kotlinx.coroutines
 
   compileOnly libs.animalSnifferAnnotations
   compileOnly libs.findBugsAnnotations
+
+  // Can't extend extraCompileOnly from compileOnly due to the circular dependencies.
+  extraCompileOnly libs.okhttp.client
 }
 
 javadoc {

--- a/retrofit/build.gradle
+++ b/retrofit/build.gradle
@@ -2,17 +2,25 @@ apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.vanniktech.maven.publish'
 
-def addMultiReleaseSourceSet(int version) {
-  def sourceSet = sourceSets.create("java$version")
-  sourceSet.java.srcDir("src/main/java$version")
+def addExtraSourceSet(String name) {
+  def sourceSet = sourceSets.create(name) {
+    java.srcDir("src/main/$name")
+  }
 
-  // Propagate dependencies to be visible to this version's source set.
-  configurations.getByName("java${version}Implementation").extendsFrom(configurations.getByName('implementation'))
-  configurations.getByName("java${version}Api").extendsFrom(configurations.getByName('api'))
-  configurations.getByName("java${version}CompileOnly").extendsFrom(configurations.getByName('compileOnly'))
+  // Propagate dependencies to be visible to this source set.
+  configurations.getByName("${name}Implementation").extendsFrom(configurations.getByName('implementation'))
+  configurations.getByName("${name}Api").extendsFrom(configurations.getByName('api'))
+  configurations.getByName("${name}CompileOnly").extendsFrom(configurations.getByName('compileOnly'))
+
+  return sourceSet
+}
+
+def addMultiReleaseSourceSet(int version) {
+  def name = "java${version}"
+  def sourceSet = addExtraSourceSet(name)
 
   // Allow types in the main source set to be visible to this version's source set.
-  dependencies.add("java${version}Implementation", sourceSets.getByName("main").output)
+  dependencies.add("${name}Implementation", sourceSets.getByName("main").output)
 
   tasks.named("compileJava${version}Java", JavaCompile) {
     javaCompiler = javaToolchains.compilerFor {
@@ -31,9 +39,12 @@ def addMultiReleaseSourceSet(int version) {
 addMultiReleaseSourceSet(14)
 addMultiReleaseSourceSet(16)
 
+def extra = addExtraSourceSet('extra')
+
 dependencies {
   api libs.okhttp.client
 
+  compileOnly extra.output
   compileOnly libs.android
   compileOnly libs.kotlinx.coroutines
 
@@ -45,7 +56,9 @@ javadoc {
   exclude('retrofit2/internal/**')
 }
 
-jar {
+tasks.named('jar', Jar) {
+  from(extra.output)
+
   manifest {
     attributes 'Automatic-Module-Name': 'retrofit2'
     attributes 'Multi-Release': 'true'

--- a/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
@@ -60,7 +60,7 @@ import retrofit2.http.PUT;
 import retrofit2.http.Part;
 import retrofit2.http.PartMap;
 import retrofit2.http.Path;
-import retrofit2.http.QUERY_METHOD;
+import retrofit2.http.QUERY;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
 import retrofit2.http.QueryName;
@@ -1009,7 +1009,7 @@ public final class RequestFactoryTest {
   @Test
   public void query() {
     class Example {
-      @QUERY_METHOD("/foo/bar/") //
+      @QUERY("/foo/bar/") //
       Call<ResponseBody> method(@Body RequestBody body) {
         return null;
       }

--- a/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
@@ -60,6 +60,7 @@ import retrofit2.http.PUT;
 import retrofit2.http.Part;
 import retrofit2.http.PartMap;
 import retrofit2.http.Path;
+import retrofit2.http.QUERY_METHOD;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
 import retrofit2.http.QueryName;
@@ -1003,6 +1004,22 @@ public final class RequestFactoryTest {
     assertThat(request.headers().size()).isEqualTo(0);
     assertThat(request.url().toString()).isEqualTo("http://example.com/foo/bar/");
     assertThat(request.body()).isNull();
+  }
+
+  @Test
+  public void query() {
+    class Example {
+      @QUERY_METHOD("/foo/bar/") //
+      Call<ResponseBody> method(@Body RequestBody body) {
+        return null;
+      }
+    }
+    RequestBody body = RequestBody.create(TEXT_PLAIN, "hi");
+    Request request = buildRequest(Example.class, body);
+    assertThat(request.method()).isEqualTo("QUERY");
+    assertThat(request.headers().size()).isEqualTo(0);
+    assertThat(request.url().toString()).isEqualTo("http://example.com/foo/bar/");
+    assertBody(request.body(), "hi");
   }
 
   @Test

--- a/retrofit/src/main/extra/retrofit2/http/QUERY.java
+++ b/retrofit/src/main/extra/retrofit2/http/QUERY.java
@@ -27,7 +27,7 @@ import okhttp3.HttpUrl;
 @Documented
 @Target(METHOD)
 @Retention(RUNTIME)
-public @interface QUERY_METHOD {
+public @interface QUERY {
   /**
    * A relative or absolute path, or full URL of the endpoint. This value is optional if the first
    * parameter of the method is annotated with {@link Url @Url}.

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -56,6 +56,7 @@ import retrofit2.http.PUT;
 import retrofit2.http.Part;
 import retrofit2.http.PartMap;
 import retrofit2.http.Path;
+import retrofit2.http.QUERY_METHOD;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
 import retrofit2.http.QueryName;
@@ -244,6 +245,8 @@ final class RequestFactory {
         parseHttpMethodAndPath("PUT", ((PUT) annotation).value(), true);
       } else if (annotation instanceof OPTIONS) {
         parseHttpMethodAndPath("OPTIONS", ((OPTIONS) annotation).value(), false);
+      } else if (annotation instanceof QUERY_METHOD) {
+        parseHttpMethodAndPath("QUERY", ((QUERY_METHOD) annotation).value(), true);
       } else if (annotation instanceof HTTP) {
         HTTP http = (HTTP) annotation;
         parseHttpMethodAndPath(http.method(), http.path(), http.hasBody());

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -56,7 +56,7 @@ import retrofit2.http.PUT;
 import retrofit2.http.Part;
 import retrofit2.http.PartMap;
 import retrofit2.http.Path;
-import retrofit2.http.QUERY_METHOD;
+import retrofit2.http.QUERY;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
 import retrofit2.http.QueryName;
@@ -245,8 +245,8 @@ final class RequestFactory {
         parseHttpMethodAndPath("PUT", ((PUT) annotation).value(), true);
       } else if (annotation instanceof OPTIONS) {
         parseHttpMethodAndPath("OPTIONS", ((OPTIONS) annotation).value(), false);
-      } else if (annotation instanceof QUERY_METHOD) {
-        parseHttpMethodAndPath("QUERY", ((QUERY_METHOD) annotation).value(), true);
+      } else if (annotation instanceof QUERY) {
+        parseHttpMethodAndPath("QUERY", ((QUERY) annotation).value(), true);
       } else if (annotation instanceof HTTP) {
         HTTP http = (HTTP) annotation;
         parseHttpMethodAndPath(http.method(), http.path(), http.hasBody());

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -112,7 +112,7 @@ public final class Retrofit {
    * the request type. The built-in methods are {@link retrofit2.http.GET GET}, {@link
    * retrofit2.http.PUT PUT}, {@link retrofit2.http.POST POST}, {@link retrofit2.http.PATCH PATCH},
    * {@link retrofit2.http.HEAD HEAD}, {@link retrofit2.http.DELETE DELETE},
-   * {@link retrofit2.http.OPTIONS OPTIONS}, and {@link retrofit2.http.QUERY_METHOD QUERY_METHOD}.
+   * {@link retrofit2.http.OPTIONS OPTIONS}, and {@link retrofit2.http.QUERY QUERY}.
    * You can use a custom HTTP method with {@link HTTP @HTTP}. For
    * a dynamic URL, omit the path on the annotation and annotate the first parameter with {@link
    * Url @Url}.

--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -111,8 +111,9 @@ public final class Retrofit {
    * <p>The relative path for a given method is obtained from an annotation on the method describing
    * the request type. The built-in methods are {@link retrofit2.http.GET GET}, {@link
    * retrofit2.http.PUT PUT}, {@link retrofit2.http.POST POST}, {@link retrofit2.http.PATCH PATCH},
-   * {@link retrofit2.http.HEAD HEAD}, {@link retrofit2.http.DELETE DELETE} and {@link
-   * retrofit2.http.OPTIONS OPTIONS}. You can use a custom HTTP method with {@link HTTP @HTTP}. For
+   * {@link retrofit2.http.HEAD HEAD}, {@link retrofit2.http.DELETE DELETE},
+   * {@link retrofit2.http.OPTIONS OPTIONS}, and {@link retrofit2.http.QUERY_METHOD QUERY_METHOD}.
+   * You can use a custom HTTP method with {@link HTTP @HTTP}. For
    * a dynamic URL, omit the path on the annotation and annotate the first parameter with {@link
    * Url @Url}.
    *

--- a/retrofit/src/main/java/retrofit2/http/QUERY_METHOD.java
+++ b/retrofit/src/main/java/retrofit2/http/QUERY_METHOD.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.http;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import okhttp3.HttpUrl;
+
+/** Make a QUERY request. */
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface QUERY_METHOD {
+  /**
+   * A relative or absolute path, or full URL of the endpoint. This value is optional if the first
+   * parameter of the method is annotated with {@link Url @Url}.
+   *
+   * <p>See {@linkplain retrofit2.Retrofit.Builder#baseUrl(HttpUrl) base URL} for details of how
+   * this is resolved against a base URL to create the full endpoint URL.
+   */
+  String value() default "";
+}


### PR DESCRIPTION
~~We can't name it to `QUERY` due to the case-insensitive file systems on MacOS and Windows. Should we rename the annotation to `SEARCH` or something else?~~

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
