### PR TITLE
Upgrade to AGP 9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ incap = "1.0.0"
 jackson = "2.20.1"
 
 [libraries]
-androidPlugin = { module = "com.android.tools.build:gradle", version = "8.13.2" }
+androidPlugin = "com.android.tools.build:gradle:9.0.0-beta05"
 robovmPlugin = { module = "com.mobidevelop.robovm:robovm-gradle-plugin", version.ref = "robovm" }
 dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:2.1.0"
 gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.35.0"

--- a/retrofit/android-test/build.gradle
+++ b/retrofit/android-test/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-  compileSdk 34
+  compileSdk = 36
   namespace 'retrofit2.android'
 
   defaultConfig {
-    minSdk 21
+    minSdk = 21
 
     // We need to disable D8 desugaring of default methods for the default method tests to work
     // correctly. This works in Android Studio because it sets the minSdk automatically based on
@@ -13,12 +13,11 @@ android {
     def emulatorApiLevel = System.getenv("API_LEVEL")
     if (emulatorApiLevel != null) {
       try {
-        minSdk Integer.parseInt(emulatorApiLevel)
+        minSdk = Integer.parseInt(emulatorApiLevel)
       } catch (NumberFormatException ignored) {
       }
     }
 
-    targetSdk 34
     testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
   }
 
@@ -35,10 +34,6 @@ android {
     debug {
       signingConfig signingConfigs.debug
     }
-  }
-
-  variantFilter { variant ->
-    variant.ignore = variant.name == "release"
   }
 }
 


### PR DESCRIPTION
Release tests are disable by default.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
