### PR TITLE
Document Jackson converter multi-format support (#4609)

### DIFF
--- a/retrofit-converters/jackson/README.md
+++ b/retrofit-converters/jackson/README.md
@@ -1,10 +1,54 @@
 Jackson Converter
 =================
 
-A `Converter` which uses [Jackson][1] for serialization to and from JSON.
+A `Converter` which uses [Jackson][1] for serialization.
 
 A default `ObjectMapper` instance will be created or one can be configured and passed to the
 `JacksonConverterFactory` construction to further control the serialization.
+
+Multi-Format Support
+--------------------
+
+This converter is not limited to JSON. Jackson supports many data formats through its
+[dataformat modules][4], and this converter works with any of them by supplying the appropriate
+mapper and media type.
+
+### XML
+
+```java
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+Retrofit retrofit = new Retrofit.Builder()
+    .baseUrl("https://example.com/")
+    .addConverterFactory(
+        JacksonConverterFactory.create(
+            new XmlMapper(),
+            MediaType.get("application/xml")))
+    .build();
+```
+
+Requires the `jackson-dataformat-xml` dependency.
+
+### CBOR
+
+```java
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
+
+Retrofit retrofit = new Retrofit.Builder()
+    .baseUrl("https://example.com/")
+    .addConverterFactory(
+        JacksonConverterFactory.create(
+            new CBORMapper(),
+            MediaType.get("application/cbor")))
+    .build();
+```
+
+Requires the `jackson-dataformat-cbor` dependency.
+
+### Other Formats
+
+The same pattern applies to other Jackson dataformat modules such as YAML, Smile, Ion, and more.
+Simply use the corresponding mapper (e.g., `YAMLMapper`, `SmileMapper`) and media type.
 
 
 Download
@@ -30,5 +74,6 @@ Snapshots of the development version are available in [Sonatype's `snapshots` re
  [1]: https://github.com/FasterXML/jackson
  [2]: https://search.maven.org/remote_content?g=com.squareup.retrofit2&a=converter-jackson&v=LATEST
  [3]: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.squareup.retrofit2%22%20a%3A%22converter-jackson%22
+ [4]: https://github.com/FasterXML/jackson#data-format-modules
  [snap]: https://s01.oss.sonatype.org/content/repositories/snapshots/
 

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -14,7 +14,7 @@ Converters can be added to support other types. Sibling modules adapt popular se
 ### Built-in converters
 
 * [Gson](https://github.com/google/gson): `com.squareup.retrofit2:converter-gson`
-* [Jackson](https://github.com/FasterXML/jackson): `com.squareup.retrofit2:converter-jackson`
+* [Jackson](https://github.com/FasterXML/jackson): `com.squareup.retrofit2:converter-jackson` - Supports [multiple formats](https://github.com/FasterXML/jackson#data-format-modules) (JSON, XML, CBOR, YAML, etc.) by supplying a different mapper and media type
 * [Moshi](https://github.com/square/moshi/): `com.squareup.retrofit2:converter-moshi`
 * [Protobuf](https://developers.google.com/protocol-buffers/): `com.squareup.retrofit2:converter-protobuf`
 * [Wire](https://github.com/square/wire): `com.squareup.retrofit2:converter-wire`


### PR DESCRIPTION
  ## Summary

  - Document that the Jackson converter supports multiple data formats beyond JSON
  - Add examples for XML (`XmlMapper`) and CBOR (`CBORMapper`) usage
  - Update website configuration docs with inline note about multi-format capability

  Fixes #4609
