### PR TITLE
Update base URL in Retrofit docs

### DIFF
--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -15,7 +15,7 @@ The `Retrofit` class generates an implementation of the `GitHubService` interfac
 
 ```java
 Retrofit retrofit = new Retrofit.Builder()
-    .baseUrl("https://api.github.com")
+    .baseUrl("https://api.github.com/")
     .build();
 
 GitHubService service = retrofit.create(GitHubService.class);


### PR DESCRIPTION
Jake on slack said

> You should always have a trailing slash on the base URL, because paths are relative and are resolved against the base URL. Thus, anything without a trailing slash is effectively ignored.

> Consider a base URL of https://example.com/api (no slash) and then a path of foo. This would result in https://example.com/foo which makes the api part of the original base URL useless.

> So either you meant https://example.com/ or you meant https://example.com/api/

I think the very first example users see should have the trailing /

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
