### PR TITLE
Fix JDK test task dependencies by wiring to source set outputs (#4072)

### DIFF
--- a/retrofit/java-test/build.gradle
+++ b/retrofit/java-test/build.gradle
@@ -25,10 +25,9 @@ tasks.withType(JavaCompile).configureEach {
     description = "Runs the test suite on JDK $majorVersion"
     group = LifecycleBasePlugin.VERIFICATION_GROUP
 
-    // Copy inputs from normal Test task.
-    def testTask = tasks.getByName("test")
-    classpath = testTask.classpath
-    testClassesDirs = testTask.testClassesDirs
+    // Wire directly to the test source set outputs for proper task dependencies.
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
   }
   tasks.named("check").configure {
     dependsOn(jdkTest)


### PR DESCRIPTION
  The testJdkN tasks in retrofit/java-test/build.gradle copied classpath and testClassesDirs from the built-in test task. This broke the Gradle task dependency graph —    
  re-running a test task would not recompile main/test sources because no dependency on compilation tasks was established.
                                                                                                                                                                           
  Wire directly to sourceSets.test outputs instead, giving Gradle implicit task dependencies through file collection producers. This also eliminates the
  tasks.getByName("test") eager realization anti-pattern.

  Fixes #4072
