### PR TITLE
docs: fix subject-verb agreement in Invocation#annotationUrl javadoc

### DIFF
--- a/retrofit/src/main/java/retrofit2/Invocation.java
+++ b/retrofit/src/main/java/retrofit2/Invocation.java
@@ -128,7 +128,7 @@ public final class Invocation {
    * If the method uses the {@link retrofit2.http.Path @Path} annotation, this is the template URL
    * before path substitution, as it occurs in source code.
    * <p>
-   * This value will be null if one of the method's parameter is annotated
+   * This value will be null if one of the method's parameters is annotated
    * {@link retrofit2.http.Url @Url}. It will also be null if this Invocation was created using one
    * of the {@linkplain #of factory-functions} that don't have this value.
    */


### PR DESCRIPTION

**Repo:** square/retrofit (⭐ 42000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Corrects a minor grammatical error in the javadoc for `Invocation#annotationUrl()`. The phrase "one of the method's parameter is annotated" should be "one of the method's parameters is annotated" — "one of" requires a plural noun.

## Why
This javadoc is part of Retrofit's public API documentation and is what consumers see in IDE tooltips and on the published Javadoc site. Small grammar fixes improve the perceived polish of the library's documentation at virtually zero risk.

## Testing
No functional change — pure javadoc comment. Compilation unaffected; no tests need updating.

## Risk
Low — comment-only change to a single javadoc block.
