### PR TITLE
Disable linguist-detectable for website dir

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,6 @@
 
 *.bat text eol=crlf
 *.jar binary
+
+# Exclude old docs from being counted as code.
+website/** linguist-detectable=false


### PR DESCRIPTION
Closes #4703.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
